### PR TITLE
feat: enforce the /sandbox toggle with bwrap and sandbox-exec

### DIFF
--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -1,0 +1,94 @@
+export * as Sandbox from "./sandbox"
+
+import os from "os"
+import { Effect, Schema } from "effect"
+
+export class UnsupportedError extends Schema.TaggedErrorClass<UnsupportedError>()("SandboxUnsupportedError", {
+  message: Schema.String,
+}) {}
+
+export type Wrapped = { exe: string; args: string[] }
+
+/** True when the session opted into sandboxed execution via the `/sandbox` toggle. */
+export function enabled(metadata: Record<string, unknown> | null | undefined) {
+  return metadata?.["sandbox"] === true
+}
+
+/** Directories a sandboxed command may write: the given roots plus temp and device locations. */
+export function writable(dirs: string[]) {
+  const set = new Set<string>()
+  for (const dir of [...dirs, os.tmpdir(), "/tmp", "/private/tmp", "/var/folders", "/private/var/folders"]) {
+    if (dir && dir !== "/") set.add(dir)
+  }
+  return [...set]
+}
+
+/** bwrap argv: read-only root with the writable roots (and /dev, /proc) re-bound on top. */
+export function linux(input: { command: string; shell: string; writable: string[] }, exe: string): Wrapped {
+  return {
+    exe,
+    args: [
+      "--ro-bind",
+      "/",
+      "/",
+      "--dev-bind",
+      "/dev",
+      "/dev",
+      "--proc",
+      "/proc",
+      // No --unshare-pid: remounting procfs in a new PID namespace fails inside
+      // containers (CI, devcontainers), and this sandbox only isolates the filesystem.
+      ...input.writable.flatMap((dir) => ["--bind-try", dir, dir]),
+      "--die-with-parent",
+      "--",
+      input.shell,
+      "-c",
+      input.command,
+    ],
+  }
+}
+
+function escape(value: string) {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')
+}
+
+/** Seatbelt profile: allow everything except file writes outside the writable roots. */
+export function profile(writable: string[]) {
+  const rules = [...writable, "/dev"].map((dir) => `  (subpath "${escape(dir)}")`).join("\n")
+  return `(version 1)\n(allow default)\n(deny file-write*)\n(allow file-write*\n${rules}\n)`
+}
+
+/** sandbox-exec argv with an inline seatbelt profile. */
+export function darwin(input: { command: string; shell: string; writable: string[] }, exe: string): Wrapped {
+  return { exe, args: ["-p", profile(input.writable), input.shell, "-c", input.command] }
+}
+
+/** Wrap a shell command so it runs with a read-only filesystem outside the writable roots.
+ * Fails closed: unsupported platforms and missing wrapper binaries refuse to run. */
+export const wrap = Effect.fn("Sandbox.wrap")(function* (input: {
+  command: string
+  shell: string
+  writable: string[]
+}) {
+  if (process.platform === "linux") {
+    const exe = Bun.which("bwrap")
+    if (!exe)
+      return yield* new UnsupportedError({
+        message:
+          "Sandbox is enabled for this session but bubblewrap (bwrap) is not installed. Install it or disable the sandbox with /sandbox.",
+      })
+    return linux(input, exe)
+  }
+  if (process.platform === "darwin") {
+    const exe = Bun.which("sandbox-exec")
+    if (!exe)
+      return yield* new UnsupportedError({
+        message:
+          "Sandbox is enabled for this session but sandbox-exec is not available. Disable the sandbox with /sandbox.",
+      })
+    return darwin(input, exe)
+  }
+  return yield* new UnsupportedError({
+    message: `Sandbox is enabled for this session but sandboxed execution is not supported on ${process.platform}. Disable the sandbox with /sandbox.`,
+  })
+})

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -1,16 +1,21 @@
 export * as BashTool from "./bash"
 
 import path from "path"
+import { eq } from "drizzle-orm"
 import { ToolFailure } from "@opencode-ai/llm"
 import { Duration, Effect, Layer, Schema } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { Config } from "../config"
