### PR TITLE
fix(ci): skip desktop updater feed when signing key is unavailable

### DIFF
--- a/script/publish.ts
+++ b/script/publish.ts
@@ -44,7 +44,19 @@ await $`bun ./packages/opencode/script/publish.ts`
 console.log("\n=== preview cli / sdk / plugin / ui: skipped (@opencode-ai scope not owned) ===\n")
 
 if (Script.release) {
-  await $`bun ./packages/desktop/scripts/finalize-latest-json.ts`
+  // latest.json signs update artifacts with the Tauri updater key. When
+  // TAURI_SIGNING_PRIVATE_KEY is missing or invalid, skip the desktop updater
+  // feed instead of failing the whole release: the release still ships, the
+  // desktop app just won't see this version via auto-update.
+  const feed = await $`bun ./packages/desktop/scripts/finalize-latest-json.ts`.nothrow()
+  if (feed.exitCode !== 0) {
+    console.warn(feed.stdout.toString())
+    console.warn(feed.stderr.toString())
+    console.warn(
+      "::warning::skipping desktop updater feed: finalize-latest-json failed (missing or invalid TAURI_SIGNING_PRIVATE_KEY?)",
+    )
+  }
+  // latest.yml uses electron-updater's embedded sha512 checksums and needs no signing key.
   await $`bun ./packages/desktop/scripts/finalize-latest-yml.ts`
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #40

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Release run 30585007660 (v2.0.0) failed at its final step: `finalize-latest-json.ts` signs desktop update artifacts via `bunx @tauri-apps/cli signer sign`, and the fork's `TAURI_SIGNING_PRIVATE_KEY` secret is not a valid minisign key (`incorrect updater private key password: Missing comment in secret key`). That killed the release after npm and Docker had already published, leaving the GitHub release stuck in draft with no version tag pushed.

This applies the same partial-release policy the workflow already uses for electron/signing legs: the updater feed skips itself with a workflow warning instead of failing the release.

```ts
const feed = await $`bun ./packages/desktop/scripts/finalize-latest-json.ts`.nothrow()
if (feed.exitCode !== 0) {
  console.warn(feed.stdout.toString())
  console.warn(feed.stderr.toString())
  console.warn(
    "::warning::skipping desktop updater feed: finalize-latest-json failed (missing or invalid TAURI_SIGNING_PRIVATE_KEY?)",
  )
}
```

`finalize-latest-yml.ts` keeps running unconditionally since electron-updater's latest.yml relies on embedded sha512 checksums, not the Tauri key. The consequence of a skip is only that the desktop app won't discover the version via auto-update; the proper long-term fix (generate a Bolt updater keypair and embed its public key in the desktop updater config) is tracked in #40.

### How did you verify your code works?

`bun build --no-bundle script/publish.ts` parses clean and the failure output is preserved in the log via the captured stdout/stderr. The change is a `.nothrow()` guard around an existing invocation; behavior with a valid key is unchanged.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->