### PR TITLE
fix(storybook): unbreak the storybook build check

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -38,3 +38,7 @@ jobs:
 
       - name: Build Storybook
         run: bun --cwd packages/storybook build
+        env:
+          # The build exceeds node's default old-space cap; raise it below the
+          # 16GB available on the 4vcpu runner.
+          NODE_OPTIONS: --max-old-space-size=6144

--- a/bun.lock
+++ b/bun.lock
@@ -955,7 +955,7 @@
         "@types/react": "18.0.25",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "solid-js": "catalog:",
+        "solid-js": "1.9.10",
         "storybook": "^10.2.13",
         "storybook-solidjs-vite": "^10.0.9",
         "typescript": "catalog:",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -22,7 +22,7 @@
     "@types/react": "18.0.25",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "solid-js": "catalog:",
+    "solid-js": "1.9.10",
     "storybook": "^10.2.13",
     "storybook-solidjs-vite": "^10.0.9",
     "typescript": "catalog:",


### PR DESCRIPTION
### Issue for this PR

Closes #48

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `storybook build` check fails on dev and every open PR with `Could not detect Solid version: solid-js is not installed`. The framework detects the Solid major version through storybook's package-manager helpers, whose fallback reads the raw dependency specifier and coerces it as semver:

```js
// storybook getVersionSafe
let version = await packageManager.getInstalledVersion(packageName);
return version || (version = packageManager.getAllDependencies()[packageName] ?? ""),
  coerce(version, { includePrerelease: !0 })?.toString();
```

`packages/storybook/package.json` declared `"solid-js": "catalog:"`, and `coerce("catalog:")` returns nothing, so detection throws before the build starts. There is no framework option to bypass it, so this pins the specifier to the concrete catalog version `1.9.10` (same resolved version, `bun install` reports no changes, and the `solid-js@1.9.10` patch still applies).

With detection fixed the build then dies with `FATAL ERROR: Ineffective mark-compacts near heap limit`, so the workflow now sets `NODE_OPTIONS: --max-old-space-size=6144` for the build step.

Tradeoff: a future solid-js catalog bump must also touch this one specifier; storybook's detection leaves no catalog-compatible alternative.

### How did you verify your code works?

Reproduced the exact CI failure locally with `bun --cwd packages/storybook build`, applied the pin (detection error gone, build proceeds), hit the OOM, and confirmed `Storybook build completed successfully` with the raised heap.

### Screenshots / recordings

_CI-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Storybook build reliability by allocating additional memory during builds.
  * Updated the Storybook package’s SolidJS version to ensure consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->