+import { Database } from "../database/database"
 import { makeLocationNode } from "../effect/app-node"
 import { FSUtil } from "../fs-util"
+import { Location } from "../location"
 import { LocationMutation } from "../location-mutation"
 import { AppProcess } from "../process"
 import { PermissionV2 } from "../permission"
+import { Sandbox } from "../sandbox"
 import { PositiveInt } from "../schema"
+import { SessionTable } from "../session/sql"
 import { ToolRegistry } from "./registry"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
@@ -102,6 +107,8 @@ const layer = Layer.effectDiscard(
     const appProcess = yield* AppProcess.Service
     const config = yield* Config.Service
     const permission = yield* PermissionV2.Service
+    const location = yield* Location.Service
+    const { db } = yield* Database.Service
 
     yield* tools
       .register({
@@ -155,13 +162,38 @@ const layer = Layer.effectDiscard(
               const shell =
                 Object.assign({}, ...entries.flatMap((entry) => (entry.type === "document" ? [entry.info] : [])))
                   .shell ?? defaultShell()
-              const command = ChildProcess.make(input.command, [], {
-                cwd: target.canonical,
-                shell,
-                stdin: "ignore",
-                detached: process.platform !== "win32",
-                forceKillAfter: Duration.seconds(3),
-              })
+              const row = yield* db
+                .select({ metadata: SessionTable.metadata })
+                .from(SessionTable)
+                .where(eq(SessionTable.id, context.sessionID))
+                .get()
+                .pipe(Effect.orDie)
+              const sandboxed = Sandbox.enabled(row?.metadata)
+              const wrapped = sandboxed
+                ? yield* Sandbox.wrap({
+                    command: input.command,
+                    shell,
+                    writable: Sandbox.writable([location.project.directory, location.directory, target.canonical]),
+                  }).pipe(
+                    Effect.catchTag("SandboxUnsupportedError", (error) =>
+                      Effect.fail(new ToolFailure({ message: error.message })),
+                    ),
+                  )
+                : undefined
+              const command = wrapped
+                ? ChildProcess.make(wrapped.exe, wrapped.args, {
+                    cwd: target.canonical,
+                    stdin: "ignore",
+                    detached: process.platform !== "win32",
+                    forceKillAfter: Duration.seconds(3),
+                  })
+                : ChildProcess.make(input.command, [], {
+                    cwd: target.canonical,
+                    shell,
+                    stdin: "ignore",
+                    detached: process.platform !== "win32",
+                    forceKillAfter: Duration.seconds(3),
+                  })
               const timeout = input.timeout ?? DEFAULT_TIMEOUT_MS
               const result = yield* appProcess
                 .run(command, {
@@ -193,7 +225,13 @@ const layer = Layer.effectDiscard(
                 truncated: result.outputTruncated === true,
                 ...(warnings.length ? { warnings } : {}),
               }
-            }).pipe(Effect.mapError(() => new ToolFailure({ message: `Unable to execute command: ${input.command}` }))),
+            }).pipe(
+              Effect.mapError((error) =>
+                error instanceof ToolFailure
+                  ? error
+                  : new ToolFailure({ message: `Unable to execute command: ${input.command}` }),
+              ),
+            ),
         }),
       })
       .pipe(Effect.orDie)
