### PR TITLE
fix(agent): resolve agents by display name after build/code rename

### DIFF
--- a/packages/app/test-browser/prompt-persistence.test.ts
+++ b/packages/app/test-browser/prompt-persistence.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test"
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test"
 import type { AsyncStorage } from "@solid-primitives/storage"
 import { createEffect, createRoot } from "solid-js"
 import { ServerScope } from "@/utils/server-scope"
@@ -16,8 +16,17 @@ const storage: AsyncStorage = {
   length: Promise.resolve(0),
 }
 
+// Module mocks leak into later test files, so snapshot the real router before
+// mocking and restore it once this file finishes.
+const router = { ...(await import("@solidjs/router")) }
+
+afterAll(() => {
+  mock.module("@solidjs/router", () => router)
+})
+
 beforeAll(async () => {
   mock.module("@solidjs/router", () => ({
+    ...router,
     useParams: () => ({}),
     useSearchParams: () => [{}],
     useLocation: () => ({ pathname: "", query: {} }),

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -519,11 +519,12 @@ const layer = Layer.effect(
 
         const list = Effect.fnUntraced(function* () {
           const cfg = yield* config.get()
+          const configuredDefault = cfg.default_agent ? yield* get(cfg.default_agent) : undefined
           return pipe(
             agents,
             values(),
             sortBy(
-              [(x) => (cfg.default_agent ? x.name === cfg.default_agent : x.name === "code"), "desc"],
+              [(x) => (configuredDefault ? x === configuredDefault : x.name === "code"), "desc"],
               [(x) => x.name, "asc"],
             ),
           )

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -519,12 +519,14 @@ const layer = Layer.effect(
 
         const list = Effect.fnUntraced(function* () {
           const cfg = yield* config.get()
-          const configuredDefault = cfg.default_agent ? yield* get(cfg.default_agent) : undefined
+          const configuredDefault = cfg.default_agent
+            ? yield* get(cfg.default_agent)
+            : Object.values(agents).find((x) => x.mode !== "subagent" && x.hidden !== true)
           return pipe(
             agents,
             values(),
             sortBy(
-              [(x) => (configuredDefault ? x === configuredDefault : x.name === "code"), "desc"],
+              [(x) => x === configuredDefault, "desc"],
               [(x) => x.name, "asc"],
             ),
           )

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -511,8 +511,10 @@ const layer = Layer.effect(
           )
         }
 
+        // Config keys and display names can diverge (the built-in "build" key is named "code"),
+        // and callers resolve agents by the name stored on messages, so fall back to name lookup.
         const get = Effect.fnUntraced(function* (agent: string) {
-          return agents[agent]
+          return agents[agent] ?? Object.values(agents).find((a) => a.name === agent)
         })
 
         const list = Effect.fnUntraced(function* () {
@@ -521,7 +523,7 @@ const layer = Layer.effect(
             agents,
             values(),
             sortBy(
-              [(x) => (cfg.default_agent ? x.name === cfg.default_agent : x.name === "build"), "desc"],
+              [(x) => (cfg.default_agent ? x.name === cfg.default_agent : x.name === "code"), "desc"],
               [(x) => x.name, "asc"],
             ),
           )
@@ -530,7 +532,7 @@ const layer = Layer.effect(
         const defaultInfo = Effect.fnUntraced(function* () {
           const c = yield* config.get()
           if (c.default_agent) {
-            const agent = agents[c.default_agent]
+            const agent = yield* get(c.default_agent)
             if (!agent) throw new Error(`default agent "${c.default_agent}" not found`)
             if (agent.mode === "subagent") throw new Error(`default agent "${c.default_agent}" is a subagent`)
             if (agent.hidden === true) throw new Error(`default agent "${c.default_agent}" is hidden`)

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -48,7 +48,7 @@ it.instance("returns default native agents when no config", () =>
   Effect.gen(function* () {
     const agents = yield* load((svc) => svc.list())
     const names = agents.map((a) => a.name)
-    expect(names).toContain("build")
+    expect(names).toContain("code")
     expect(names).toContain("plan")
     expect(names).toContain("general")
     expect(names).toContain("explore")
@@ -646,17 +646,17 @@ it.instance(
   },
 )
 
-it.instance("defaultAgent returns build when no default_agent config", () =>
+it.instance("defaultAgent returns code when no default_agent config", () =>
   Effect.gen(function* () {
     const agent = yield* load((svc) => svc.defaultAgent())
-    expect(agent).toBe("build")
+    expect(agent).toBe("code")
   }),
 )
 
-it.instance("defaultInfo returns resolved build agent when no default_agent config", () =>
+it.instance("defaultInfo returns resolved code agent when no default_agent config", () =>
   Effect.gen(function* () {
     const agent = yield* load((svc) => svc.defaultInfo())
-    expect(agent.name).toBe("build")
+    expect(agent.name).toBe("code")
     expect(agent.mode).toBe("primary")
   }),
 )
@@ -749,6 +749,14 @@ it.instance(
       agent: {
         build: { disable: true },
         plan: { disable: true },
+        ask: { disable: true },
+        "code-review": { disable: true },
+        debug: { disable: true },
+        refactor: { disable: true },
+        docs: { disable: true },
+        security: { disable: true },
+        migrate: { disable: true },
+        perf: { disable: true },
       },
     },
   },

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -578,7 +578,7 @@ it.instance("legacy prompt emits message events without session.next events", ()
       expect(second.info.model).toEqual(ref)
     }
     expect(yield* sessions.get(chat.id)).toMatchObject({
-      agent: "build",
+      agent: "code",
       model: { providerID: ref.providerID, id: ref.modelID },
     })
     expect(seen).toContain(Session.Event.Updated.type)
@@ -1034,7 +1034,7 @@ it.instance(
       const tool = yield* pollWithTimeout(
         Effect.gen(function* () {
           const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
-          const assistant = msgs.findLast((item) => item.info.role === "assistant" && item.info.agent === "build")
+          const assistant = msgs.findLast((item) => item.info.role === "assistant" && item.info.agent === "code")
           const tool = assistant?.parts.find(
             (part): part is SessionV1.ToolPart => part.type === "tool" && part.tool === "task",
           )
@@ -2365,7 +2365,7 @@ noLLMServer.instance(
         const err = Cause.squash(exit.cause)
         expect(NamedError.Unknown.isInstance(err)).toBe(true)
         if (NamedError.Unknown.isInstance(err)) {
-          expect(err.data.message).toContain("build")
+          expect(err.data.message).toContain("code")
         }
       }
     }),


### PR DESCRIPTION
### Issue for this PR

Closes #25

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the `unit (linux)` failure on the `test` workflow that breaks every `dev` push (e.g. run 30569631272): the "Run HttpApi exerciser gates" step fails 4 scenarios (`session.init`, `session.prompt`, `session.prompt_async`, `session.command`) in `effect` mode with 500 `UnknownError`.

The built-in agent record in `packages/opencode/src/agent/agent.ts` kept the config key `build` when its display name was renamed to `"code"`. Sessions and messages store the agent by display name, but `Agent.get()` resolved by key only, so re-resolving a stored agent threw `Agent not found: "code"` in `SessionPrompt.createUserMessage`.

Changes:
- `Agent.get()` falls back to a display-name lookup when the key lookup misses.
- The default-agent sort literal and `defaultInfo()` use the same resolution, so `default_agent: "code"` (and the built-in default) resolve correctly.
- Updates stale `"build"` assertions in `test/agent/agent.test.ts` and `test/session/prompt.test.ts` that the turbo cache has been masking, including the disabled-agents test which now disables all primary visible agents.

### How did you verify your code works?

- Reproduced the gate failure locally, then with the fix: `bun run test:httpapi` passes all three modes (`summary pass=208 fail=0` each).
- `bun test test/agent/agent.test.ts test/session/prompt.test.ts` passes (100 tests, 0 fail).
- Full `packages/opencode` suite passes except two pre-existing chmod-based tests that cannot fail when run as root in the sandbox (they pass on CI's non-root runners).
- `bun typecheck` in `packages/opencode` is clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent selection now resolves by either internal identifier or display name.
  * The default built-in agent is now **Code** (previously **Build**).

* **Bug Fixes**
  * Improved default-agent resolution when configuration uses a display name that differs from the internal identifier.
  * Updated behavior when the configured default agent is missing or invalid to match the resolved agent.

* **Tests**
  * Updated expectations for the assistant agent, unknown-agent messaging, and default-agent selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->