### PR TITLE
feat(cli): autosave memory by digesting finished session turns

### DIFF
--- a/packages/opencode/src/memory/host.ts
+++ b/packages/opencode/src/memory/host.ts
@@ -39,7 +39,7 @@ function text(parts: SessionV1.Part[]) {
 function output(parts: SessionV1.Part[]) {
   return parts
     .flatMap((part) => {
-      if (part.type === "text") return [part.text.trim()]
+      if (part.type === "text") return [MemoryRedact.text(part.text.trim())]
       if (part.type === "tool") return [toolSummary(part)]
       return []
     })
@@ -156,11 +156,11 @@ function recalled(turn: Turn) {
 // --- Model resolution + invocation (host provider/`ai` -> port ModelHandle) --------------------
 
 function isOpenAI(model: Provider.Model) {
-  return model.providerID === "openai" && model.api.npm === "@ai-sdk/openai"
+  return model.providerID === "openai" || model.api.npm === "@ai-sdk/openai"
 }
 
 function options(model: Provider.Model) {
-  if (model.providerID === "openai" || model.api.npm === "@ai-sdk/openai") return { store: false }
+  if (isOpenAI(model)) return { store: false }
   return ProviderTransform.smallOptions(model)
 }
 
@@ -291,18 +291,14 @@ export function modelPort(input: { provider: Provider.Interface }): MemoryPorts.
         const parsed = MemoryConfig.parse(configured)
         const fallback = () =>
           input.provider.getModel(ProviderV2.ID.make(session.providerID), ModelV2.ID.make(session.modelID))
-        const source = yield* Effect.gen(function* () {
-          if (configured && !parsed)
-            return { model: yield* fallback(), reason: "invalid model" }
-          if (parsed)
-            return yield* input.provider
+        const source = parsed
+          ? yield* input.provider
               .getModel(ProviderV2.ID.make(parsed.providerID), ModelV2.ID.make(parsed.modelID))
               .pipe(
-                Effect.map((model) => ({ model, reason: undefined })),
+                Effect.map((model) => ({ model, reason: undefined as string | undefined })),
                 Effect.catch(() => Effect.map(fallback(), (model) => ({ model, reason: "model unavailable" }))),
               )
-          return { model: yield* fallback(), reason: undefined }
-        })
+          : { model: yield* fallback(), reason: configured ? "invalid model" : undefined }
         if (source.reason)
           yield* Effect.logWarning("memory model config ignored", { reason: source.reason, model: configured })
         const language = yield* input.provider.getLanguage(source.model)

--- a/packages/opencode/src/memory/host.ts
+++ b/packages/opencode/src/memory/host.ts
@@ -1,0 +1,363 @@
+import { generateText, streamText } from "ai"
+import { Effect } from "effect"
+import type { LanguageModelV3 } from "@ai-sdk/provider"
+import { MemoryConfig } from "@opencode-ai/memory/effect/config"
+import { MemoryError } from "@opencode-ai/memory/effect/errors"
+import type { MemoryPorts } from "@opencode-ai/memory/effect/ports"
+import { MemoryPaths } from "@opencode-ai/memory/effect/paths"
+import { MemoryService } from "@opencode-ai/memory/effect/service"
+import { MemoryTurn } from "@opencode-ai/memory/effect/turn"
+import { MemoryRedact } from "@opencode-ai/memory/redact"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { Provider } from "@/provider/provider"
+import { ProviderTransform } from "@/provider/transform"
+import { InstanceState } from "@/effect/instance-state"
+import { SessionID } from "@/session/schema"
+import type { Session } from "@/session/session"
+import type { SessionSummary } from "@/session/summary"
+import type { Snapshot } from "@/snapshot"
+
+// --- Transcript extraction (host message model -> port TurnView) ------------------------------
+
+function brief(input: string, max: number) {
+  const text = input.trim().replaceAll(/\s+/g, " ")
+  if (text.length <= max) return text
+  return `${text.slice(0, Math.max(0, max - 3))}...`
+}
+
+function text(parts: SessionV1.Part[]) {
+  return parts
+    .filter((part): part is SessionV1.TextPart => part.type === "text")
+    .filter((part) => !part.synthetic && !part.ignored)
+    .map((part) => MemoryRedact.text(part.text.trim()))
+    .filter(Boolean)
+    .join("\n\n")
+}
+
+function output(parts: SessionV1.Part[]) {
+  return parts
+    .flatMap((part) => {
+      if (part.type === "text") return [part.text.trim()]
+      if (part.type === "tool") return [toolSummary(part)]
+      return []
+    })
+    .filter(Boolean)
+    .join("\n")
+}
+
+function hidden(input: string) {
+  const flat = input.trim().replaceAll(/\s+/g, " ")
+  if (!flat) return ""
+  if (MemoryRedact.has(flat)) return "[redacted]"
+  return brief(flat, 220)
+}
+
+function field(input: Record<string, unknown>, key: string) {
+  const value = input[key]
+  return typeof value === "string" ? hidden(value) : ""
+}
+
+function exit(input: Record<string, unknown> | undefined) {
+  const value = input?.exit
+  if (typeof value !== "number" && typeof value !== "string") return ""
+  return String(value)
+}
+
+function toolSummary(part: SessionV1.ToolPart) {
+  const state = part.state
+  const pieces = [`Tool ${part.tool} ${state.status}`]
+  const command = field(state.input, "command")
+  const file = field(state.input, "filePath")
+  const pattern = field(state.input, "pattern")
+  const query = field(state.input, "query")
+  if (state.status === "completed" || state.status === "running") {
+    const title = state.title ? hidden(state.title) : ""
+    if (title) pieces.push(`title=${title}`)
+  }
+  if (command) pieces.push(`command=${command}`)
+  if (file) pieces.push(`file=${file}`)
+  if (pattern) pieces.push(`pattern=${pattern}`)
+  if (query) pieces.push(`query=${query}`)
+  if (state.status === "completed") {
+    const code = exit(state.metadata)
+    if (code) pieces.push(`exit=${code}`)
+  }
+  if (state.status === "error") {
+    const error = hidden(state.error)
+    if (error) pieces.push(`error=${error}`)
+  }
+  return pieces.join(" | ")
+}
+
+type UserTurn = SessionV1.WithParts & { info: SessionV1.User }
+type AssistantTurn = SessionV1.WithParts & { info: SessionV1.Assistant }
+type Turn = {
+  user: UserTurn
+  assistant: AssistantTurn
+  assistants: AssistantTurn[]
+}
+
+function trace(messages: SessionV1.WithParts[], max: number) {
+  return messages
+    .flatMap((item) => {
+      if (item.info.role === "user") {
+        const body = text(item.parts)
+        return body ? [`User: ${body}`] : []
+      }
+      if (item.info.role !== "assistant" || item.info.summary === true || item.info.error) return []
+      const body = output(item.parts)
+      return body ? [`Assistant: ${body}`] : []
+    })
+    .slice(-max)
+    .join("\n\n")
+}
+
+function latest(messages: SessionV1.WithParts[]): Turn | undefined {
+  const assistant = messages.findLast(
+    (item): item is AssistantTurn =>
+      item.info.role === "assistant" &&
+      Boolean(item.info.finish) &&
+      item.info.summary !== true &&
+      !item.info.error &&
+      Boolean(item.info.parentID),
+  )
+  if (!assistant) return
+  const idx = messages.findIndex((item) => item.info.id === assistant.info.parentID)
+  const user = idx >= 0 ? messages[idx] : undefined
+  if (!user || user.info.role !== "user") return
+  const assistants = messages
+    .slice(idx + 1)
+    .filter(
+      (item): item is AssistantTurn =>
+        item.info.role === "assistant" &&
+        item.info.parentID === user.info.id &&
+        item.info.summary !== true &&
+        !item.info.error,
+    )
+  return { user: user as UserTurn, assistant, assistants }
+}
+
+/** True when the turn was answered from memory (targeted recall ran); digesting it would echo memory back into itself. */
+function recalled(turn: Turn) {
+  return [turn.user, ...turn.assistants]
+    .flatMap((item) => item.parts)
+    .some(
+      (part) =>
+        part.type === "tool" &&
+        part.tool === "memory_recall" &&
+        part.state.status === "completed" &&
+        typeof part.state.metadata.count === "number" &&
+        part.state.metadata.count > 0,
+    )
+}
+
+// --- Model resolution + invocation (host provider/`ai` -> port ModelHandle) --------------------
+
+function isOpenAI(model: Provider.Model) {
+  return model.providerID === "openai" && model.api.npm === "@ai-sdk/openai"
+}
+
+function options(model: Provider.Model) {
+  if (model.providerID === "openai" || model.api.npm === "@ai-sdk/openai") return { store: false }
+  return ProviderTransform.smallOptions(model)
+}
+
+function params(input: { model: Provider.Model; options: Record<string, unknown>; system: string }) {
+  const openai = isOpenAI(input.model)
+  const merged = openai ? { ...input.options, instructions: input.system } : input.options
+  return {
+    providerOptions: ProviderTransform.providerOptions(input.model, merged),
+    system: openai ? undefined : input.system,
+  }
+}
+
+async function invoke(input: {
+  source: Provider.Model
+  language: LanguageModelV3
+  options: Record<string, unknown>
+  system: string
+  prompt: string
+  timeoutMs: number
+  temperature?: number
+  topP?: number
+  topK?: number
+  signal?: AbortSignal
+}) {
+  const ctl = new AbortController()
+  const ms = Math.max(1, input.timeoutMs)
+  const resolved = params({ model: input.source, options: input.options, system: input.system })
+  const openai = isOpenAI(input.source)
+  const common = {
+    model: input.language,
+    ...(resolved.system ? { system: resolved.system } : {}),
+    prompt: input.prompt,
+    providerOptions: resolved.providerOptions,
+    abortSignal: input.signal ? AbortSignal.any([ctl.signal, input.signal]) : ctl.signal,
+    temperature: input.temperature,
+    topP: input.topP,
+    topK: input.topK,
+  }
+  const work = async () => {
+    if (!openai) return generateText(common)
+
+    const result = streamText(common)
+    const chunks: string[] = []
+    let usage: unknown
+    for await (const part of result.fullStream) {
+      if (part.type === "text-delta" && part.text) chunks.push(part.text)
+      if (part.type === "finish-step") usage = part.usage
+      if (part.type === "finish") usage = part.totalUsage
+      if (part.type === "error") throw part.error
+    }
+    return { text: chunks.join(""), usage }
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      ctl.abort()
+      reject(new Error("memory model timed out"))
+    }, ms)
+  })
+  try {
+    return await Promise.race([work(), timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+    ctl.abort()
+  }
+}
+
+function handle(model: Provider.Model, language: LanguageModelV3) {
+  const opts = options(model)
+  // No explicit output cap: valid output is already bounded by the compact-JSON prompt, the parser's
+  // 64KB guard, and the capture timeout — and some backends reject explicit caps outright.
+  const temperature = ProviderTransform.temperature(model)
+  const topP = ProviderTransform.topP(model)
+  const topK = ProviderTransform.topK(model)
+  return { source: model, language, options: opts, temperature, topP, topK }
+}
+
+type ModelHandle = ReturnType<typeof handle>
+
+// --- Ports -------------------------------------------------------------------------------------
+
+/** Host SessionPort: extracts a TurnView from the session store + snapshot diffs so the package
+ * orchestrator never touches the host message model. */
+export function sessionPort(input: {
+  sessions: Session.Interface
+  summary: SessionSummary.Interface
+}): MemoryPorts.SessionPort {
+  return {
+    readTurn: ({ sessionID, window }) =>
+      Effect.gen(function* () {
+        const messages = yield* input.sessions.messages({ sessionID: SessionID.make(sessionID), limit: window })
+        const turn = latest(messages)
+        if (!turn) return undefined
+        const diffs = yield* input.summary.computeDiff({ messages: [turn.user, ...turn.assistants] }).pipe(
+          Effect.catch((err) =>
+            Effect.logWarning("memory turn diff unavailable", { error: String(err) }).pipe(
+              Effect.as([] as Snapshot.FileDiff[]),
+            ),
+          ),
+        )
+        return {
+          user: text(turn.user.parts),
+          assistant: output(turn.assistant.parts),
+          recent: trace(messages, 8),
+          lastAssistantID: turn.assistant.info.id,
+          sessionModel: {
+            providerID: turn.user.info.model.providerID,
+            modelID: turn.user.info.model.modelID,
+          },
+          recalledMemory: recalled(turn),
+          diffs: [...diffs],
+        }
+      }).pipe(Effect.mapError(MemoryError.from)),
+    get: ({ sessionID }) =>
+      input.sessions.get(SessionID.make(sessionID)).pipe(
+        Effect.map((info) => ({ parentID: info.parentID })),
+        Effect.mapError(MemoryError.from),
+      ),
+  }
+}
+
+/** Host ModelPort: resolves the consolidation model through the provider service and runs it via
+ * the `ai` SDK, exposing the resolved model to the package as an opaque handle. */
+export function modelPort(input: { provider: Provider.Interface }): MemoryPorts.ModelPort {
+  return {
+    resolve: ({ configured, session }) =>
+      Effect.gen(function* () {
+        const parsed = MemoryConfig.parse(configured)
+        const fallback = () =>
+          input.provider.getModel(ProviderV2.ID.make(session.providerID), ModelV2.ID.make(session.modelID))
+        const source = yield* Effect.gen(function* () {
+          if (configured && !parsed)
+            return { model: yield* fallback(), reason: "invalid model" }
+          if (parsed)
+            return yield* input.provider
+              .getModel(ProviderV2.ID.make(parsed.providerID), ModelV2.ID.make(parsed.modelID))
+              .pipe(
+                Effect.map((model) => ({ model, reason: undefined })),
+                Effect.catch(() => Effect.map(fallback(), (model) => ({ model, reason: "model unavailable" }))),
+              )
+          return { model: yield* fallback(), reason: undefined }
+        })
+        if (source.reason)
+          yield* Effect.logWarning("memory model config ignored", { reason: source.reason, model: configured })
+        const language = yield* input.provider.getLanguage(source.model)
+        return {
+          handle: handle(source.model, language),
+          ...(source.reason ? { fallback: { reason: source.reason } } : {}),
+        }
+      }).pipe(Effect.mapError(MemoryError.from)),
+    run: ({ handle: opaque, system, prompt, timeoutMs, signal }) => {
+      const resolved = opaque as ModelHandle
+      return invoke({
+        source: resolved.source,
+        language: resolved.language,
+        options: resolved.options,
+        system,
+        prompt,
+        timeoutMs,
+        temperature: resolved.temperature,
+        topP: resolved.topP,
+        topK: resolved.topK,
+        signal,
+      })
+    },
+  }
+}
+
+// --- Turn lifecycle ------------------------------------------------------------------------------
+
+export type Reason = MemoryTurn.Reason
+
+const memory = MemoryService.make()
+
+/** Cancel a pending idle flush when a new turn begins on the session. */
+export function open(input: { sessionID: SessionID }) {
+  MemoryTurn.open({ sessionID: input.sessionID })
+}
+
+/** Digest the finished turn into the memory store. Delegates locking and idle-flush scheduling to
+ * the memory package; a disabled store makes this a cheap no-op. */
+export const close = Effect.fn("MemoryHost.close")(function* (input: {
+  sessionID: SessionID
+  reason: Reason
+  sessions: Session.Interface
+  summary: SessionSummary.Interface
+  provider: Provider.Interface
+}) {
+  const ctx = yield* InstanceState.context
+  const root = MemoryPaths.root({ ctx })
+  return yield* MemoryTurn.close({
+    root,
+    sessionID: input.sessionID,
+    reason: input.reason,
+    session: sessionPort({ sessions: input.sessions, summary: input.summary }),
+    model: modelPort({ provider: input.provider }),
+  }).pipe(Effect.provideService(MemoryService.Service, memory))
+})
+
+export * as MemoryHost from "./host"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1344,7 +1344,7 @@ const layer = Layer.effect(
     const loop: (input: LoopInput) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.loop")(function* (
       input: LoopInput,
     ) {
-      MemoryHost.open({ sessionID: input.sessionID })
+      yield* Effect.sync(() => MemoryHost.open({ sessionID: input.sessionID }))
       return yield* state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID)).pipe(
         Effect.onExit((exit) =>
           MemoryHost.close({
@@ -1353,7 +1353,12 @@ const layer = Layer.effect(
             sessions,
             summary,
             provider,
-          }).pipe(Effect.ignore, Effect.forkIn(scope)),
+          }).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("memory turn close failed", { "session.id": input.sessionID, cause }),
+            ),
+            Effect.forkIn(scope),
+          ),
         ),
       )
     })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -53,6 +53,7 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { eq } from "drizzle-orm"
 import { SessionTable } from "@opencode-ai/core/session/sql"
