### PR TITLE
fix(ci): pass npm token to publish and reuse existing draft release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -578,6 +578,9 @@ jobs:
 
       - run: ./script/publish.ts
         env:
+          # npm auth: setup-node writes ~/.npmrc reading $NODE_AUTH_TOKEN; without this the
+          # placeholder token is used and every npm publish fails with E404.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           OPENCODE_VERSION: ${{ needs.version.outputs.version }}
           OPENCODE_RELEASE: ${{ needs.version.outputs.release }}
           AUR_KEY: ${{ secrets.AUR_KEY }}

--- a/script/version.ts
+++ b/script/version.ts
@@ -15,7 +15,10 @@ if (!Script.preview) {
   const dir = process.env.RUNNER_TEMP ?? "/tmp"
   const notesFile = `${dir}/opencode-release-notes.txt`
   await Bun.write(notesFile, body)
-  await $`gh release create v${Script.version} -d --target ${sha} --title "v${Script.version}" --notes-file ${notesFile}`
+  // reuse an existing draft so a failed publish can be re-dispatched with the same version
+  const existing = await $`gh release view v${Script.version}`.nothrow().quiet()
+  if (existing.exitCode !== 0)
+    await $`gh release create v${Script.version} -d --target ${sha} --title "v${Script.version}" --notes-file ${notesFile}`
   const release = await $`gh release view v${Script.version} --json tagName,databaseId`.json()
   output.push(`release=${release.databaseId}`)
   output.push(`tag=${release.tagName}`)


### PR DESCRIPTION
### Issue for this PR

Closes #33

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The v0.0.1 release got through every build, signing, and asset upload, then died in `script/publish.ts` on the first `npm publish` with `E404 PUT https://registry.npmjs.org/@bolt-builder%2fbolt-cli-darwin-arm64`. The job log shows `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX`: that's setup-node's placeholder, meaning no real npm token was ever passed to the publish step, so the registry rejected the publish (npm reports auth/permission failures on PUT as 404).

```yaml
- run: ./script/publish.ts
  env:
    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
    # ...
```

Also makes `script/version.ts` reuse an existing draft release instead of failing on `gh release create`, so a failed publish can be re-dispatched with the same version (the v0.0.1 draft with all its assets survives the retry).

Requires an `NPM_TOKEN` repo secret: a granular npm access token with read/write publish access to the `@bolt-builder` scope, and the `bolt-builder` org must exist on npmjs.com.

### How did you verify your code works?

Traced the failed v0.0.1 run logs to confirm the placeholder token was the cause, and verified `script/version.ts` now looks up the existing draft release before falling back to `gh release create`. Full verification is re-dispatching the publish workflow once the `NPM_TOKEN` secret is set.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
