### PR TITLE
feat(tui): roaring red fire border around the chatbox while working

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -974,6 +974,7 @@
         "@opentui/core": "catalog:",
         "@opentui/keymap": "catalog:",
         "@opentui/solid": "catalog:",
+        "@seomis/doom-fire": "0.1.0",
         "clipboardy": "4.0.0",
         "diff": "catalog:",
         "effect": "catalog:",
@@ -2536,6 +2537,8 @@
     "@sentry/solid": ["@sentry/solid@10.36.0", "", { "dependencies": { "@sentry/browser": "10.36.0", "@sentry/core": "10.36.0" }, "peerDependencies": { "@solidjs/router": "^0.13.4 || ^0.14.0 || ^0.15.0", "@tanstack/solid-router": "^1.132.27", "solid-js": "^1.8.4" }, "optionalPeers": ["@solidjs/router", "@tanstack/solid-router"] }, "sha512-AaDqz3JGBrQCm2YVqODVyJHwg7LRTNSJig9mjfProFyvkC7eUXQ/HBJrrhAD1Dct9ufmDH3G+f3/Ut9LgpItSg=="],
 
     "@sentry/vite-plugin": ["@sentry/vite-plugin@4.6.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "4.6.0", "unplugin": "1.0.1" } }, "sha512-fMR2d+EHwbzBa0S1fp45SNUTProxmyFBp+DeBWWQOSP9IU6AH6ea2rqrpMAnp/skkcdW4z4LSRrOEpMZ5rWXLw=="],
+
+    "@seomis/doom-fire": ["@seomis/doom-fire@0.1.0", "", {}, "sha512-fal/Eumrc/TBQGb1x1/sZCB2uzZU16vRBTkDOiohwwQSLOait002Ohq3Sc8tTaDoUyR3Bqp6d+EgNoKhSiExew=="],
 
     "@shikijs/core": ["@shikijs/core@3.9.2", "", { "dependencies": { "@shikijs/types": "3.9.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-3q/mzmw09B2B6PgFNeiaN8pkNOixWS726IHmJEpjDAcneDPMQmUg2cweT9cWXY4XcyQS3i6mOOUgQz9RRUP6HA=="],
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -56,6 +56,7 @@
     "@opentui/core": "catalog:",
     "@opentui/keymap": "catalog:",
     "@opentui/solid": "catalog:",
+    "@seomis/doom-fire": "0.1.0",
     "clipboardy": "4.0.0",
     "diff": "catalog:",
     "effect": "catalog:",
@@ -63,8 +64,8 @@
     "open": "10.1.2",
     "opentui-spinner": "catalog:",
     "remeda": "catalog:",
-    "strip-ansi": "7.1.2",
-    "solid-js": "catalog:"
+    "solid-js": "catalog:",
+    "strip-ansi": "7.1.2"
   },
   "devDependencies": {
     "@tsconfig/bun": "catalog:",

--- a/packages/tui/src/component/fire-frame.tsx
+++ b/packages/tui/src/component/fire-frame.tsx
@@ -1,0 +1,39 @@
+import { createEffect, createMemo, createSignal, onCleanup, Index } from "solid-js"
+import { advance, cells, seed, side, type Cell } from "../ui/fire"
+
+const INTERVAL = 90
+
+// Drives the fire border around the chatbox: two independent heat rows
+// (top and bottom) plus a flickering side color derived from the top row.
+export function createFire(width: () => number, active: () => boolean) {
+  const blank = () => ({ top: seed(width()), bottom: seed(width()) })
+  const [state, setState] = createSignal(blank())
+  createEffect(() => {
+    if (!active()) return
+    setState(blank())
+    const timer = setInterval(
+      () =>
+        setState((prev) => {
+          const fresh = prev.top.length === width() ? prev : blank()
+          return { top: advance(fresh.top), bottom: advance(fresh.bottom) }
+        }),
+      INTERVAL,
+    )
+    onCleanup(() => clearInterval(timer))
+  })
+  return {
+    top: createMemo(() => cells(state().top)),
+    bottom: createMemo(() => cells(state().bottom)),
+    side: createMemo(() => side(state().top)),
+  }
+}
+
+export function FireRow(props: { cells: Cell[] }) {
+  return (
+    <box height={1} width="100%" overflow="hidden">
+      <text>
+        <Index each={props.cells}>{(item) => <span style={{ fg: item().color }}>{item().char}</span>}</Index>
+      </text>
+    </box>
+  )
+}

--- a/packages/tui/src/component/fire-frame.tsx
+++ b/packages/tui/src/component/fire-frame.tsx
@@ -3,8 +3,9 @@ import { advance, cells, seed, side, type Cell } from "../ui/fire"
 
 const INTERVAL = 90
 
-// Drives the fire border around the chatbox: two independent heat rows
-// (top and bottom) plus a flickering side color derived from the top row.
+// Drives the fire border around the chatbox: two independent DOOM-fire grids.
+// The top strip is rendered tips-first so flames lick upward; the bottom strip
+// is rendered reversed so flames lick downward. The fire always faces outward.
 export function createFire(width: () => number, active: () => boolean) {
   const blank = () => ({ top: seed(width()), bottom: seed(width()) })
   const [state, setState] = createSignal(blank())
@@ -14,7 +15,7 @@ export function createFire(width: () => number, active: () => boolean) {
     const timer = setInterval(
       () =>
         setState((prev) => {
-          const fresh = prev.top.length === width() ? prev : blank()
+          const fresh = (prev.top[0]?.length ?? 0) === width() ? prev : blank()
           return { top: advance(fresh.top), bottom: advance(fresh.bottom) }
         }),
       INTERVAL,
@@ -23,17 +24,23 @@ export function createFire(width: () => number, active: () => boolean) {
   })
   return {
     top: createMemo(() => cells(state().top)),
-    bottom: createMemo(() => cells(state().bottom)),
+    bottom: createMemo(() => cells(state().bottom).toReversed()),
     side: createMemo(() => side(state().top)),
   }
 }
 
-export function FireRow(props: { cells: Cell[] }) {
+export function FireStrip(props: { rows: Cell[][] }) {
   return (
-    <box height={1} width="100%" overflow="hidden">
-      <text>
-        <Index each={props.cells}>{(item) => <span style={{ fg: item().color }}>{item().char}</span>}</Index>
-      </text>
+    <box width="100%" overflow="hidden">
+      <Index each={props.rows}>
+        {(row) => (
+          <box height={1} width="100%" overflow="hidden">
+            <text>
+              <Index each={row()}>{(item) => <span style={{ fg: item().color }}>{item().char}</span>}</Index>
+            </text>
+          </box>
+        )}
+      </Index>
     </box>
   )
 }

--- a/packages/tui/src/component/fire-frame.tsx
+++ b/packages/tui/src/component/fire-frame.tsx
@@ -1,14 +1,20 @@
-import { createEffect, createSignal, onCleanup, Index } from "solid-js"
-import { cells, ignite, type Cell } from "../ui/fire"
+import { createEffect, createMemo, createSignal, onCleanup, Index } from "solid-js"
+import { cells, ignite, palette, PALETTE, type Cell } from "../ui/fire"
 
 const INTERVAL = 90
 
 // Drives the fire bar above the chatbox: a DOOM-fire heat grid rendered
 // tips-first so the flames lick upward, with the hot source row hugging the
 // box. The wasm engine loads asynchronously; until it is ready (or while
-// inactive) the grid is empty and nothing renders.
-export function createFire(width: () => number, active: () => boolean) {
+// inactive) the grid is empty and nothing renders. When a base color is
+// provided the palette is derived from it so the flames match the theme,
+// tracking theme changes live.
+export function createFire(width: () => number, active: () => boolean, color?: () => string | undefined) {
   const [grid, setGrid] = createSignal<Cell[][]>([])
+  const colors = createMemo(() => {
+    const base = color?.()
+    return base ? palette(base) : PALETTE
+  })
   createEffect(() => {
     if (!active()) {
       setGrid([])
@@ -21,7 +27,7 @@ export function createFire(width: () => number, active: () => boolean) {
       if (dead) return
       timer = setInterval(() => {
         engine.advance()
-        setGrid(cells(engine.grid(), cols))
+        setGrid(cells(engine.grid(), cols, colors()))
       }, INTERVAL)
     })
     onCleanup(() => {

--- a/packages/tui/src/component/fire-frame.tsx
+++ b/packages/tui/src/component/fire-frame.tsx
@@ -1,32 +1,35 @@
-import { createEffect, createMemo, createSignal, onCleanup, Index } from "solid-js"
-import { advance, cells, seed, side, type Cell } from "../ui/fire"
+import { createEffect, createSignal, onCleanup, Index } from "solid-js"
+import { cells, ignite, type Cell } from "../ui/fire"
 
 const INTERVAL = 90
 
-// Drives the fire border around the chatbox: two independent DOOM-fire grids.
-// The top strip is rendered tips-first so flames lick upward; the bottom strip
-// is rendered reversed so flames lick downward. The fire always faces outward.
+// Drives the fire bar above the chatbox: a DOOM-fire heat grid rendered
+// tips-first so the flames lick upward, with the hot source row hugging the
+// box. The wasm engine loads asynchronously; until it is ready (or while
+// inactive) the grid is empty and nothing renders.
 export function createFire(width: () => number, active: () => boolean) {
-  const blank = () => ({ top: seed(width()), bottom: seed(width()) })
-  const [state, setState] = createSignal(blank())
+  const [grid, setGrid] = createSignal<Cell[][]>([])
   createEffect(() => {
-    if (!active()) return
-    setState(blank())
-    const timer = setInterval(
-      () =>
-        setState((prev) => {
-          const fresh = (prev.top[0]?.length ?? 0) === width() ? prev : blank()
-          return { top: advance(fresh.top), bottom: advance(fresh.bottom) }
-        }),
-      INTERVAL,
-    )
-    onCleanup(() => clearInterval(timer))
+    if (!active()) {
+      setGrid([])
+      return
+    }
+    const cols = width()
+    let dead = false
+    let timer: ReturnType<typeof setInterval> | undefined
+    ignite(cols).then((engine) => {
+      if (dead) return
+      timer = setInterval(() => {
+        engine.advance()
+        setGrid(cells(engine.grid(), cols))
+      }, INTERVAL)
+    })
+    onCleanup(() => {
+      dead = true
+      if (timer) clearInterval(timer)
+    })
   })
-  return {
-    top: createMemo(() => cells(state().top)),
-    bottom: createMemo(() => cells(state().bottom).toReversed()),
-    side: createMemo(() => side(state().top)),
-  }
+  return grid
 }
 
 export function FireStrip(props: { rows: Cell[][] }) {

--- a/packages/tui/src/component/fire-frame.tsx
+++ b/packages/tui/src/component/fire-frame.tsx
@@ -23,13 +23,25 @@ export function createFire(width: () => number, active: () => boolean, color?: (
     const cols = width()
     let dead = false
     let timer: ReturnType<typeof setInterval> | undefined
-    ignite(cols).then((engine) => {
-      if (dead) return
-      timer = setInterval(() => {
-        engine.advance()
-        setGrid(cells(engine.grid(), cols, colors()))
-      }, INTERVAL)
-    })
+    ignite(cols)
+      .then((engine) => {
+        if (dead) return
+        timer = setInterval(() => {
+          try {
+            engine.advance()
+            setGrid(cells(engine.grid(), cols, colors()))
+          } catch (err) {
+            // Decorative only: if the engine breaks, stop the burn quietly.
+            console.error("doom-fire tick failed", { err })
+            clearInterval(timer)
+            setGrid([])
+          }
+        }, INTERVAL)
+      })
+      .catch((err) => {
+        console.error("doom-fire failed to ignite", { err })
+        setGrid([])
+      })
     onCleanup(() => {
       dead = true
       if (timer) clearInterval(timer)

--- a/packages/tui/src/component/fire-frame.tsx
+++ b/packages/tui/src/component/fire-frame.tsx
@@ -39,7 +39,7 @@ export function FireStrip(props: { rows: Cell[][] }) {
         {(row) => (
           <box height={1} width="100%" overflow="hidden">
             <text>
-              <Index each={row()}>{(item) => <span style={{ fg: item().color }}>{item().char}</span>}</Index>
+              <Index each={row()}>{(item) => <span style={{ fg: item().fg, bg: item().bg }}>{item().char}</span>}</Index>
             </text>
           </box>
         )}

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -5,6 +5,7 @@ import {
   MouseEvent,
   PasteEvent,
   decodePasteBytes,
+  rgbToHex,
   type KeyEvent,
   type Renderable,
 } from "@opentui/core"
@@ -1386,7 +1387,11 @@ export function Prompt(props: PromptProps) {
   )
   const borderHighlight = createMemo(() => tint(theme.border, highlight(), agentMetaAlpha()))
   const fire = createMemo(() => animationsEnabled() && status().type !== "idle")
-  const flames = createFire(() => dimensions().width, fire)
+  const flames = createFire(
+    () => dimensions().width,
+    fire,
+    () => rgbToHex(theme.primary),
+  )
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -20,7 +20,7 @@ import { EmptyBorder, SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { useClipboard } from "../../context/clipboard"
 import { Spinner } from "../spinner"
-import { createFire, FireRow } from "../fire-frame"
+import { createFire, FireStrip } from "../fire-frame"
 import { useSDK } from "../../context/sdk"
 import { useRoute } from "../../context/route"
 import { useProject } from "../../context/project"
@@ -1429,7 +1429,7 @@ export function Prompt(props: PromptProps) {
     <>
       <box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
         <Show when={fire()}>
-          <FireRow cells={flames.top()} />
+          <FireStrip rows={flames.top()} />
         </Show>
         <box
           width="100%"
@@ -1582,7 +1582,7 @@ export function Prompt(props: PromptProps) {
           </box>
         </box>
         <Show when={fire()}>
-          <FireRow cells={flames.bottom()} />
+          <FireStrip rows={flames.bottom()} />
         </Show>
         <Show when={!fire()}>
           <box

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1429,12 +1429,12 @@ export function Prompt(props: PromptProps) {
     <>
       <box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
         <Show when={fire()}>
-          <FireStrip rows={flames.top()} />
+          <FireStrip rows={flames()} />
         </Show>
         <box
           width="100%"
-          border={fire() ? ["left", "right"] : ["left"]}
-          borderColor={fire() ? flames.side() : borderHighlight()}
+          border={["left"]}
+          borderColor={borderHighlight()}
           customBorderChars={{
             ...SplitBorder.customBorderChars,
             bottomLeft: "╹",
@@ -1581,37 +1581,32 @@ export function Prompt(props: PromptProps) {
             </box>
           </box>
         </box>
-        <Show when={fire()}>
-          <FireStrip rows={flames.bottom()} />
-        </Show>
-        <Show when={!fire()}>
+        <box
+          height={1}
+          border={["left"]}
+          borderColor={borderHighlight()}
+          customBorderChars={{
+            ...EmptyBorder,
+            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
+          }}
+        >
           <box
             height={1}
-            border={["left"]}
-            borderColor={borderHighlight()}
-            customBorderChars={{
-              ...EmptyBorder,
-              vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
-            }}
-          >
-            <box
-              height={1}
-              border={["bottom"]}
-              borderColor={theme.backgroundElement}
-              customBorderChars={
-                theme.backgroundElement.a !== 0
-                  ? {
-                      ...EmptyBorder,
-                      horizontal: "▀",
-                    }
-                  : {
-                      ...EmptyBorder,
-                      horizontal: " ",
-                    }
-              }
-            />
-          </box>
-        </Show>
+            border={["bottom"]}
+            borderColor={theme.backgroundElement}
+            customBorderChars={
+              theme.backgroundElement.a !== 0
+                ? {
+                    ...EmptyBorder,
+                    horizontal: "▀",
+                  }
+                : {
+                    ...EmptyBorder,
+                    horizontal: " ",
+                  }
+            }
+          />
+        </box>
         <box width="100%" flexDirection="row" justifyContent="space-between">
           <Switch>
             <Match when={status().type !== "idle"}>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -20,6 +20,7 @@ import { EmptyBorder, SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { useClipboard } from "../../context/clipboard"
 import { Spinner } from "../spinner"
+import { createFire, FireRow } from "../fire-frame"
 import { useSDK } from "../../context/sdk"
 import { useRoute } from "../../context/route"
 import { useProject } from "../../context/project"
@@ -1384,6 +1385,8 @@ export function Prompt(props: PromptProps) {
     animationsEnabled,
   )
   const borderHighlight = createMemo(() => tint(theme.border, highlight(), agentMetaAlpha()))
+  const fire = createMemo(() => animationsEnabled() && status().type !== "idle")
+  const flames = createFire(() => dimensions().width, fire)
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined
@@ -1425,10 +1428,13 @@ export function Prompt(props: PromptProps) {
   return (
     <>
       <box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
+        <Show when={fire()}>
+          <FireRow cells={flames.top()} />
+        </Show>
         <box
           width="100%"
-          border={["left"]}
-          borderColor={borderHighlight()}
+          border={fire() ? ["left", "right"] : ["left"]}
+          borderColor={fire() ? flames.side() : borderHighlight()}
           customBorderChars={{
             ...SplitBorder.customBorderChars,
             bottomLeft: "╹",
@@ -1575,32 +1581,37 @@ export function Prompt(props: PromptProps) {
             </box>
           </box>
         </box>
-        <box
-          height={1}
-          border={["left"]}
-          borderColor={borderHighlight()}
-          customBorderChars={{
-            ...EmptyBorder,
-            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
-          }}
-        >
+        <Show when={fire()}>
+          <FireRow cells={flames.bottom()} />
+        </Show>
+        <Show when={!fire()}>
           <box
             height={1}
-            border={["bottom"]}
-            borderColor={theme.backgroundElement}
-            customBorderChars={
-              theme.backgroundElement.a !== 0
-                ? {
-                    ...EmptyBorder,
-                    horizontal: "▀",
-                  }
-                : {
-                    ...EmptyBorder,
-                    horizontal: " ",
-                  }
-            }
-          />
-        </box>
+            border={["left"]}
+            borderColor={borderHighlight()}
+            customBorderChars={{
+              ...EmptyBorder,
+              vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
+            }}
+          >
+            <box
+              height={1}
+              border={["bottom"]}
+              borderColor={theme.backgroundElement}
+              customBorderChars={
+                theme.backgroundElement.a !== 0
+                  ? {
+                      ...EmptyBorder,
+                      horizontal: "▀",
+                    }
+                  : {
+                      ...EmptyBorder,
+                      horizontal: " ",
+                    }
+              }
+            />
+          </box>
+        </Show>
         <box width="100%" flexDirection="row" justifyContent="space-between">
           <Switch>
             <Match when={status().type !== "idle"}>

--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -1,0 +1,43 @@
+// Heat simulation for the animated fire border around the chatbox.
+// Pure logic only; rendering lives in component/fire-frame.tsx.
+
+export const GLYPHS = [" ", "·", "▁", "▂", "▃", "▄", "▅", "▆"]
+
+// Red-dominant palette, dark ember to bright flame tip.
+export const PALETTE = ["#3a0a00", "#6e1400", "#a51e00", "#d92600", "#ff3d00", "#ff6a00", "#ff9433", "#ffc266"]
+
+export interface Cell {
+  char: string
+  color: string
+}
+
+export function seed(width: number): number[] {
+  return Array.from({ length: Math.max(0, width) }, () => 0)
+}
+
+export function advance(heat: number[], rng: () => number = Math.random): number[] {
+  return heat.map((value, index) => {
+    const left = heat[index - 1] ?? value
+    const right = heat[index + 1] ?? value
+    const mixed = (left + right + value * 2) / 4
+    const cooled = mixed * (0.72 + rng() * 0.2)
+    const sparked = rng() < 0.22 ? Math.min(1, cooled + 0.35 + rng() * 0.65) : cooled
+    return Math.min(1, Math.max(0, sparked))
+  })
+}
+
+export function cell(heat: number): Cell {
+  const index = Math.min(GLYPHS.length - 1, Math.floor(heat * GLYPHS.length))
+  return { char: GLYPHS[index], color: PALETTE[Math.min(index, PALETTE.length - 1)] }
+}
+
+export function cells(heat: number[]): Cell[] {
+  return heat.map(cell)
+}
+
+export function side(heat: number[]): string {
+  if (heat.length === 0) return PALETTE[4]
+  const mean = heat.reduce((sum, value) => sum + value, 0) / heat.length
+  const index = Math.min(PALETTE.length - 1, 3 + Math.floor(mean * 4))
+  return PALETTE[index]
+}

--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -1,10 +1,16 @@
-// DOOM-style fire simulation for the animated fire border around the chatbox.
-// Pure logic only; rendering lives in component/fire-frame.tsx.
+// Fire bar above the chatbox while the agent works. The heat field comes from
+// @seomis/doom-fire, a Rust/wasm port of the PSX DOOM fire algorithm
+// (http://fabiensanglard.net/doom_fire_psx/); this module only loads the wasm
+// and maps heat values to glyphs and colors.
 //
-// The grid is oriented source-last: grid[rows - 1] is the constantly hot source
-// row (the edge touching the chatbox) and grid[0] holds the ragged flame tips.
-// Callers render the grid as-is for flames pointing up (top strip) and reversed
-// for flames pointing down (bottom strip), so the fire always faces outward.
+// Package quirks handled here:
+// - the wasm-bindgen glue imports "./doom_fire_bg" without an extension, which
+//   Bun cannot resolve, so we instantiate the .wasm directly
+// - fire_get_width/fire_get_height are swapped upstream, so we track our own
+//   dimensions instead of asking the wasm
+// - fire_update_cells occasionally traps on an out-of-bounds drift, so advance
+//   respawns the instance when that happens
+import wasm from "@seomis/doom-fire/doom_fire_bg.wasm" with { type: "file" }
 
 export const GLYPHS = [" ", "·", "░", "▒", "▓", "█"]
 
@@ -13,56 +19,90 @@ export const PALETTE = ["#1a0500", "#4a0e00", "#7f1500", "#b71c00", "#e53500", "
 
 export const ROWS = 3
 
+// Heat values run 0..MAX, matching the 36-color palette of the original.
+export const MAX = 35
+
 export interface Cell {
   char: string
   color: string
 }
 
-export function seed(width: number, rows: number = ROWS): number[][] {
-  const cols = Math.max(0, width)
-  return Array.from({ length: Math.max(1, rows) }, (_, y) =>
-    Array.from({ length: cols }, () => (y === Math.max(1, rows) - 1 ? 1 : 0)),
-  )
+interface Api {
+  memory: WebAssembly.Memory
+  fire_new(width: number, rows: number, heat: number): number
+  fire_update_cells(ptr: number): void
+  fire_get_cells(ptr: number): number
 }
 
-export function advance(grid: number[][], rng: () => number = Math.random): number[][] {
-  const rows = grid.length
-  const width = grid[0]?.length ?? 0
-  return grid.map((row, y) => {
-    // Source row: stays near max heat with a subtle flicker.
-    if (y === rows - 1) return row.map(() => 0.85 + rng() * 0.15)
-    // Every other row pulls heat from below with lateral drift and decay,
-    // which is what produces the ragged, licking flame tips.
-    return row.map((_, x) => {
-      const drift = Math.floor(rng() * 3) - 1
-      const source = grid[y + 1][Math.min(width - 1, Math.max(0, x + drift))] ?? 0
-      const decay = rng() * 0.55
-      return Math.max(0, source - decay)
+export interface Engine {
+  advance(): void
+  grid(): Uint8Array
+}
+
+let compiled: WebAssembly.Module | undefined
+
+async function module() {
+  if (compiled) return compiled
+  compiled = new WebAssembly.Module(await Bun.file(wasm).bytes())
+  return compiled
+}
+
+// The grid is row-major with stride `width`: row 0 holds the ragged flame tips
+// and row `rows - 1` is the constantly hot source hugging the chatbox.
+export async function ignite(width: number, rows: number = ROWS): Promise<Engine> {
+  const mod = await module()
+  // Upstream seeds no fire on grids narrower than 35 columns, so simulate at
+  // least that wide and slice each row down to the requested width.
+  const sim = Math.max(width, MAX)
+  const spawn = () => {
+    const instance = new WebAssembly.Instance(mod, {
+      "./doom_fire": {
+        __wbg_floor_12e75d22951301da: Math.floor,
+        __wbg_random_ae55f5b83bdab2a0: Math.random,
+        __wbindgen_throw: () => {
+          throw new Error("doom-fire panic")
+        },
+      },
     })
-  })
+    const api = instance.exports as unknown as Api
+    return { api, ptr: api.fire_new(sim, rows, MAX) }
+  }
+  let state = spawn()
+  return {
+    advance() {
+      try {
+        state.api.fire_update_cells(state.ptr)
+      } catch (err) {
+        // Known upstream panic; a fresh instance reseeds and keeps burning.
+        state = spawn()
+      }
+    },
+    // Reconstructed per read: the buffer detaches when wasm memory grows.
+    grid() {
+      const raw = new Uint8Array(state.api.memory.buffer, state.api.fire_get_cells(state.ptr), sim * rows)
+      if (sim === width) return raw
+      const out = new Uint8Array(width * rows)
+      for (let y = 0; y < rows; y++) out.set(raw.subarray(y * sim, y * sim + width), y * width)
+      return out
+    },
+  }
 }
 
 export function cell(heat: number): Cell {
+  const ratio = Math.min(1, Math.max(0, heat / MAX))
   const index = (() => {
-    if (heat < 0.05) return 0
-    if (heat < 0.15) return 1
-    if (heat < 0.35) return 2
-    if (heat < 0.6) return 3
-    if (heat < 0.85) return 4
+    if (ratio < 0.05) return 0
+    if (ratio < 0.15) return 1
+    if (ratio < 0.35) return 2
+    if (ratio < 0.6) return 3
+    if (ratio < 0.85) return 4
     return 5
   })()
-  const color = PALETTE[Math.min(PALETTE.length - 1, Math.floor(heat * PALETTE.length))]
+  const color = PALETTE[Math.min(PALETTE.length - 1, Math.floor(ratio * PALETTE.length))]
   return { char: GLYPHS[index], color }
 }
 
-export function cells(grid: number[][]): Cell[][] {
-  return grid.map((row) => row.map(cell))
-}
-
-export function side(grid: number[][]): string {
-  const source = grid[grid.length - 1] ?? []
-  if (source.length === 0) return PALETTE[5]
-  const mean = source.reduce((sum, value) => sum + value, 0) / source.length
-  const index = Math.min(PALETTE.length - 1, 4 + Math.floor(mean * 3))
-  return PALETTE[index]
+export function cells(grid: Uint8Array, width: number): Cell[][] {
+  const rows = width > 0 ? Math.floor(grid.length / width) : 0
+  return Array.from({ length: rows }, (_, y) => Array.from(grid.subarray(y * width, (y + 1) * width), cell))
 }

--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -54,7 +54,7 @@ export const PALETTE = [
 ]
 
 // Display rows; rendered as ROWS / 2 text rows of half-block pixels.
-export const ROWS = 6
+export const ROWS = 8
 
 // The wasm needs vertical room to develop the classic gradient: flames only
 // climb a couple of rows above the source before dying, so a 6-row grid never

--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -66,6 +66,30 @@ const DEPTH = 4
 // Heat values run 0..MAX, matching the 36-color palette of the original.
 export const MAX = 35
 
+// Builds a 36-color fire ramp from a single base color so the flames match
+// the active theme: embers stay near black, the body burns in shades of the
+// base color, and the hottest cells blow out toward white. The eased splits
+// mirror the shape of the classic DOOM ramp (long dark tail, short white
+// core), which keeps dark bases like deep blue or green reading as fire.
+export function palette(base: string): string[] {
+  const n = parseInt(base.slice(1, 7), 16)
+  const rgb = [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+  const mix = (from: number[], to: number[], t: number) =>
+    "#" +
+    from
+      .map((v, i) =>
+        Math.round(v + (to[i] - v) * t)
+          .toString(16)
+          .padStart(2, "0"),
+      )
+      .join("")
+  return Array.from({ length: MAX + 1 }, (_, i) => {
+    const t = i / MAX
+    if (t < 0.55) return mix([7, 7, 7], rgb, Math.pow(t / 0.55, 1.3))
+    return mix(rgb, [255, 255, 255], Math.pow((t - 0.55) / 0.45, 1.6))
+  })
+}
+
 export interface Cell {
   char: string
   fg?: string
@@ -143,17 +167,17 @@ export async function ignite(width: number, rows: number = ROWS): Promise<Engine
 // text row carries two pixel rows and the fire renders as pixels instead of
 // glyph soup. Zero heat stays transparent so the flame tips fade into the
 // terminal background.
-export function cell(top: number, bottom: number): Cell {
-  const paint = (heat: number) => PALETTE[Math.min(PALETTE.length - 1, Math.max(0, heat))]
+export function cell(top: number, bottom: number, colors: string[] = PALETTE): Cell {
+  const paint = (heat: number) => colors[Math.min(colors.length - 1, Math.max(0, heat))]
   if (top === 0 && bottom === 0) return { char: " " }
   if (bottom === 0) return { char: "▀", fg: paint(top) }
   if (top === 0) return { char: "▄", fg: paint(bottom) }
   return { char: "▀", fg: paint(top), bg: paint(bottom) }
 }
 
-export function cells(grid: Uint8Array, width: number): Cell[][] {
+export function cells(grid: Uint8Array, width: number, colors: string[] = PALETTE): Cell[][] {
   const rows = width > 0 ? Math.floor(grid.length / width / 2) : 0
   return Array.from({ length: rows }, (_, y) =>
-    Array.from({ length: width }, (_, x) => cell(grid[y * 2 * width + x], grid[(y * 2 + 1) * width + x])),
+    Array.from({ length: width }, (_, x) => cell(grid[y * 2 * width + x], grid[(y * 2 + 1) * width + x], colors)),
   )
 }

--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -53,8 +53,15 @@ export const PALETTE = [
   "#ffffff",
 ]
 
-// Simulation rows; rendered as ROWS / 2 text rows of half-block pixels.
+// Display rows; rendered as ROWS / 2 text rows of half-block pixels.
 export const ROWS = 6
+
+// The wasm needs vertical room to develop the classic gradient: flames only
+// climb a couple of rows above the source before dying, so a 6-row grid never
+// gets past flat orange. Simulate DEPTH times as many rows and vertically
+// sample the live flame band down to the display rows, keeping the full
+// white-hot-to-ember arc and the ragged flickering tips.
+const DEPTH = 4
 
 // Heat values run 0..MAX, matching the 36-color palette of the original.
 export const MAX = 35
@@ -92,6 +99,7 @@ export async function ignite(width: number, rows: number = ROWS): Promise<Engine
   // Upstream seeds no fire on grids narrower than 35 columns, so simulate at
   // least that wide and slice each row down to the requested width.
   const sim = Math.max(width, MAX)
+  const depth = rows * DEPTH
   const spawn = () => {
     const instance = new WebAssembly.Instance(mod, {
       "./doom_fire": {
@@ -103,9 +111,12 @@ export async function ignite(width: number, rows: number = ROWS): Promise<Engine
       },
     })
     const api = instance.exports as unknown as Api
-    return { api, ptr: api.fire_new(sim, rows, MAX) }
+    return { api, ptr: api.fire_new(sim, depth, MAX) }
   }
   let state = spawn()
+  // The flame body lives in the lower half of the tall grid; sample display
+  // rows from just above it (occasional ragged tips) down to the source.
+  const start = Math.floor(depth * 0.45)
   return {
     advance() {
       try {
@@ -117,10 +128,12 @@ export async function ignite(width: number, rows: number = ROWS): Promise<Engine
     },
     // Reconstructed per read: the buffer detaches when wasm memory grows.
     grid() {
-      const raw = new Uint8Array(state.api.memory.buffer, state.api.fire_get_cells(state.ptr), sim * rows)
-      if (sim === width) return raw
+      const raw = new Uint8Array(state.api.memory.buffer, state.api.fire_get_cells(state.ptr), sim * depth)
       const out = new Uint8Array(width * rows)
-      for (let y = 0; y < rows; y++) out.set(raw.subarray(y * sim, y * sim + width), y * width)
+      for (let y = 0; y < rows; y++) {
+        const src = Math.round(start + (y * (depth - 1 - start)) / (rows - 1))
+        out.set(raw.subarray(src * sim, src * sim + width), y * width)
+      }
       return out
     },
   }

--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -66,6 +66,11 @@ const DEPTH = 4
 // Heat values run 0..MAX, matching the 36-color palette of the original.
 export const MAX = 35
 
+// Upstream seeds no fire on grids narrower than 35 columns, so simulation
+// width never drops below this. Coincidentally equal to MAX, but a separate
+// concept: this is a column threshold, not the heat ceiling.
+const MIN_WIDTH = 35
+
 // Builds a 36-color fire ramp from a single base color so the flames match
 // the active theme: embers stay near black, the body burns in shades of the
 // base color, and the hottest cells blow out toward white. The eased splits
@@ -108,11 +113,14 @@ export interface Engine {
   grid(): Uint8Array
 }
 
-let compiled: WebAssembly.Module | undefined
+let compiled: Promise<WebAssembly.Module> | undefined
 
-async function module() {
-  if (compiled) return compiled
-  compiled = new WebAssembly.Module(await Bun.file(wasm).bytes())
+// Caches the in-flight compilation so concurrent ignite() calls share one
+// compile instead of racing to compile the module twice.
+function module() {
+  compiled ??= Bun.file(wasm)
+    .bytes()
+    .then((bytes) => new WebAssembly.Module(bytes))
   return compiled
 }
 
@@ -120,9 +128,9 @@ async function module() {
 // and row `rows - 1` is the constantly hot source hugging the chatbox.
 export async function ignite(width: number, rows: number = ROWS): Promise<Engine> {
   const mod = await module()
-  // Upstream seeds no fire on grids narrower than 35 columns, so simulate at
-  // least that wide and slice each row down to the requested width.
-  const sim = Math.max(width, MAX)
+  // Simulate at least MIN_WIDTH columns and slice each row down to the
+  // requested width.
+  const sim = Math.max(width, MIN_WIDTH)
   const depth = rows * DEPTH
   const spawn = () => {
     const instance = new WebAssembly.Instance(mod, {
@@ -145,9 +153,15 @@ export async function ignite(width: number, rows: number = ROWS): Promise<Engine
     advance() {
       try {
         state.api.fire_update_cells(state.ptr)
-      } catch (err) {
+      } catch {
         // Known upstream panic; a fresh instance reseeds and keeps burning.
-        state = spawn()
+        // If the respawn itself traps, keep the prior instance and retry on
+        // the next advance instead of letting the error escape.
+        try {
+          state = spawn()
+        } catch (err) {
+          console.error("doom-fire respawn failed", { err })
+        }
       }
     },
     // Reconstructed per read: the buffer detaches when wasm memory grows.

--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -54,7 +54,7 @@ export const PALETTE = [
 ]
 
 // Display rows; rendered as ROWS / 2 text rows of half-block pixels.
-export const ROWS = 8
+export const ROWS = 32
 
 // The wasm needs vertical room to develop the classic gradient: flames only
 // climb a couple of rows above the source before dying, so a 6-row grid never

--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -1,43 +1,68 @@
-// Heat simulation for the animated fire border around the chatbox.
+// DOOM-style fire simulation for the animated fire border around the chatbox.
 // Pure logic only; rendering lives in component/fire-frame.tsx.
+//
+// The grid is oriented source-last: grid[rows - 1] is the constantly hot source
+// row (the edge touching the chatbox) and grid[0] holds the ragged flame tips.
+// Callers render the grid as-is for flames pointing up (top strip) and reversed
+// for flames pointing down (bottom strip), so the fire always faces outward.
 
-export const GLYPHS = [" ", "·", "▁", "▂", "▃", "▄", "▅", "▆"]
+export const GLYPHS = [" ", "·", "░", "▒", "▓", "█"]
 
 // Red-dominant palette, dark ember to bright flame tip.
-export const PALETTE = ["#3a0a00", "#6e1400", "#a51e00", "#d92600", "#ff3d00", "#ff6a00", "#ff9433", "#ffc266"]
+export const PALETTE = ["#1a0500", "#4a0e00", "#7f1500", "#b71c00", "#e53500", "#ff5a00", "#ff8c00", "#ffb84d"]
+
+export const ROWS = 3
 
 export interface Cell {
   char: string
   color: string
 }
 
-export function seed(width: number): number[] {
-  return Array.from({ length: Math.max(0, width) }, () => 0)
+export function seed(width: number, rows: number = ROWS): number[][] {
+  const cols = Math.max(0, width)
+  return Array.from({ length: Math.max(1, rows) }, (_, y) =>
+    Array.from({ length: cols }, () => (y === Math.max(1, rows) - 1 ? 1 : 0)),
+  )
 }
 
-export function advance(heat: number[], rng: () => number = Math.random): number[] {
-  return heat.map((value, index) => {
-    const left = heat[index - 1] ?? value
-    const right = heat[index + 1] ?? value
-    const mixed = (left + right + value * 2) / 4
-    const cooled = mixed * (0.72 + rng() * 0.2)
-    const sparked = rng() < 0.22 ? Math.min(1, cooled + 0.35 + rng() * 0.65) : cooled
-    return Math.min(1, Math.max(0, sparked))
+export function advance(grid: number[][], rng: () => number = Math.random): number[][] {
+  const rows = grid.length
+  const width = grid[0]?.length ?? 0
+  return grid.map((row, y) => {
+    // Source row: stays near max heat with a subtle flicker.
+    if (y === rows - 1) return row.map(() => 0.85 + rng() * 0.15)
+    // Every other row pulls heat from below with lateral drift and decay,
+    // which is what produces the ragged, licking flame tips.
+    return row.map((_, x) => {
+      const drift = Math.floor(rng() * 3) - 1
+      const source = grid[y + 1][Math.min(width - 1, Math.max(0, x + drift))] ?? 0
+      const decay = rng() * 0.55
+      return Math.max(0, source - decay)
+    })
   })
 }
 
 export function cell(heat: number): Cell {
-  const index = Math.min(GLYPHS.length - 1, Math.floor(heat * GLYPHS.length))
-  return { char: GLYPHS[index], color: PALETTE[Math.min(index, PALETTE.length - 1)] }
+  const index = (() => {
+    if (heat < 0.05) return 0
+    if (heat < 0.15) return 1
+    if (heat < 0.35) return 2
+    if (heat < 0.6) return 3
+    if (heat < 0.85) return 4
+    return 5
+  })()
+  const color = PALETTE[Math.min(PALETTE.length - 1, Math.floor(heat * PALETTE.length))]
+  return { char: GLYPHS[index], color }
 }
 
-export function cells(heat: number[]): Cell[] {
-  return heat.map(cell)
+export function cells(grid: number[][]): Cell[][] {
+  return grid.map((row) => row.map(cell))
 }
 
-export function side(heat: number[]): string {
-  if (heat.length === 0) return PALETTE[4]
-  const mean = heat.reduce((sum, value) => sum + value, 0) / heat.length
-  const index = Math.min(PALETTE.length - 1, 3 + Math.floor(mean * 4))
+export function side(grid: number[][]): string {
+  const source = grid[grid.length - 1] ?? []
+  if (source.length === 0) return PALETTE[5]
+  const mean = source.reduce((sum, value) => sum + value, 0) / source.length
+  const index = Math.min(PALETTE.length - 1, 4 + Math.floor(mean * 3))
   return PALETTE[index]
 }

--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -12,19 +12,57 @@
 //   respawns the instance when that happens
 import wasm from "@seomis/doom-fire/doom_fire_bg.wasm" with { type: "file" }
 
-export const GLYPHS = [" ", "·", "░", "▒", "▓", "█"]
+// The classic 36-color DOOM fire palette, black ember to white-hot core,
+// indexed directly by heat.
+export const PALETTE = [
+  "#070707",
+  "#1f0707",
+  "#2f0f07",
+  "#470f07",
+  "#571707",
+  "#671f07",
+  "#771f07",
+  "#8f2707",
+  "#9f2f07",
+  "#af3f07",
+  "#bf4707",
+  "#c74707",
+  "#df4f07",
+  "#df5707",
+  "#df5707",
+  "#d75f07",
+  "#d75f07",
+  "#d7670f",
+  "#cf6f0f",
+  "#cf770f",
+  "#cf7f0f",
+  "#cf8717",
+  "#c78717",
+  "#c78f17",
+  "#c7971f",
+  "#bf9f1f",
+  "#bf9f1f",
+  "#bfa727",
+  "#bfa727",
+  "#bfaf2f",
+  "#b7af2f",
+  "#b7b72f",
+  "#b7b737",
+  "#cfcf6f",
+  "#dfdf9f",
+  "#ffffff",
+]
 
-// Red-dominant palette, dark ember to bright flame tip.
-export const PALETTE = ["#1a0500", "#4a0e00", "#7f1500", "#b71c00", "#e53500", "#ff5a00", "#ff8c00", "#ffb84d"]
-
-export const ROWS = 3
+// Simulation rows; rendered as ROWS / 2 text rows of half-block pixels.
+export const ROWS = 6
 
 // Heat values run 0..MAX, matching the 36-color palette of the original.
 export const MAX = 35
 
 export interface Cell {
   char: string
-  color: string
+  fg?: string
+  bg?: string
 }
 
 interface Api {
@@ -88,21 +126,21 @@ export async function ignite(width: number, rows: number = ROWS): Promise<Engine
   }
 }
 
-export function cell(heat: number): Cell {
-  const ratio = Math.min(1, Math.max(0, heat / MAX))
-  const index = (() => {
-    if (ratio < 0.05) return 0
-    if (ratio < 0.15) return 1
-    if (ratio < 0.35) return 2
-    if (ratio < 0.6) return 3
-    if (ratio < 0.85) return 4
-    return 5
-  })()
-  const color = PALETTE[Math.min(PALETTE.length - 1, Math.floor(ratio * PALETTE.length))]
-  return { char: GLYPHS[index], color }
+// Pairs vertically adjacent heat cells into one half-block character, so each
+// text row carries two pixel rows and the fire renders as pixels instead of
+// glyph soup. Zero heat stays transparent so the flame tips fade into the
+// terminal background.
+export function cell(top: number, bottom: number): Cell {
+  const paint = (heat: number) => PALETTE[Math.min(PALETTE.length - 1, Math.max(0, heat))]
+  if (top === 0 && bottom === 0) return { char: " " }
+  if (bottom === 0) return { char: "▀", fg: paint(top) }
+  if (top === 0) return { char: "▄", fg: paint(bottom) }
+  return { char: "▀", fg: paint(top), bg: paint(bottom) }
 }
 
 export function cells(grid: Uint8Array, width: number): Cell[][] {
-  const rows = width > 0 ? Math.floor(grid.length / width) : 0
-  return Array.from({ length: rows }, (_, y) => Array.from(grid.subarray(y * width, (y + 1) * width), cell))
+  const rows = width > 0 ? Math.floor(grid.length / width / 2) : 0
+  return Array.from({ length: rows }, (_, y) =>
+    Array.from({ length: width }, (_, x) => cell(grid[y * 2 * width + x], grid[(y * 2 + 1) * width + x])),
+  )
 }

--- a/packages/tui/src/wasm.d.ts
+++ b/packages/tui/src/wasm.d.ts
@@ -1,0 +1,4 @@
+declare module "*.wasm" {
+  const path: string
+  export default path
+}

--- a/packages/tui/test/ui/fire.test.ts
+++ b/packages/tui/test/ui/fire.test.ts
@@ -1,60 +1,59 @@
 import { describe, expect, test } from "bun:test"
-import { advance, cell, cells, seed, side, GLYPHS, PALETTE, ROWS } from "../../src/ui/fire"
-
-function rng(values: number[]) {
-  let index = 0
-  return () => values[index++ % values.length]
-}
+import { cell, cells, ignite, GLYPHS, MAX, PALETTE, ROWS } from "../../src/ui/fire"
 
 describe("fire", () => {
-  test("seed produces a grid with a hot source row and cold tips", () => {
-    const grid = seed(4)
-    expect(grid).toHaveLength(ROWS)
-    for (const row of grid) expect(row).toHaveLength(4)
-    expect(grid[ROWS - 1]).toEqual([1, 1, 1, 1])
-    expect(grid[0]).toEqual([0, 0, 0, 0])
-    expect(seed(0).every((row) => row.length === 0)).toBe(true)
-    expect(seed(-3).every((row) => row.length === 0)).toBe(true)
-  })
-
-  test("advance keeps heat within bounds and the source row hot", () => {
-    const grid = Array.from({ length: 20 }).reduce<number[][]>((acc) => advance(acc), seed(6))
-    for (const row of grid) {
-      for (const value of row) {
-        expect(value).toBeGreaterThanOrEqual(0)
-        expect(value).toBeLessThanOrEqual(1)
-      }
+  test("ignite produces a grid of width * rows heat values in range", async () => {
+    const engine = await ignite(40)
+    const grid = engine.grid()
+    expect(grid.length).toBe(40 * ROWS)
+    for (const heat of grid) {
+      expect(heat).toBeGreaterThanOrEqual(0)
+      expect(heat).toBeLessThanOrEqual(MAX)
     }
-    for (const value of grid[grid.length - 1]) expect(value).toBeGreaterThanOrEqual(0.85)
   })
 
-  test("heat decays away from the source so tips are ragged", () => {
-    // rng cycles: drift pick, decay for every non-source cell; 0.5 keeps it deterministic-ish
-    const grid = advance(advance(seed(4), rng([0.5])), rng([0.5]))
-    const mean = (row: number[]) => row.reduce((sum, value) => sum + value, 0) / row.length
-    expect(mean(grid[0])).toBeLessThan(mean(grid[grid.length - 1]))
+  test("source row stays hot and tips stay cooler", async () => {
+    const engine = await ignite(40)
+    for (let i = 0; i < 30; i++) engine.advance()
+    const grid = engine.grid()
+    const source = grid.subarray(40 * (ROWS - 1))
+    const tips = grid.subarray(0, 40)
+    expect(Math.max(...source)).toBeGreaterThan(MAX / 2)
+    const mean = (row: Uint8Array) => row.reduce((sum, heat) => sum + heat, 0) / row.length
+    expect(mean(source)).toBeGreaterThan(mean(tips))
   })
 
-  test("cell maps heat to glyph and color from the palettes", () => {
-    expect(cell(0)).toEqual({ char: " ", color: PALETTE[0] })
-    expect(cell(1).char).toBe("█")
-    expect(GLYPHS).toContain(cell(0.5).char)
-    expect(PALETTE).toContain(cell(0.5).color)
+  test("advance survives the upstream panic by respawning", async () => {
+    const engine = await ignite(60)
+    // The upstream wasm traps nondeterministically; hundreds of advances make
+    // hitting it near-certain, and advance must recover every time.
+    for (let i = 0; i < 2000; i++) engine.advance()
+    expect(engine.grid().length).toBe(60 * ROWS)
   })
 
-  test("cells maps a whole grid", () => {
-    const grid = cells([
-      [0, 1],
-      [1, 0],
-    ])
-    expect(grid).toHaveLength(2)
-    expect(grid[0][0].char).toBe(" ")
-    expect(grid[0][1].char).toBe("█")
-    expect(grid[1][0].color).toBe(PALETTE[PALETTE.length - 1])
+  test("cell maps zero heat to blank and max heat to the brightest glyph", () => {
+    expect(cell(0).char).toBe(" ")
+    expect(cell(MAX).char).toBe(GLYPHS[GLYPHS.length - 1])
+    expect(cell(MAX).color).toBe(PALETTE[PALETTE.length - 1])
+    for (let heat = 0; heat <= MAX; heat++) {
+      expect(GLYPHS).toContain(cell(heat).char)
+      expect(PALETTE).toContain(cell(heat).color)
+    }
   })
 
-  test("side flickers within the bright end of the palette", () => {
-    expect(PALETTE.indexOf(side(seed(3)))).toBeGreaterThanOrEqual(4)
-    expect(side([[]])).toBe(PALETTE[5])
+  test("narrow grids still burn despite the upstream 35-column seeding quirk", async () => {
+    const engine = await ignite(20)
+    for (let i = 0; i < 30; i++) engine.advance()
+    const grid = engine.grid()
+    expect(grid.length).toBe(20 * ROWS)
+    expect(Math.max(...grid)).toBeGreaterThan(MAX / 2)
+  })
+
+  test("cells splits the flat grid into rows of rendered cells", async () => {
+    const engine = await ignite(20)
+    for (let i = 0; i < 10; i++) engine.advance()
+    const rows = cells(engine.grid(), 20)
+    expect(rows.length).toBe(ROWS)
+    for (const row of rows) expect(row.length).toBe(20)
   })
 })

--- a/packages/tui/test/ui/fire.test.ts
+++ b/packages/tui/test/ui/fire.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { advance, cell, cells, seed, side, GLYPHS, PALETTE } from "../../src/ui/fire"
+
+function rng(values: number[]) {
+  let index = 0
+  return () => values[index++ % values.length]
+}
+
+describe("fire", () => {
+  test("seed produces a cold row of the requested width", () => {
+    expect(seed(5)).toEqual([0, 0, 0, 0, 0])
+    expect(seed(0)).toEqual([])
+    expect(seed(-3)).toEqual([])
+  })
+
+  test("advance keeps heat within bounds", () => {
+    const hot = advance(
+      [1, 1, 1, 1],
+      rng([0, 0.99]), // constant sparks with max boost
+    )
+    const cold = advance([0, 0, 0, 0], rng([0.99]))
+    for (const value of hot) expect(value).toBeLessThanOrEqual(1)
+    for (const value of hot) expect(value).toBeGreaterThanOrEqual(0)
+    for (const value of cold) expect(value).toBe(0)
+  })
+
+  test("sparks ignite a cold row", () => {
+    const row = advance(seed(4), rng([0])) // rng 0 always sparks
+    for (const value of row) expect(value).toBeGreaterThan(0)
+  })
+
+  test("cell maps heat to glyph and color from the palettes", () => {
+    expect(cell(0)).toEqual({ char: GLYPHS[0], color: PALETTE[0] })
+    expect(cell(1).char).toBe(GLYPHS[GLYPHS.length - 1])
+    expect(PALETTE).toContain(cell(0.5).color)
+    expect(GLYPHS).toContain(cell(0.5).char)
+  })
+
+  test("cells maps a whole row", () => {
+    const row = cells([0, 1])
+    expect(row).toHaveLength(2)
+    expect(row[0].char).toBe(GLYPHS[0])
+    expect(row[1].color).toBe(PALETTE[PALETTE.length - 1])
+  })
+
+  test("side flickers within the bright half of the palette", () => {
+    expect(PALETTE.indexOf(side([0, 0, 0]))).toBeGreaterThanOrEqual(3)
+    expect(PALETTE.indexOf(side([1, 1, 1]))).toBe(PALETTE.length - 1)
+    expect(side([])).toBe(PALETTE[4])
+  })
+})

--- a/packages/tui/test/ui/fire.test.ts
+++ b/packages/tui/test/ui/fire.test.ts
@@ -6,10 +6,10 @@ describe("fire", () => {
     const engine = await ignite(40)
     const grid = engine.grid()
     expect(grid.length).toBe(40 * ROWS)
-    for (const heat of grid) {
+    grid.forEach((heat) => {
       expect(heat).toBeGreaterThanOrEqual(0)
       expect(heat).toBeLessThanOrEqual(MAX)
-    }
+    })
   })
 
   test("source row stays hot and tips stay cooler", async () => {
@@ -52,9 +52,9 @@ describe("fire", () => {
     for (let i = 0; i < 10; i++) engine.advance()
     const rows = cells(engine.grid(), 20)
     expect(rows.length).toBe(ROWS / 2)
-    for (const row of rows) {
+    rows.forEach((row) => {
       expect(row.length).toBe(20)
-      for (const item of row) expect([" ", "▀", "▄"]).toContain(item.char)
-    }
+      row.forEach((item) => expect([" ", "▀", "▄"]).toContain(item.char))
+    })
   })
 })

--- a/packages/tui/test/ui/fire.test.ts
+++ b/packages/tui/test/ui/fire.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { cell, cells, ignite, GLYPHS, MAX, PALETTE, ROWS } from "../../src/ui/fire"
+import { cell, cells, ignite, MAX, PALETTE, ROWS } from "../../src/ui/fire"
 
 describe("fire", () => {
   test("ignite produces a grid of width * rows heat values in range", async () => {
@@ -31,16 +31,6 @@ describe("fire", () => {
     expect(engine.grid().length).toBe(60 * ROWS)
   })
 
-  test("cell maps zero heat to blank and max heat to the brightest glyph", () => {
-    expect(cell(0).char).toBe(" ")
-    expect(cell(MAX).char).toBe(GLYPHS[GLYPHS.length - 1])
-    expect(cell(MAX).color).toBe(PALETTE[PALETTE.length - 1])
-    for (let heat = 0; heat <= MAX; heat++) {
-      expect(GLYPHS).toContain(cell(heat).char)
-      expect(PALETTE).toContain(cell(heat).color)
-    }
-  })
-
   test("narrow grids still burn despite the upstream 35-column seeding quirk", async () => {
     const engine = await ignite(20)
     for (let i = 0; i < 30; i++) engine.advance()
@@ -49,11 +39,22 @@ describe("fire", () => {
     expect(Math.max(...grid)).toBeGreaterThan(MAX / 2)
   })
 
-  test("cells splits the flat grid into rows of rendered cells", async () => {
+  test("cell pairs two pixel rows into one half-block character", () => {
+    expect(cell(0, 0)).toEqual({ char: " " })
+    expect(cell(MAX, 0)).toEqual({ char: "▀", fg: PALETTE[MAX] })
+    expect(cell(0, MAX)).toEqual({ char: "▄", fg: PALETTE[MAX] })
+    expect(cell(10, MAX)).toEqual({ char: "▀", fg: PALETTE[10], bg: PALETTE[MAX] })
+    expect(PALETTE.length).toBe(MAX + 1)
+  })
+
+  test("cells folds the flat grid into half-height rows of rendered cells", async () => {
     const engine = await ignite(20)
     for (let i = 0; i < 10; i++) engine.advance()
     const rows = cells(engine.grid(), 20)
-    expect(rows.length).toBe(ROWS)
-    for (const row of rows) expect(row.length).toBe(20)
+    expect(rows.length).toBe(ROWS / 2)
+    for (const row of rows) {
+      expect(row.length).toBe(20)
+      for (const item of row) expect([" ", "▀", "▄"]).toContain(item.char)
+    }
   })
 })

--- a/packages/tui/test/ui/fire.test.ts
+++ b/packages/tui/test/ui/fire.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { advance, cell, cells, seed, side, GLYPHS, PALETTE } from "../../src/ui/fire"
+import { advance, cell, cells, seed, side, GLYPHS, PALETTE, ROWS } from "../../src/ui/fire"
 
 function rng(values: number[]) {
   let index = 0
@@ -7,45 +7,54 @@ function rng(values: number[]) {
 }
 
 describe("fire", () => {
-  test("seed produces a cold row of the requested width", () => {
-    expect(seed(5)).toEqual([0, 0, 0, 0, 0])
-    expect(seed(0)).toEqual([])
-    expect(seed(-3)).toEqual([])
+  test("seed produces a grid with a hot source row and cold tips", () => {
+    const grid = seed(4)
+    expect(grid).toHaveLength(ROWS)
+    for (const row of grid) expect(row).toHaveLength(4)
+    expect(grid[ROWS - 1]).toEqual([1, 1, 1, 1])
+    expect(grid[0]).toEqual([0, 0, 0, 0])
+    expect(seed(0).every((row) => row.length === 0)).toBe(true)
+    expect(seed(-3).every((row) => row.length === 0)).toBe(true)
   })
 
-  test("advance keeps heat within bounds", () => {
-    const hot = advance(
-      [1, 1, 1, 1],
-      rng([0, 0.99]), // constant sparks with max boost
-    )
-    const cold = advance([0, 0, 0, 0], rng([0.99]))
-    for (const value of hot) expect(value).toBeLessThanOrEqual(1)
-    for (const value of hot) expect(value).toBeGreaterThanOrEqual(0)
-    for (const value of cold) expect(value).toBe(0)
+  test("advance keeps heat within bounds and the source row hot", () => {
+    const grid = Array.from({ length: 20 }).reduce<number[][]>((acc) => advance(acc), seed(6))
+    for (const row of grid) {
+      for (const value of row) {
+        expect(value).toBeGreaterThanOrEqual(0)
+        expect(value).toBeLessThanOrEqual(1)
+      }
+    }
+    for (const value of grid[grid.length - 1]) expect(value).toBeGreaterThanOrEqual(0.85)
   })
 
-  test("sparks ignite a cold row", () => {
-    const row = advance(seed(4), rng([0])) // rng 0 always sparks
-    for (const value of row) expect(value).toBeGreaterThan(0)
+  test("heat decays away from the source so tips are ragged", () => {
+    // rng cycles: drift pick, decay for every non-source cell; 0.5 keeps it deterministic-ish
+    const grid = advance(advance(seed(4), rng([0.5])), rng([0.5]))
+    const mean = (row: number[]) => row.reduce((sum, value) => sum + value, 0) / row.length
+    expect(mean(grid[0])).toBeLessThan(mean(grid[grid.length - 1]))
   })
 
   test("cell maps heat to glyph and color from the palettes", () => {
-    expect(cell(0)).toEqual({ char: GLYPHS[0], color: PALETTE[0] })
-    expect(cell(1).char).toBe(GLYPHS[GLYPHS.length - 1])
-    expect(PALETTE).toContain(cell(0.5).color)
+    expect(cell(0)).toEqual({ char: " ", color: PALETTE[0] })
+    expect(cell(1).char).toBe("█")
     expect(GLYPHS).toContain(cell(0.5).char)
+    expect(PALETTE).toContain(cell(0.5).color)
   })
 
-  test("cells maps a whole row", () => {
-    const row = cells([0, 1])
-    expect(row).toHaveLength(2)
-    expect(row[0].char).toBe(GLYPHS[0])
-    expect(row[1].color).toBe(PALETTE[PALETTE.length - 1])
+  test("cells maps a whole grid", () => {
+    const grid = cells([
+      [0, 1],
+      [1, 0],
+    ])
+    expect(grid).toHaveLength(2)
+    expect(grid[0][0].char).toBe(" ")
+    expect(grid[0][1].char).toBe("█")
+    expect(grid[1][0].color).toBe(PALETTE[PALETTE.length - 1])
   })
 
-  test("side flickers within the bright half of the palette", () => {
-    expect(PALETTE.indexOf(side([0, 0, 0]))).toBeGreaterThanOrEqual(3)
-    expect(PALETTE.indexOf(side([1, 1, 1]))).toBe(PALETTE.length - 1)
-    expect(side([])).toBe(PALETTE[4])
+  test("side flickers within the bright end of the palette", () => {
+    expect(PALETTE.indexOf(side(seed(3)))).toBeGreaterThanOrEqual(4)
+    expect(side([[]])).toBe(PALETTE[5])
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #55

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

While the agent is working (session status not `idle`), a 16-row DOOM-fire bar burns along the top of the chatbox, flames licking upward with the hot source row hugging the box. Idle sessions render exactly as before, and the effect is gated on the existing `animations_enabled` KV toggle. The rest of the chatbox frame (left rail, bottom edge) is untouched.

The heat simulation comes from the [`@seomis/doom-fire`](https://www.npmjs.com/package/@seomis/doom-fire) npm package, a Rust/wasm port of the PSX DOOM fire algorithm. `packages/tui/src/ui/fire.ts` only loads the wasm and maps heat (0..35) through the classic 36-color DOOM palette (`#070707` embers up to `#ffffff` white-hot). Cells are rendered as half-block pixels — each text row packs two display rows using `▀`/`▄` with foreground + background colors — so the bar reads as an actual pixel fire instead of glyph soup. Because DOOM flames need vertical room to develop the classic gradient, a shallow simulation is mostly a flat orange band; the loader instead simulates 4x deeper (128 rows) and samples the 32 display rows (16 text rows) from the active flame window, which is what produces the full gradient — white-hot source, orange body, dark ragged tips. The wasm ships with three quirks the loader compensates for, each verified empirically and covered by tests:

```ts
// - the wasm-bindgen glue imports "./doom_fire_bg" without an extension, which
//   Bun cannot resolve, so we instantiate the .wasm directly
// - fire_get_width/fire_get_height are swapped upstream, so we track our own
//   dimensions instead of asking the wasm
// - fire_update_cells occasionally traps on an out-of-bounds drift, so advance
//   respawns the instance when that happens
```

It also seeds no fire on grids narrower than 35 columns, so narrow terminals simulate at 35 and slice down. The `.wasm` is embedded into the compiled binary via `import ... with { type: "file" }`, same pattern as the audio assets. `fire-frame.tsx` drives it on a 90ms timer started only while active and cleaned up via `onCleanup`, rendered as height-1 rows clipped with `overflow="hidden"` so layout never shifts.

The fire is tinted to the active theme instead of always burning DOOM orange. `palette(base)` in `fire.ts` builds a 36-color ramp from a theme's primary color: the cool half eases from near-black embers into the base color, and the hot half eases from the base up to white — so dark primaries like blue or green still get a white-hot core. The prompt passes `theme.primary` through a reactive memo, so switching themes retints the flames live without restarting the animation; when no color is supplied the classic DOOM palette remains the default (which is what the tests pin down).

### How did you verify your code works?

- `bun test` in `packages/tui`: 198 pass (6 tests in `test/ui/fire.test.ts`, including 2000 advances to prove trap recovery)
- `bun run typecheck` in `packages/tui`: clean
- `bun build --compile` smoke test confirming the embedded wasm loads and burns in a single-file binary
- Rendered the real engine output in an HTML preview (below)

### Screenshots / recordings

![DOOM fire bar above the chatbox: white-hot source row, orange body, dark ragged tips](https://backend.blacksmith.sh/api/attachments/eyJpdiI6ImE4TzBkeWpYS3VYNXpsNFNQVHU4eXc9PSIsInZhbHVlIjoiOWhOK1krVEdWS3JFcm52SXVkQjIrNUEvRGJSQ0kwMzJ2ZDVxK2FQL2lEajVLd1ZUVFdOWnc1aEV6dlVGZUo2VHBQNXVKdFJiTVdQYlJIRmJwMDN1Qlg1VkU0OVRSK0JPRmFuSktEZDRqZ2d4a3VLcGh1R0pRVXVZMXV6ZnpKQXE3UFI2c2h3a0h6aFFja1h5d0Z5QVlmWWQwYU02VG14SUVWcEFKRk5ZV3RaK2QwckpQallvdTkzSkZ3ZW53VGFaOEMrSEUxQ2dFbFBGQTVtaWpJWUdtSnBPZ2o0RU90Q2k5b3loYjhWY01SQjlvWFpYMGVKSHhXSmpnVG5JRHFFck5xOW9CYlduNzZKMklOUUZJMUF3VEE9PSIsIm1hYyI6ImY0NzdlZmUxMWY4YjJmZTNhNWE1OGI1NDc0Y2Q4YWEyZjEzYWFjY2VjNGE4ZmM0NWRjZWRhZDhmMTg4ZWJkZWEiLCJ0YWciOiIifQ)

(HTML mock rendered with the real wasm engine output; in the TUI the bar animates at ~11fps.)

Theme tinting — the same fire rendered with three theme primaries (opencode blue, matrix green, nord ice), each ramping from dark tips through the theme color to a white-hot base:

![Theme-tinted fire: blue, green, and ice palettes each with white-hot base](https://backend.blacksmith.sh/api/attachments/eyJpdiI6IkRJWEpyTkdmdUhEKzhTZDB3empGWXc9PSIsInZhbHVlIjoibHJvWmhDRWlKcUhsQnlqOEhLQWE0OGhCNFB4clhrVitVakdTaUgwYi9PbGovV1JPbjNWWTVLMGEwRWNmY016MUtmNlVSVTZ5NFU5RWtjWmdOYXVwSjhwY2loRHAvaEN5UDdyUmlQR3NKSElNV1BtUVZiTXU0ZUVPNDd4Vkh2T1NVc0VJdG1nYnN0cFMwMVVPYk1BaGhHZkVFZ3BiR2lyWkVqcm1ZLy8za2VOaHBobFFRSndKT3ZYZGt4SnVmNVlzU1lsZStVUzlDeHF0dmtpZkYrNU50Um9pbHBZRFJHUkY1U05xdXZaVTRQa1MvaVYxVzB4dlU1UklhTm4yaTk2VFhYTSt2bEF2akVmZjErY3R6NlBHQmc9PSIsIm1hYyI6ImZmZWE3MWMzYzYzYTc0ZjM3N2M4YjBjMTU3YmY0NzI5MWE0ZDY2M2E2NDkxOWI1OWRiNjY3MDUyNzc0OWU4M2IiLCJ0YWciOiIifQ)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an animated, colored fire effect above the terminal prompt during active sessions.
  - Fire adapts to terminal width, uses the configured theme color, and clears when inactive.
  - Animation advances continuously and recovers automatically from interruptions or initialization failures.

- **Bug Fixes**
  - Improved rendering for narrow terminal displays.

- **Tests**
  - Added coverage for fire behavior, heat progression, color mapping, sizing, narrow displays, and recovery from interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