@@ -203,5 +241,14 @@ const layer = Layer.effectDiscard(
 export const node = makeLocationNode({
   name: "tool/bash",
   layer,
-  deps: [ToolRegistry.node, LocationMutation.node, FSUtil.node, AppProcess.node, Config.node, PermissionV2.node],
+  deps: [
+    ToolRegistry.node,
+    LocationMutation.node,
+    FSUtil.node,
+    AppProcess.node,
+    Config.node,
+    PermissionV2.node,
+    Location.node,
+    Database.node,
+  ],
 })

--- a/packages/core/test/sandbox.test.ts
+++ b/packages/core/test/sandbox.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import { Sandbox } from "../src/sandbox"
+
+describe("sandbox", () => {
+  test("enabled reads the session metadata flag strictly", () => {
+    expect(Sandbox.enabled({ sandbox: true })).toBe(true)
+    expect(Sandbox.enabled({ sandbox: "true" })).toBe(false)
+    expect(Sandbox.enabled({ sandbox: false })).toBe(false)
+    expect(Sandbox.enabled({})).toBe(false)
+    expect(Sandbox.enabled(undefined)).toBe(false)
+    expect(Sandbox.enabled(null)).toBe(false)
+  })
+
+  test("writable dedupes roots, adds temp locations, and drops empty or root entries", () => {
+    const dirs = Sandbox.writable(["/repo", "/repo", "", "/"])
+    expect(dirs).toContain("/repo")
+    expect(dirs).toContain("/tmp")
+    expect(dirs).toContain(os.tmpdir())
+    expect(dirs).not.toContain("")
+    expect(dirs).not.toContain("/")
+    expect(new Set(dirs).size).toBe(dirs.length)
+  })
+
+  test("linux argv rebinds writable roots over a read-only root and runs the shell", () => {
+    const wrapped = Sandbox.linux({ command: "bun test", shell: "/bin/sh", writable: ["/repo", "/tmp"] }, "/usr/bin/bwrap")
+    expect(wrapped.exe).toBe("/usr/bin/bwrap")
+    expect(wrapped.args.slice(0, 3)).toEqual(["--ro-bind", "/", "/"])
+    expect(wrapped.args).toContain("--die-with-parent")
+    expect(wrapped.args.join(" ")).toContain("--bind-try /repo /repo")
+    expect(wrapped.args.join(" ")).toContain("--bind-try /tmp /tmp")
+    expect(wrapped.args.slice(-3)).toEqual(["/bin/sh", "-c", "bun test"])
+  })
+
+  test("darwin profile denies writes outside the writable roots and escapes quotes", () => {
+    const text = Sandbox.profile(['/repo/we"ird', "/tmp"])
+    expect(text).toContain("(deny file-write*)")
+    expect(text).toContain('(subpath "/repo/we\\"ird")')
+    expect(text).toContain('(subpath "/tmp")')
+    expect(text).toContain('(subpath "/dev")')
+
+    const wrapped = Sandbox.darwin({ command: "bun test", shell: "/bin/zsh", writable: ["/repo"] }, "/usr/bin/sandbox-exec")
+    expect(wrapped.args[0]).toBe("-p")
+    expect(wrapped.args.slice(-3)).toEqual(["/bin/zsh", "-c", "bun test"])
+  })
+})

--- a/packages/core/test/tool-bash.test.ts
+++ b/packages/core/test/tool-bash.test.ts
@@ -4,8 +4,12 @@ import path from "path"
 import { describe, expect, test } from "bun:test"
 import { Effect, Layer } from "effect"
 import { ChildProcess } from "effect/unstable/process"
+import { Database } from "@opencode-ai/core/database/database"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Config } from "@opencode-ai/core/config"
+import { Project } from "@opencode-ai/core/project"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Location } from "@opencode-ai/core/location"
@@ -26,6 +30,7 @@ const sessionID = SessionV2.ID.make("ses_bash_tool_test")
 const assertions: PermissionV2.AssertInput[] = []
 const runs: Array<{
   readonly command: string
+  readonly args?: ReadonlyArray<string>
   readonly cwd?: string
   readonly shell?: string | boolean
   readonly options?: AppProcess.RunOptions
@@ -67,7 +72,13 @@ const appProcess = Layer.succeed(
     run: (command: ChildProcess.Command, options?: AppProcess.RunOptions) =>
       Effect.suspend(() => {
         if (command._tag !== "StandardCommand") throw new Error("expected standard command")
-        runs.push({ command: command.command, cwd: command.options.cwd, shell: command.options.shell, options })
+        runs.push({
+          command: command.command,
+          args: command.args,
+          cwd: command.options.cwd,
+          shell: command.options.shell,
+          options,
+        })
         return runFailure ? Effect.fail(runFailure) : Effect.succeed(result)
       }),
   } as unknown as AppProcess.Interface),
