### PR TITLE
fix(cli): repair install/upgrade/docker paths and accept bolt configs

### DIFF
--- a/install
+++ b/install
@@ -20,9 +20,9 @@ Options:
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
 
 Examples:
-    curl -fsSL https://opencode.ai/install | bash
-    curl -fsSL https://opencode.ai/install | bash -s -- --version 1.0.180
-    ./install --binary /path/to/opencode
+    curl -fsSL https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install | bash
+    curl -fsSL https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install | bash -s -- --version 0.0.1
+    ./install --binary /path/to/bolt
 EOF
 }
 
@@ -165,7 +165,8 @@ else
       target="$target-musl"
     fi
 
-    filename="$APP-$target$archive_ext"
+    # release assets are named bolt-cli-<os>-<arch>[...] by packages/opencode/script/build.ts
+    filename="bolt-cli-$target$archive_ext"
 
 
     if [ "$os" = "linux" ]; then
@@ -340,8 +341,12 @@ download_and_install() {
         unzip -q "$tmp_dir/$filename" -d "$tmp_dir"
     fi
 
-    mv "$tmp_dir/bolt" "$INSTALL_DIR"
-    chmod 755 "${INSTALL_DIR}/bolt"
+    binary="bolt"
+    if [ "$os" = "windows" ]; then
+        binary="bolt.exe"
+    fi
+    mv "$tmp_dir/$binary" "$INSTALL_DIR"
+    chmod 755 "${INSTALL_DIR}/$binary"
     rm -rf "$tmp_dir"
 }
 
@@ -455,6 +460,6 @@ echo -e ""
 echo -e "cd <project>  ${MUTED}# Open directory${NC}"
 echo -e "bolt          ${MUTED}# Run command${NC}"
 echo -e ""
-echo -e "${MUTED}For more information visit ${NC}https://opencode.ai/docs until the CLI is fully documented and hostes our own documentation/"
+echo -e "${MUTED}For more information visit ${NC}https://github.com/bolt-builder/bolt-cli"
 echo -e ""
 echo -e ""

--- a/packages/opencode/Dockerfile
+++ b/packages/opencode/Dockerfile
@@ -7,12 +7,12 @@ ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
 RUN apk add libgcc libstdc++ ripgrep
 
 FROM base AS build-amd64
-COPY dist/opencode-linux-x64-baseline-musl/bin/bolt /usr/local/bin/bolt
+COPY dist/@bolt-builder/bolt-cli-linux-x64-baseline-musl/bin/bolt /usr/local/bin/bolt
 
 FROM base AS build-arm64
-COPY dist/opencode-linux-arm64-musl/bin/bolt /usr/local/bin/bolt
+COPY dist/@bolt-builder/bolt-cli-linux-arm64-musl/bin/bolt /usr/local/bin/bolt
 
 ARG TARGETARCH
 FROM build-${TARGETARCH}
