### PR TITLE
docs: add a Done roadmap section and check off shipped items

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,11 @@ Where Bolt is headed, for the CLI, the desktop app, and everything around them. 
 
 - [ ] Session sync engine rollout (event-sourced storage, phase 1 shipped)
 - [ ] V2 session core (durable runner and coordinator)
-- [ ] Project memory module
 
 ### Next
 
 <details>
-<summary><strong>CLI and sessions (15)</strong></summary>
+<summary><strong>CLI and sessions (14)</strong></summary>
 
 - [ ] `session tail`: live-follow a running session from another terminal
 - [ ] `session search`: full-text search across all transcripts
@@ -196,7 +195,6 @@ Where Bolt is headed, for the CLI, the desktop app, and everything around them. 
 - [ ] Structured output schemas for `run --format json`
 - [ ] Session templates: reusable prompt, agent, and model presets
 - [ ] Session tags and filters in `session list`
-- [ ] `bolt memory`: view and edit what the agent remembers per project
 - [ ] Skills management: `bolt skill list/add`
 - [ ] Committable permission presets (`.bolt/permissions.jsonc`)
 - [ ] Lifecycle hooks: run shell commands before/after tool calls
@@ -358,6 +356,11 @@ Where Bolt is headed, for the CLI, the desktop app, and everything around them. 
 - [ ] Codebase visualization maps
 - [ ] Time-travel debugging across session checkpoints
 - [ ] AI release manager: cut, verify, and publish releases end to end
+
+### Done
+
+- [x] Project memory module: automatic capture with save and recall tools
+- [x] `bolt memory`: view and edit what the agent remembers per project (`/memory` in the TUI)
 
 ## Contributing
 


### PR DESCRIPTION
### Issue for this PR

Closes #57

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a `### Done` section to the README roadmap and moves the two items that have actually shipped into it, checked off:

```md
### Done

- [x] Project memory module: automatic capture with save and recall tools
- [x] `bolt memory`: view and edit what the agent remembers per project (`/memory` in the TUI)
```

Both were verified against the code before checking them off: the memory module landed in #43 (`MemorySaveTool` / `MemoryRecallTool` registered in the tool builtins, autosave closing memory turns from the prompt loop) and the TUI exposes `/memory` (alias `/mem`) for viewing and editing project memory. Everything else on the roadmap was checked too (`run --background`, `bolt doctor`, `session tail/search`, `stats` export, permission presets, and friends) and none of it exists yet, so nothing else moved. The "CLI and sessions" summary count drops from 15 to 14 accordingly.

### How did you verify your code works?

- Grepped the CLI command registry and core for each roadmap item before deciding whether to check it off
- Rendered the markdown locally to confirm the new section and checkbox formatting

### Screenshots / recordings

N/A (docs only)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to reflect the completion of the Project Memory module and `bolt memory` command.
  * Corrected the listed CLI and session count from 15 to 14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->