@@ -111,7 +122,7 @@ const withTool = <A, E, R>(
   }).pipe(
     Effect.provide(
       AppNodeBuilder.build(
-        LayerNode.group([ToolRegistry.node, ToolRegistry.toolsNode, LocationMutation.node, BashTool.node]),
+        LayerNode.group([ToolRegistry.node, ToolRegistry.toolsNode, LocationMutation.node, BashTool.node, Database.node]),
         [
           [Location.node, activeLocation],
           [PermissionV2.node, permission],
@@ -411,6 +422,64 @@ describe("BashTool", () => {
               })
             }),
           ),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
+  it.live("sandboxed session wraps execution or fails closed", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        return withTool(tmp.path, (registry) =>
+          Effect.gen(function* () {
+            const { db } = yield* Database.Service
+            yield* db
+              .insert(ProjectTable)
+              .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+              .onConflictDoNothing()
+              .run()
+              .pipe(Effect.orDie)
+            const boxed = SessionV2.ID.make("ses_bash_sandbox_test")
+            yield* db
+              .insert(SessionTable)
+              .values({
+                id: boxed,
+                project_id: Project.ID.global,
+                slug: "sandbox",
+                directory: "/project",
+                title: "sandbox",
+                version: "test",
+                agent: "test",
+                metadata: { sandbox: true },
+              })
+              .onConflictDoNothing()
+              .run()
+              .pipe(Effect.orDie)
+            const settled = yield* settleTool(registry, {
+              sessionID: boxed,
+              ...toolIdentity,
+              call: { type: "tool-call" as const, id: "call-sandbox", name: "bash", input: { command: "pwd" } },
+            })
+            const exe =
+              process.platform === "linux"
+                ? Bun.which("bwrap")
+                : process.platform === "darwin"
+                  ? Bun.which("sandbox-exec")
+                  : null
+            if (exe) {
+              expect(runs).toHaveLength(1)
+              expect(runs[0]?.command).toBe(exe)
+              expect(runs[0]?.shell).toBeUndefined()
+              expect(runs[0]?.args ?? []).toContain("-c")
+              expect(runs[0]?.args ?? []).toContain("pwd")
+              return
+            }
+            expect(runs).toEqual([])
+            expect(settled.result).toMatchObject({ type: "error" })
+          }),
         )
       },
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -10,6 +10,10 @@ import { Language, type Node } from "web-tree-sitter"
 
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { fileURLToPath } from "url"
+import { eq } from "drizzle-orm"
+import { Database } from "@opencode-ai/core/database/database"
+import { Sandbox } from "@opencode-ai/core/sandbox"
+import { SessionTable } from "@opencode-ai/core/session/sql"
 import { Config } from "@/config/config"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Shell } from "@opencode-ai/core/shell"
@@ -344,6 +348,7 @@ export const ShellTool = Tool.define(
     const trunc = yield* Truncate.Service
     const plugin = yield* Plugin.Service
     const flags = yield* RuntimeFlags.Service
+    const { db } = yield* Database.Service
     const defaultTimeoutMs = flags.bashDefaultTimeoutMs ?? 2 * 60 * 1000
 
     const cygpath = Effect.fn("ShellTool.cygpath")(function* (shell: string, text: string) {
@@ -432,6 +437,7 @@ export const ShellTool = Tool.define(
         cwd: string
         env: NodeJS.ProcessEnv
         timeout: number
+        wrapped?: Sandbox.Wrapped
       },
       ctx: Tool.Context,
     ) {
@@ -481,7 +487,16 @@ export const ShellTool = Tool.define(
       const code: number | null = yield* Effect.scoped(
         Effect.gen(function* () {
           yield* Effect.addFinalizer(closeSink)
-          const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
+          const handle = yield* spawner.spawn(
+            input.wrapped
+              ? ChildProcess.make(input.wrapped.exe, input.wrapped.args, {
+                  cwd: input.cwd,
+                  env: input.env,
+                  stdin: "ignore",
+                  detached: process.platform !== "win32",
+                })
+              : cmd(input.shell, input.command, input.cwd, input.env),
+          )
 
           yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
@@ -628,6 +643,20 @@ export const ShellTool = Tool.define(
                 }),
               )
 
+              const row = yield* db
+                .select({ metadata: SessionTable.metadata })
+                .from(SessionTable)
+                .where(eq(SessionTable.id, ctx.sessionID))
+                .get()
+                .pipe(Effect.orDie)
+              const wrapped = Sandbox.enabled(row?.metadata)
+                ? yield* Sandbox.wrap({
+                    command: params.command,
+                    shell,
+                    writable: Sandbox.writable([instanceCtx.worktree, instanceCtx.directory, cwd]),
+                  }).pipe(Effect.catchTag("SandboxUnsupportedError", (error) => Effect.die(new Error(error.message))))
+                : undefined
+
               return yield* run(
                 {
                   shell,
@@ -635,6 +664,7 @@ export const ShellTool = Tool.define(
                   cwd,
                   env: yield* shellEnv(ctx, cwd),
                   timeout,
+                  ...(wrapped ? { wrapped } : {}),
                 },
                 ctx,
               )

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -15,6 +15,7 @@ import { Agent } from "../../src/agent/agent"
 import { Truncate } from "@/tool/truncate"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Database } from "@opencode-ai/core/database/database"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Plugin } from "../../src/plugin"
 import { testEffect } from "../lib/effect"
@@ -32,6 +33,7 @@ const shellLayer = Layer.mergeAll(
       Config.node,
       Agent.node,
       RuntimeFlags.node,
+      Database.node,
     ]),
   ),
   testInstanceStoreLayer,


### PR DESCRIPTION
### Issue for this PR

Closes #44

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI's `/sandbox` toggle sets `metadata.sandbox: true` on the session and shows a badge, but no execution path ever read the flag — commands still ran with full host authority. This adds the backend.

`packages/core/src/sandbox.ts` wraps a shell command in a filesystem sandbox:

- **Linux**: bubblewrap with a read-only root and the worktree/temp roots re-bound read-write:

```ts
args: [
  "--ro-bind", "/", "/",
  "--dev-bind", "/dev", "/dev",
  "--proc", "/proc",
  // No --unshare-pid: remounting procfs in a new PID namespace fails inside
  // containers (CI, devcontainers), and this sandbox only isolates the filesystem.
  ...input.writable.flatMap((dir) => ["--bind-try", dir, dir]),
  "--die-with-parent",
  "--", input.shell, "-c", input.command,
]
```

- **macOS**: `sandbox-exec` with an inline seatbelt profile — `(allow default)` + `(deny file-write*)` + `(allow file-write* (subpath ...))` for the worktree, temp locations, and `/dev`.
- **Fail closed**: Windows, or a missing wrapper binary, refuses to run with a clear "disable the sandbox with /sandbox" message instead of silently running unsandboxed.

Both spawn paths consult the flag by reading the session row's `metadata` JSON column (v1 and v2 sessions share `SessionTable`): the core `bash` tool swaps its `ChildProcess` for the wrapped argv, and the v1 `shell` tool passes a `wrapped` command into its runner. Scope is filesystem isolation only — network and process authority are unchanged, and the permission/approval flow is untouched.

### How did you verify your code works?

- Real bwrap run: `touch /etc/blocked` inside the wrapper fails with `Read-only file system`, worktree writes succeed, `/proc` works. Also discovered `--unshare-pid` breaks under nested containers, hence the comment above.
- `bun test ./test/sandbox.test.ts ./test/tool-bash.test.ts` from `packages/core/` — 16 pass, including a new integration test that inserts a session with `metadata.sandbox: true` and asserts the wrapped argv (with bwrap installed) or the fail-closed error (without).
- `bun test ./test/tool/shell.test.ts` from `packages/opencode/` — 23 pass.
- `tsgo --noEmit` clean in both packages.

### Screenshots / recordings

_Not a UI change (the `/sandbox` UI already exists)._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->