-RUN opencode --version
-ENTRYPOINT ["opencode"]
+RUN bolt --version
+ENTRYPOINT ["bolt"]

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -24,7 +24,7 @@ interface RemovalTargets {
 
 export const UninstallCommand = {
   command: "uninstall",
-  describe: "uninstall opencode and remove all related files",
+  describe: "uninstall bolt and remove all related files",
   builder: (yargs: Argv) =>
     yargs
       .option("keep-config", {
@@ -55,7 +55,7 @@ export const UninstallCommand = {
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()
-    prompts.intro("Uninstall OpenCode")
+    prompts.intro("Uninstall Bolt")
 
     const method = await Installation.method()
     prompts.log.info(`Installation method: ${method}`)
@@ -129,13 +129,13 @@ async function showRemovalSummary(targets: RemovalTargets, method: Installation.
 
   if (method !== "curl" && method !== "unknown") {
     const cmds: Record<string, string> = {
-      npm: "npm uninstall -g opencode-ai",
-      pnpm: "pnpm uninstall -g opencode-ai",
-      bun: "bun remove -g opencode-ai",
-      yarn: "yarn global remove opencode-ai",
-      brew: "brew uninstall opencode",
-      choco: "choco uninstall opencode",
-      scoop: "scoop uninstall opencode",
+      npm: "npm uninstall -g @bolt-builder/bolt-cli",
+      pnpm: "pnpm uninstall -g @bolt-builder/bolt-cli",
+      bun: "bun remove -g @bolt-builder/bolt-cli",
+      yarn: "yarn global remove @bolt-builder/bolt-cli",
+      brew: "brew uninstall bolt",
+      choco: "choco uninstall bolt",
+      scoop: "scoop uninstall bolt",
     }
     prompts.log.info(`  ✓ Package: ${cmds[method] || method}`)
   }
@@ -180,19 +180,19 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
 
   if (method !== "curl" && method !== "unknown") {
     const cmds: Record<string, string[]> = {
-      npm: ["npm", "uninstall", "-g", "opencode-ai"],
-      pnpm: ["pnpm", "uninstall", "-g", "opencode-ai"],
-      bun: ["bun", "remove", "-g", "opencode-ai"],
-      yarn: ["yarn", "global", "remove", "opencode-ai"],
-      brew: ["brew", "uninstall", "opencode"],
-      choco: ["choco", "uninstall", "opencode"],
-      scoop: ["scoop", "uninstall", "opencode"],
+      npm: ["npm", "uninstall", "-g", "@bolt-builder/bolt-cli"],
+      pnpm: ["pnpm", "uninstall", "-g", "@bolt-builder/bolt-cli"],
+      bun: ["bun", "remove", "-g", "@bolt-builder/bolt-cli"],
+      yarn: ["yarn", "global", "remove", "@bolt-builder/bolt-cli"],
+      brew: ["brew", "uninstall", "bolt"],
+      choco: ["choco", "uninstall", "bolt"],
+      scoop: ["scoop", "uninstall", "bolt"],
     }
 
     const cmd = cmds[method]
     if (cmd) {
       spinner.start(`Running ${cmd.join(" ")}...`)
-      const result = await Process.run(method === "choco" ? ["choco", "uninstall", "opencode", "-y", "-r"] : cmd, {
+      const result = await Process.run(method === "choco" ? ["choco", "uninstall", "bolt", "-y", "-r"] : cmd, {
         nothrow: true,
       })
       if (result.code !== 0) {
@@ -215,7 +215,7 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
     prompts.log.info(`  rm "${targets.binary}"`)
 
     const binDir = path.dirname(targets.binary)
-    if (binDir.includes(".opencode")) {
+    if (binDir.includes(".bolt") || binDir.includes(".opencode")) {
       prompts.log.info(`  rmdir "${binDir}" 2>/dev/null`)
     }
   }
@@ -229,7 +229,7 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
   }
 
   UI.empty()
-  prompts.log.success("Thank you for using OpenCode!")
+  prompts.log.success("Thank you for using Bolt!")
 }
 
 async function getShellConfigFile(): Promise<string | null> {
@@ -266,7 +266,12 @@ async function getShellConfigFile(): Promise<string | null> {
     if (!exists) continue
 
     const content = await Filesystem.readText(file).catch(() => "")
-    if (content.includes("# opencode") || content.includes(".opencode/bin")) {
+    if (
+      content.includes("# bolt") ||
+      content.includes(".bolt/bin") ||
+      content.includes("# opencode") ||
+      content.includes(".opencode/bin")
+    ) {
       return file
     }
   }
@@ -284,21 +289,21 @@ async function cleanShellConfig(file: string) {
   for (const line of lines) {
     const trimmed = line.trim()
 
-    if (trimmed === "# opencode") {
+    if (trimmed === "# bolt" || trimmed === "# opencode") {
       skip = true
       continue
     }
 
     if (skip) {
       skip = false
-      if (trimmed.includes(".opencode/bin") || trimmed.includes("fish_add_path")) {
+      if (trimmed.includes(".bolt/bin") || trimmed.includes(".opencode/bin") || trimmed.includes("fish_add_path")) {
         continue
       }
     }
 
     if (
-      (trimmed.startsWith("export PATH=") && trimmed.includes(".opencode/bin")) ||
-      (trimmed.startsWith("fish_add_path") && trimmed.includes(".opencode"))
+      (trimmed.startsWith("export PATH=") && (trimmed.includes(".bolt/bin") || trimmed.includes(".opencode/bin"))) ||
+      (trimmed.startsWith("fish_add_path") && (trimmed.includes(".bolt") || trimmed.includes(".opencode")))
     ) {
       continue
     }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -137,7 +137,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Co
 export const use = serviceUse(Service)
 
 function globalConfigFile() {
-  const candidates = ["opencode.jsonc", "opencode.json", "config.json"].map((file) =>
+  const candidates = ["bolt.jsonc", "bolt.json", "opencode.jsonc", "opencode.json", "config.json"].map((file) =>
     path.join(Global.Path.config, file),
   )
   for (const file of candidates) {
@@ -258,6 +258,9 @@ const layer = Layer.effect(
       result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "config.json"), env))
       result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.json"), env))
       result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.jsonc"), env))
+      // bolt configs load last so they win over legacy opencode configs
+      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "bolt.json"), env))
+      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "bolt.jsonc"), env))
 
       const legacy = path.join(Global.Path.config, "config")
       if (existsSync(legacy)) {
@@ -404,8 +407,10 @@ const layer = Layer.effect(
         }
 
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
-          for (const file of yield* ConfigPaths.files("opencode", ctx.directory, ctx.worktree).pipe(Effect.orDie)) {
-            yield* merge(file, yield* loadFile(file, authEnv), "local")
+          for (const name of ["opencode", "bolt"]) {
+            for (const file of yield* ConfigPaths.files(name, ctx.directory, ctx.worktree).pipe(Effect.orDie)) {
+              yield* merge(file, yield* loadFile(file, authEnv), "local")
+            }
           }
         }
 
@@ -422,8 +427,8 @@ const layer = Layer.effect(
         const deps: Fiber.Fiber<void>[] = []
 
         for (const dir of directories) {
-          if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
-            for (const file of ["opencode.json", "opencode.jsonc"]) {
+          if (dir.endsWith(".bolt") || dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
+            for (const file of ["opencode.json", "opencode.jsonc", "bolt.json", "bolt.jsonc"]) {
               const source = path.join(dir, file)
               yield* Effect.logDebug(`loading config from ${source}`)
               yield* merge(source, yield* loadFile(source, authEnv))

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -26,13 +26,13 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
     Global.Path.config,
     ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
       ? yield* afs.up({
-          targets: [".opencode"],
+          targets: [".opencode", ".bolt"],
           start: directory,
           stop: worktree,
         })
       : []),
     ...(yield* afs.up({
-      targets: [".opencode"],
+      targets: [".opencode", ".bolt"],
       start: Global.Path.home,
       stop: Global.Path.home,
     })),

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -197,13 +197,15 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
     yield* mergeFile(acc, file)
   }
 
-  // 4. `.opencode` directories (and OPENCODE_CONFIG_DIR) discovered while
-  // walking up the tree. Also returned below so callers can install plugin
-  // dependencies from each location.
-  const dirs = unique(directories).filter((dir) => dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR)
+  // 4. `.opencode` / `.bolt` directories (and OPENCODE_CONFIG_DIR) discovered
+  // while walking up the tree. Also returned below so callers can install
+  // plugin dependencies from each location.
+  const dirs = unique(directories).filter(
+    (dir) => dir.endsWith(".opencode") || dir.endsWith(".bolt") || dir === Flag.OPENCODE_CONFIG_DIR,
+  )
 
   for (const dir of dirs) {
-    if (!dir.endsWith(".opencode") && dir !== Flag.OPENCODE_CONFIG_DIR) continue
+    if (!dir.endsWith(".opencode") && !dir.endsWith(".bolt") && dir !== Flag.OPENCODE_CONFIG_DIR) continue
     for (const file of ConfigPaths.fileInDirectory(dir, "tui")) {
       yield* mergeFile(acc, file)
     }

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -39,7 +39,7 @@ export const Info = Schema.Struct({
 export type Info = Schema.Schema.Type<typeof Info>
 
 export function userAgent(client = "cli") {
-  return `opencode/${InstallationChannel}/${InstallationVersion}/${client}`
+  return `bolt/${InstallationChannel}/${InstallationVersion}/${client}`
 }
 
 export const USER_AGENT = userAgent()
@@ -144,7 +144,9 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
 
     const upgradeCurl = Effect.fnUntraced(
       function* (target: string) {
-        const response = yield* httpOk.execute(HttpClientRequest.get("https://opencode.ai/install"))
+        const response = yield* httpOk.execute(
+          HttpClientRequest.get("https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install"),
+        )
         const body = yield* response.text
         const bodyBytes = new TextEncoder().encode(body)
         const shell = yield* upgradeScriptShell()
@@ -172,7 +174,8 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
         }
       }),
       method: Effect.fn("Installation.method")(function* () {
-        if (process.execPath.includes(path.join(".opencode", "bin"))) return "curl" as Method
+        if (process.execPath.includes(path.join(".bolt", "bin")) || process.execPath.includes(path.join(".opencode", "bin")))
+          return "curl" as Method
         if (process.execPath.includes(path.join(".local", "bin"))) return "curl" as Method
         const exec = process.execPath.toLowerCase()
 
@@ -181,9 +184,9 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
           { name: "yarn", command: () => text(["yarn", "global", "list"]) },
           { name: "pnpm", command: () => text(["pnpm", "list", "-g", "--depth=0"]) },
           { name: "bun", command: () => text(["bun", "pm", "ls", "-g"]) },
-          { name: "brew", command: () => text(["brew", "list", "--formula", "opencode"]) },
-          { name: "scoop", command: () => text(["scoop", "list", "opencode"]) },
-          { name: "choco", command: () => text(["choco", "list", "--limit-output", "opencode"]) },
+          { name: "brew", command: () => text(["brew", "list", "--formula", "bolt"]) },
+          { name: "scoop", command: () => text(["scoop", "list", "bolt"]) },
+          { name: "choco", command: () => text(["choco", "list", "--limit-output", "bolt"]) },
         ]
 
         checks.sort((a, b) => {
@@ -197,7 +200,9 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
         for (const check of checks) {
           const output = yield* check.command()
           const installedName =
-            check.name === "brew" || check.name === "choco" || check.name === "scoop" ? "opencode" : "opencode-ai"
+            check.name === "brew" || check.name === "choco" || check.name === "scoop"
+              ? "bolt"
+              : "@bolt-builder/bolt-cli"
           if (output.includes(installedName)) {
             return check.name
           }
@@ -227,7 +232,7 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
         if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm") {
           const response = yield* httpOk.execute(
             HttpClientRequest.get(
-              `${yield* NpmConfig.registry(process.cwd())}/opencode-ai/${InstallationChannel}`,
+              `${yield* NpmConfig.registry(process.cwd())}/@bolt-builder/bolt-cli/${InstallationChannel}`,
             ).pipe(HttpClientRequest.acceptJson),
           )
           const data = yield* HttpClientResponse.schemaBodyJson(NpmPackage)(response)
@@ -269,13 +274,13 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
             upgradeResult = yield* upgradeCurl(target)
             break
           case "npm":
-            upgradeResult = yield* run(["npm", "install", "-g", `opencode-ai@${target}`])
+            upgradeResult = yield* run(["npm", "install", "-g", `@bolt-builder/bolt-cli@${target}`])
             break
           case "pnpm":
-            upgradeResult = yield* run(["pnpm", "install", "-g", `opencode-ai@${target}`])
+            upgradeResult = yield* run(["pnpm", "install", "-g", `@bolt-builder/bolt-cli@${target}`])
             break
           case "bun":
-            upgradeResult = yield* run(["bun", "install", "-g", `opencode-ai@${target}`])
+            upgradeResult = yield* run(["bun", "install", "-g", `@bolt-builder/bolt-cli@${target}`])
             break
           case "brew": {
             const formula = yield* getBrewFormula()

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -313,7 +313,8 @@ it.effect("creates global jsonc config with schema when no global configs exist"
     Effect.gen(function* () {
       yield* Config.use.get().pipe(provideInstanceEffect(dir))
 
-      const content = yield* FSUtil.use.readFileString(path.join(dir, "opencode.jsonc"))
+      // fresh installs get a bolt.jsonc; legacy opencode configs are still read when present
+      const content = yield* FSUtil.use.readFileString(path.join(dir, "bolt.jsonc"))
       expect(content).toContain('"$schema": "https://opencode.ai/config.json"')
     }).pipe(Effect.provide(testInstanceStoreLayer), Effect.provide(LayerNode.compile(CrossSpawnSpawner.node))),
   ),


### PR DESCRIPTION
### Issue for this PR

Closes #35

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the remaining install-path breakage from the Bolt rename and adds dual config discovery, split into 7 per-file commits.

Install/upgrade/docker correctness (these break real users of v0.0.1):

- The curl installer downloaded `Bolt-<target>.tar.gz` while releases publish `bolt-cli-<os>-<arch>.tar.gz|zip`; it now uses the right asset prefix, handles `bolt.exe` on Windows, and its usage/epilogue point at this repo instead of opencode.ai

```bash
# release assets are named bolt-cli-<os>-<arch>[...] by packages/opencode/script/build.ts
filename="bolt-cli-$target$archive_ext"
```

- `Dockerfile` copied `dist/opencode-linux-*` (nonexistent) and ran `opencode`; now `dist/@bolt-builder/bolt-cli-linux-*` with `ENTRYPOINT ["bolt"]`
- `bolt upgrade` fetched the upstream opencode.ai installer and installed `opencode-ai` from npm; it now fetches this repo's installer, upgrades `@bolt-builder/bolt-cli`, and detects curl installs in `~/.bolt/bin` (legacy `~/.opencode/bin` still recognized). The installation client string is now `bolt/<channel>/<version>/<client>`
- `bolt uninstall` cleaned only `.opencode` paths and `# opencode` PATH markers while the installer writes `~/.bolt/bin` + `# bolt`; it now handles both generations

Config dual-read (opencode configs keep working, bolt configs win):

- Global: `bolt.json(c)` loads after `opencode.json(c)`, so it takes precedence; fresh installs scaffold `bolt.jsonc`
- Project: config discovery walks for both `bolt.json(c)` and `opencode.json(c)`, and `.bolt` directories are discovered alongside `.opencode`
- TUI config is read from `.bolt` directories as well

These fixes work because each change points an existing code path at the names the build and release pipeline actually produces (`bolt-cli-<os>-<arch>` assets, `dist/@bolt-builder/bolt-cli-linux-*`, `@bolt-builder/bolt-cli` on npm, `~/.bolt/bin`), while keeping the legacy opencode names recognized for reads and cleanup so existing installs and configs are not broken.

### How did you verify your code works?

Added unit tests in `packages/opencode/test/config/config.test.ts` covering dual config discovery and precedence (bolt over opencode), and validated the branch via CI. The installer and Dockerfile changes were checked against the asset names produced by `packages/opencode/script/build.ts`.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR