### PR TITLE
docs: restore quick-install command with corrected URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Bolt reads your codebase, understands what you're building, and ships code with 
 ## Get started in 30 seconds
 
 ```bash
+# Quick install (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install | bash
 
 # Or with npm / bun / pnpm / yarn
 npm i -g @bolt-builder/bolt-cli


### PR DESCRIPTION
### Issue for this PR

Closes #52

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Restores the curl quick-install line removed in 3f085b6. It failed for two reasons: the raw URL was missing the branch segment (404), and the install script downloads from `releases/latest`, which had no published release until v2.0.0 went live. Both are fixed, so the README gets the corrected command back:

```bash
curl -fsSL https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install | bash
```

### How did you verify your code works?

Ran the exact command on a clean Linux machine: it downloaded the v2.0.0 release asset and `bolt --version` printed `2.0.0`.

### Screenshots / recordings

_Docs-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a curl-based quick-install command for macOS and Linux to the getting-started instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->