### PR TITLE
docs: redesign README with welcoming structure and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Then, from any project:
 
 ```bash
 # Open the TUI in the current directory
+bolt
+
 # Run a prompt directly (non-interactive)
 bolt run "explain this codebase"
 
@@ -112,6 +114,17 @@ Bolt also ships as a desktop app: multi-window and multi-tab session management,
 > The desktop app is still being rebranded from its OpenCode origins, so current builds ship under the old name and icons. The Bolt identity lands as part of the roadmap below.
 
 ## Configuration
+
+Configuration lives in `.bolt/bolt.jsonc` in your project root (created on first run).
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    // Provider config goes here
+  },
+}
+```
 
 ### Environment variables
 
@@ -348,6 +361,11 @@ We'd love your help, whether it's a bug fix, a new provider, or better docs. Rea
 
 ```bash
 # Clone and build
+git clone https://github.com/Bolt-builder/bolt-cli.git
+cd bolt-cli
+bun install
+
+# Start the TUI in dev mode (from packages/bolt)
 cd packages/bolt
 bun dev
 


### PR DESCRIPTION
### Issue for this PR

No linked issue; this is a standalone documentation improvement for the README.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Originally this PR redesigned the English README (hero, badges, "Why Bolt?", "Get started in 30 seconds", collapsible CLI table, Now/Next/Later roadmap). Most of that redesign has since been absorbed into `dev` by commit 21da7b2, so after rebasing onto `dev` this PR now carries only the pieces that commit dropped:

- Restores the `bolt` command in the quick start (the section had the "Open the TUI" comment but no command).
- Restores the Configuration intro and the `.bolt/bolt.jsonc` example, which was left as an empty section heading.
- Restores the `git clone` / `bun install` steps in the Contributing dev setup snippet.

Translated READMEs (README.zh.md etc.) remain untouched.

No code changes.

### How did you verify your code works?

Markdown/docs-only change: reviewed the rendered README on the `readme-redesign` branch on GitHub.

### Screenshots / recordings

Not a UI change; the rendered result is viewable directly on the branch: https://github.com/bolt-builder/bolt-cli/blob/readme-redesign/README.md

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the Getting Started experience with a 30-second setup guide.
  * Added guidance on built-in agents, power features, and the Desktop app.
  * Updated configuration variables and expanded the CLI command reference.
  * Reorganized the roadmap into categorized priorities.
  * Refreshed development, testing, type-checking, contribution, language, and licensing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