+import { MemoryHost } from "@/memory/host"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
@@ -1343,7 +1344,18 @@ const layer = Layer.effect(
     const loop: (input: LoopInput) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.loop")(function* (
       input: LoopInput,
     ) {
-      return yield* state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID))
+      MemoryHost.open({ sessionID: input.sessionID })
+      return yield* state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID)).pipe(
+        Effect.onExit((exit) =>
+          MemoryHost.close({
+            sessionID: input.sessionID,
+            reason: Exit.isSuccess(exit) ? "completed" : Cause.hasInterruptsOnly(exit.cause) ? "interrupted" : "error",
+            sessions,
+            summary,
+            provider,
+          }).pipe(Effect.ignore, Effect.forkIn(scope)),
+        ),
+      )
     })
 
     const shell: (input: ShellInput) => Effect.Effect<SessionV1.WithParts, Session.BusyError> = Effect.fn(

--- a/packages/opencode/test/memory/host.test.ts
+++ b/packages/opencode/test/memory/host.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, test } from "bun:test"
+import type { LanguageModelV3 } from "@ai-sdk/provider"
+import { Effect } from "effect"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ModelNotFoundError, type Provider } from "@/provider/provider"
+import { MessageID, PartID, SessionID } from "@/session/schema"
+import type { Session } from "@/session/session"
+import type { SessionSummary } from "@/session/summary"
+import type { Snapshot } from "@/snapshot"
+import { MemoryHost } from "@/memory/host"
+
+const pid = ProviderV2.ID.make("test")
+const mid = ModelV2.ID.make("fake-memory-model")
+
+function mdl(id = mid): Provider.Model {
+  return {
+    id,
+    providerID: pid,
+    api: { id, npm: "test-provider", url: "" },
+    limit: { context: 100_000, output: 4_000 },
+    capabilities: {
+      toolcall: true,
+      attachment: false,
+      reasoning: false,
+      temperature: true,
+      input: { text: true, image: false, audio: false, video: false },
+      output: { text: true, image: false, audio: false, video: false },
+    },
+  } as unknown as Provider.Model
+}
+
+function lang(outputs = ["{}"]): LanguageModelV3 {
+  let idx = 0
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "fake-memory-model",
+    supportedUrls: {},
+    doGenerate: async () => {
+      const text = outputs[idx++] ?? outputs.at(-1) ?? "{}"
+      return {
+        content: [{ type: "text", text }],
+        finishReason: { unified: "stop" },
+        usage: {
+          inputTokens: { total: 12 },
+          outputTokens: { total: 8 },
+          raw: {},
+        },
+        warnings: [],
+        providerMetadata: {},
+        request: {},
+        response: {},
+      }
+    },
+  } as unknown as LanguageModelV3
+}
+
+function provider(input: { outputs?: string[]; seen?: string[] } = {}): Provider.Interface {
+  const base = mdl()
+  const mem = mdl(ModelV2.ID.make("memory-config-model"))
+  const info = {
+    id: pid,
+    name: "Test",
+    source: "config",
+    env: [],
+    options: {},
+    models: { [base.id]: base, [mem.id]: mem },
+  } as unknown as Provider.Info
+  return {
+    list: () => Effect.succeed({ [pid]: info }),
+    getProvider: () => Effect.succeed(info),
+    getModel: (providerID, modelID) => {
+      const found = info.models[modelID]
+      if (found) return Effect.succeed(found)
+      return Effect.fail(new ModelNotFoundError({ providerID, modelID }))
+    },
+    getLanguage: (model) => {
+      input.seen?.push(model.id)
+      return Effect.succeed(lang(input.outputs))
+    },
+    closest: () => Effect.succeed({ providerID: pid, modelID: base.id }),
+    getSmallModel: () => Effect.succeed(mem),
+    defaultModel: () => Effect.succeed({ providerID: pid, modelID: base.id }),
+  }
+}
+
+function text(sessionID: SessionID, messageID: MessageID, body: string): SessionV1.TextPart {
+  return {
+    id: PartID.make(`prt_${messageID}_text`),
+    sessionID,
+    messageID,
+    type: "text",
+    text: body,
+  }
+}
+
+function tool(input: {
+  sessionID: SessionID
+  messageID: MessageID
+  name: string
+  command?: string
+  meta?: Record<string, unknown>
+}): SessionV1.ToolPart {
+  return {
+    id: PartID.make(`prt_${input.messageID}_tool`),
+    sessionID: input.sessionID,
+    messageID: input.messageID,
+    type: "tool",
+    callID: `call_${input.messageID}`,
+    tool: input.name,
+    state: {
+      status: "completed",
+      input: input.command ? { command: input.command } : {},
+      output: "",
+      title: input.name,
+      metadata: input.meta ?? {},
+      time: { start: 1, end: 2 },
+    },
+  }
+}
+
+function user(input: { sessionID: SessionID; id: MessageID; body: string }): SessionV1.WithParts {
+  return {
+    info: {
+      id: input.id,
+      sessionID: input.sessionID,
+      role: "user",
+      time: { created: 1 },
+      agent: "code",
+      model: { providerID: pid, modelID: mid },
+    },
+    parts: [text(input.sessionID, input.id, input.body)],
+  }
+}
+
+function assistant(input: {
+  sessionID: SessionID
+  id: MessageID
+  parentID: MessageID
+  parts: SessionV1.Part[]
+  time: number
+  finish?: string
+}): SessionV1.WithParts {
+  return {
+    info: {
+      id: input.id,
+      sessionID: input.sessionID,
+      role: "assistant",
+      time: { created: input.time, completed: input.time + 1 },
+      parentID: input.parentID,
+      modelID: mid,
+      providerID: pid,
+      mode: "build",
+      agent: "code",
+      path: { cwd: "/repo", root: "/repo" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      finish: input.finish ?? "stop",
+    },
+    parts: input.parts,
+  }
+}
+
+function sessions(messages: SessionV1.WithParts[]): Session.Interface {
+  return {
+    get: () => Effect.succeed({ parentID: undefined }),
+    messages: (input?: { limit?: number }) => Effect.succeed(input?.limit ? messages.slice(-input.limit) : messages),
+  } as unknown as Session.Interface
+}
+
+function summary(input: { seen: string[]; diffs: Snapshot.FileDiff[] }): SessionSummary.Interface {
+  return {
+    summarize: () => Effect.void,
+    diff: () => Effect.succeed([]),
+    computeDiff: (current: { messages: SessionV1.WithParts[] }) => {
+      input.seen.push(...current.messages.map((item) => item.info.id))
+      return Effect.succeed(input.diffs)
+    },
+  } as SessionSummary.Interface
+}
+
+const ref = { providerID: "test", modelID: "fake-memory-model" }
+
+describe("memory host", () => {
+  test("session port extracts the latest turn, recall markers, and all assistant steps", async () => {
+    const sessionID = SessionID.make("ses_memory_adapter")
+    const uid = MessageID.make("msg_user")
+    const recall = MessageID.make("msg_recall")
+    const shell = MessageID.make("msg_shell")
+    const final = MessageID.make("msg_final")
+    const diffs = [
+      {
+        file: "packages/opencode/src/memory/host.ts",
+        additions: 4,
+        deletions: 1,
+        status: "modified" as const,
+      },
+    ] satisfies Snapshot.FileDiff[]
+    const seen: string[] = []
+    const messages = [
+      user({
+        sessionID,
+        id: uid,
+        body: "remember the package test command with OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890",
+      }),
+      assistant({
+        sessionID,
+        id: recall,
+        parentID: uid,
+        time: 2,
+        finish: "tool-calls",
+        parts: [
+          tool({
+            sessionID,
+            messageID: recall,
+            name: "memory_recall",
+            meta: { count: 2, bytes: 120, tokens: 30, files: ["project.md"] },
+          }),
+        ],
+      }),
+      assistant({
+        sessionID,
+        id: shell,
+        parentID: uid,
+        time: 4,
+        finish: "tool-calls",
+        parts: [
+          tool({
+            sessionID,
+            messageID: shell,
+            name: "bash",
+            command: "OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 bun test",
+          }),
+        ],
+      }),
+      assistant({
+        sessionID,
+        id: final,
+        parentID: uid,
+        time: 6,
+        parts: [text(sessionID, final, "Run bun test from packages/opencode for CLI memory tests.")],
+      }),
+    ]
+
+    const view = await Effect.runPromise(
+      MemoryHost.sessionPort({ sessions: sessions(messages), summary: summary({ seen, diffs }) }).readTurn({
+        sessionID,
+        window: 24,
+      }),
+    )
+
+    expect(view).toMatchObject({
+      user: "remember the package test command with [redacted]",
+      assistant: "Run bun test from packages/opencode for CLI memory tests.",
+      lastAssistantID: final,
+      sessionModel: ref,
+      recalledMemory: true,
+      diffs,
+    })
+    expect(view?.recent).toContain("Tool memory_recall completed")
+    expect(view?.recent).toContain("command=[redacted]")
+    expect(view?.recent).not.toContain("sk-proj-abcdefghijklmnopqrstuvwxyz1234567890")
+    expect(view?.user).not.toContain("sk-proj-abcdefghijklmnopqrstuvwxyz1234567890")
+    expect(seen).toEqual([uid, recall, shell, final])
+  })
+
+  test("session port returns undefined when no finished assistant turn exists", async () => {
+    const sessionID = SessionID.make("ses_memory_empty")
+    const uid = MessageID.make("msg_user_only")
+    const seen: string[] = []
+    const view = await Effect.runPromise(
+      MemoryHost.sessionPort({
+        sessions: sessions([user({ sessionID, id: uid, body: "hello" })]),
+        summary: summary({ seen, diffs: [] }),
+      }).readTurn({ sessionID, window: 24 }),
+    )
+    expect(view).toBeUndefined()
+    expect(seen).toEqual([])
+  })
+
+  test("model port resolves configured models and falls back to the session model", async () => {
+    const seen: string[] = []
+    const port = MemoryHost.modelPort({ provider: provider({ seen }) })
+
+    const configured = await Effect.runPromise(port.resolve({ configured: "test/memory-config-model", session: ref }))
+    const fallback = await Effect.runPromise(port.resolve({ configured: "test/missing-memory-model", session: ref }))
+
+    expect(configured.fallback).toBeUndefined()
+    expect(fallback.fallback).toEqual({ reason: "model unavailable" })
+    expect(seen).toEqual(["memory-config-model", "fake-memory-model"])
+  })
+
+  test("model port clears its timeout after successful output", async () => {
+    const set = globalThis.setTimeout
+    const clear = globalThis.clearTimeout
+    const handles = new Set<ReturnType<typeof setTimeout>>()
+    const cleared = new Set<ReturnType<typeof setTimeout>>()
+
+    ;(globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((...args: Parameters<typeof setTimeout>) => {
+      const handle = set(...args)
+      if (args[1] === 30_000) handles.add(handle)
+      return handle
+    }) as typeof setTimeout
+    ;(globalThis as { clearTimeout: typeof clearTimeout }).clearTimeout = ((
+      handle?: Parameters<typeof clearTimeout>[0],
+    ) => {
+      if (handle && handles.has(handle as ReturnType<typeof setTimeout>)) {
+        cleared.add(handle as ReturnType<typeof setTimeout>)
+      }
+      return clear(handle)
+    }) as typeof clearTimeout
+
+    try {
+      const port = MemoryHost.modelPort({ provider: provider({ outputs: ["{}"] }) })
+      const resolved = await Effect.runPromise(port.resolve({ session: ref }))
+
+      await port.run({
+        handle: resolved.handle,
+        system: "system",
+        prompt: "prompt",
+        timeoutMs: 30_000,
+      })
+    } finally {
+      ;(globalThis as { setTimeout: typeof setTimeout }).setTimeout = set
+      ;(globalThis as { clearTimeout: typeof clearTimeout }).clearTimeout = clear
+    }
+
+    expect(handles.size).toBe(1)
+    expect(cleared.size).toBe(1)
+  })
+})

--- a/packages/opencode/test/memory/host.test.ts
+++ b/packages/opencode/test/memory/host.test.ts
@@ -42,10 +42,10 @@ function lang(outputs = ["{}"]): LanguageModelV3 {
       const text = outputs[idx++] ?? outputs.at(-1) ?? "{}"
       return {
         content: [{ type: "text", text }],
-        finishReason: { unified: "stop" },
+        finishReason: { unified: "stop", raw: "stop" },
         usage: {
-          inputTokens: { total: 12 },
-          outputTokens: { total: 8 },
+          inputTokens: { total: 12, noCache: 12, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 8, text: 8, reasoning: 0 },
           raw: {},
         },
         warnings: [],
@@ -240,7 +240,13 @@ describe("memory host", () => {
         id: final,
         parentID: uid,
         time: 6,
-        parts: [text(sessionID, final, "Run bun test from packages/opencode for CLI memory tests.")],
+        parts: [
+          text(
+            sessionID,
+            final,
+            "Run bun test from packages/opencode for CLI memory tests. The key was OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890",
+          ),
+        ],
       }),
     ]
 
@@ -253,7 +259,7 @@ describe("memory host", () => {
 
     expect(view).toMatchObject({
       user: "remember the package test command with [redacted]",
-      assistant: "Run bun test from packages/opencode for CLI memory tests.",
+      assistant: "Run bun test from packages/opencode for CLI memory tests. The key was [redacted]",
       lastAssistantID: final,
       sessionModel: ref,
       recalledMemory: true,
@@ -263,6 +269,7 @@ describe("memory host", () => {
     expect(view?.recent).toContain("command=[redacted]")
     expect(view?.recent).not.toContain("sk-proj-abcdefghijklmnopqrstuvwxyz1234567890")
     expect(view?.user).not.toContain("sk-proj-abcdefghijklmnopqrstuvwxyz1234567890")
+    expect(view?.assistant).not.toContain("sk-proj-abcdefghijklmnopqrstuvwxyz1234567890")
     expect(seen).toEqual([uid, recall, shell, final])
   })
 

--- a/packages/opencode/test/memory/host.test.ts
+++ b/packages/opencode/test/memory/host.test.ts
@@ -57,7 +57,7 @@ function lang(outputs = ["{}"]): LanguageModelV3 {
   } as unknown as LanguageModelV3
 }
 
-function provider(input: { outputs?: string[]; seen?: string[] } = {}): Provider.Interface {
+function provider(input: { outputs?: string[]; seen?: string[]; language?: LanguageModelV3 } = {}): Provider.Interface {
   const base = mdl()
   const mem = mdl(ModelV2.ID.make("memory-config-model"))
   const info = {
@@ -78,7 +78,7 @@ function provider(input: { outputs?: string[]; seen?: string[] } = {}): Provider
     },
     getLanguage: (model) => {
       input.seen?.push(model.id)
-      return Effect.succeed(lang(input.outputs))
+      return Effect.succeed(input.language ?? lang(input.outputs))
     },
     closest: () => Effect.succeed({ providerID: pid, modelID: base.id }),
     getSmallModel: () => Effect.succeed(mem),
@@ -299,42 +299,22 @@ describe("memory host", () => {
     expect(seen).toEqual(["memory-config-model", "fake-memory-model"])
   })
 
-  test("model port clears its timeout after successful output", async () => {
-    const set = globalThis.setTimeout
-    const clear = globalThis.clearTimeout
-    const handles = new Set<ReturnType<typeof setTimeout>>()
-    const cleared = new Set<ReturnType<typeof setTimeout>>()
+  test("model port returns output within the timeout and fails hung models with the capture timeout", async () => {
+    const port = MemoryHost.modelPort({ provider: provider({ outputs: ["{}"] }) })
+    const resolved = await Effect.runPromise(port.resolve({ session: ref }))
+    const result = await port.run({
+      handle: resolved.handle,
+      system: "system",
+      prompt: "prompt",
+      timeoutMs: 30_000,
+    })
+    expect(result.text).toBe("{}")
 
-    ;(globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((...args: Parameters<typeof setTimeout>) => {
-      const handle = set(...args)
-      if (args[1] === 30_000) handles.add(handle)
-      return handle
-    }) as typeof setTimeout
-    ;(globalThis as { clearTimeout: typeof clearTimeout }).clearTimeout = ((
-      handle?: Parameters<typeof clearTimeout>[0],
-    ) => {
-      if (handle && handles.has(handle as ReturnType<typeof setTimeout>)) {
-        cleared.add(handle as ReturnType<typeof setTimeout>)
-      }
-      return clear(handle)
-    }) as typeof clearTimeout
-
-    try {
-      const port = MemoryHost.modelPort({ provider: provider({ outputs: ["{}"] }) })
-      const resolved = await Effect.runPromise(port.resolve({ session: ref }))
-
-      await port.run({
-        handle: resolved.handle,
-        system: "system",
-        prompt: "prompt",
-        timeoutMs: 30_000,
-      })
-    } finally {
-      ;(globalThis as { setTimeout: typeof setTimeout }).setTimeout = set
-      ;(globalThis as { clearTimeout: typeof clearTimeout }).clearTimeout = clear
-    }
-
-    expect(handles.size).toBe(1)
-    expect(cleared.size).toBe(1)
+    const hanging = { ...(lang() as object), doGenerate: () => new Promise(() => {}) } as unknown as LanguageModelV3
+    const hung = MemoryHost.modelPort({ provider: provider({ language: hanging }) })
+    const stalled = await Effect.runPromise(hung.resolve({ session: ref }))
+    await expect(
+      hung.run({ handle: stalled.handle, system: "system", prompt: "prompt", timeoutMs: 25 }),
+    ).rejects.toThrow("memory model timed out")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #42

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The memory package already ships a full turn-close capture pipeline (`MemoryCapture.turn`, `MemoryTurn.open/close` with locking and idle-flush scheduling), but nothing in the CLI drives it, so memory only grows when the model explicitly calls `memory_save`. This PR adds the host side so finished turns get digested automatically.

`packages/opencode/src/memory/host.ts` implements the two capture ports the package needs and keeps all host-model knowledge (SessionV1 shapes, provider resolution, the `ai` SDK) out of the package:

- `sessionPort` extracts a `TurnView` from the session store: latest finished assistant turn (finish set, not a summary, no error), its parent user message, redacted user/assistant text, a redacted recent-trace window, snapshot diffs via `SessionSummary.computeDiff`, and a `recalledMemory` flag (turn answered by `memory_recall` with hits) so recall echoes are not digested back into the store.
- `modelPort` resolves the consolidation model (configured `provider/model` with fallback to the session model) and runs it through `generateText`/`streamText` with the existing provider transforms and a hard timeout.

The prompt loop drives the lifecycle; close is forked onto the service scope and ignored so it can never fail, delay, or interrupt the session:

```ts
MemoryHost.open({ sessionID: input.sessionID })
return yield* state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID)).pipe(
  Effect.onExit((exit) =>
    MemoryHost.close({
      sessionID: input.sessionID,
      reason: Exit.isSuccess(exit) ? "completed" : Cause.hasInterruptsOnly(exit.cause) ? "interrupted" : "error",
      sessions,
      summary,
      provider,
    }).pipe(Effect.ignore, Effect.forkIn(scope)),
  ),
)
```

When memory is disabled, `MemoryCapture.turn` skips immediately (`state.enabled || capture.turnClose` gate), so the default path stays a cheap no-op. Child sessions are skipped by the package's `parentID` check. The `MemoryService` instance is module-local, matching how the core memory tools construct theirs.

### How did you verify your code works?

- `bun test ./test/memory/host.test.ts` from `packages/opencode/` — 4 tests covering turn extraction (redaction, recall markers, multi-step assistant turns), the no-finished-turn case, model resolution fallback, and timeout cleanup.
- `bun test ./test/session/prompt.test.ts` — 56 pass, confirming the loop hook does not regress the prompt path.
- `bun run typecheck` (`tsgo --noEmit`) clean in `packages/opencode/`.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic session memory handling, including conversation turn detection, context recall, transcript redaction, and tool-output summaries.
  - Memory processing now supports provider and model selection, streaming responses, and timeout protection.
  - Session memory is opened and finalized automatically as conversations complete, are interrupted, or encounter errors.

- **Bug Fixes**
  - Improved handling of empty sessions, unavailable models, fallback providers, and stalled model responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->