### PR TITLE
fix(ci): retry bun install on transient network failures

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -58,11 +58,21 @@ runs:
         # Workaround for patched peer variants
         # e.g. ./patches/ for standard-openapi
         # https://github.com/oven-sh/bun/issues/28147
+        flags="${{ inputs.install-flags }}"
         if [ "$RUNNER_OS" = "Windows" ]; then
-          bun install --linker hoisted ${{ inputs.install-flags }}
-        else
-          bun install ${{ inputs.install-flags }}
+          flags="--linker hoisted $flags"
         fi
+        # Retry: installs run native install scripts (node-gyp fetches headers over
+        # the network) and transient ETIMEDOUT/registry errors otherwise fail the job.
+        for attempt in 1 2 3; do
+          bun install $flags && exit 0
+          if [ "$attempt" -lt 3 ]; then
+            echo "::warning::bun install failed (attempt ${attempt}/3), retrying..."
+            sleep $((attempt * 15))
+          fi
+        done
+        echo "::error::bun install failed after 3 attempts"
+        exit 1
       shell: bash
 
     - name: Save Bun dependencies

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -60,7 +60,8 @@ runs:
         # https://github.com/oven-sh/bun/issues/28147
         flags="${{ inputs.install-flags }}"
         if [ "$RUNNER_OS" = "Windows" ]; then
-          flags="--linker hoisted $flags"
+          # Appended after caller flags so the enforced linker wins (bun uses the last --linker value)
+          flags="$flags --linker hoisted"
         fi
         # Retry: installs run native install scripts (node-gyp fetches headers over
         # the network) and transient ETIMEDOUT/registry errors otherwise fail the job.


### PR DESCRIPTION
### Issue for this PR

Closes #50

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Every workflow installs dependencies through the shared `setup-bun` composite action, and a single transient network error there fails the whole job (most recently an `ETIMEDOUT` during the `tree-sitter-powershell` node-gyp rebuild on PR #39, which required a manual rerun). This wraps the install in a bounded retry with backoff:

```bash
for attempt in 1 2 3; do
  bun install $flags && exit 0
  if [ "$attempt" -lt 3 ]; then
    echo "::warning::bun install failed (attempt ${attempt}/3), retrying..."
    sleep $((attempt * 15))
  fi
done
echo "::error::bun install failed after 3 attempts"
exit 1
```

Real dependency problems (lockfile mismatch, broken install scripts) still fail, just after three attempts, with an explicit final error line. The Windows `--linker hoisted` workaround is folded into a `$flags` variable so the retry loop has a single install invocation.

### How did you verify your code works?

Validated the embedded script with `bash -n` (syntax) and traced the retry/exit semantics under GitHub's `bash -e` step shell (`cmd && exit 0` is exempt from errexit as the left side of a list, so the loop and final `exit 1` behave as intended). CI on this PR exercises the action itself.

### Screenshots / recordings

_CI-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation reliability across supported platforms.
  * Added Windows-specific installation compatibility improvements.
  * Added automatic retries with increasing delays when installation fails.
  * Added clearer warning and error messages to make installation problems easier to identify and troubleshoot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->