### PR TITLE
fix(tui): reference wasm declaration from fire module

### DIFF
--- a/packages/tui/src/ui/fire.ts
+++ b/packages/tui/src/ui/fire.ts
@@ -10,6 +10,10 @@
 //   dimensions instead of asking the wasm
 // - fire_update_cells occasionally traps on an out-of-bounds drift, so advance
 //   respawns the instance when that happens
+// The reference pulls the ambient *.wasm module declaration into any program
+// that compiles this file; packages importing tui sources (like cli) don't
+// include tui's wasm.d.ts on their own.
+/// <reference path="../wasm.d.ts" />
 import wasm from "@seomis/doom-fire/doom_fire_bg.wasm" with { type: "file" }
 
 // The classic 36-color DOOM fire palette, black ember to white-hot core,


### PR DESCRIPTION
### Issue for this PR

Closes #62

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the typecheck failure on dev introduced with the fire bar (#56). `packages/tui/src/wasm.d.ts` declares the `*.wasm` ambient module, but that declaration only exists in tui's own TS program. The cli package imports tui sources, so its typecheck compiles `fire.ts` without the declaration and fails with `TS2307: Cannot find module '@seomis/doom-fire/doom_fire_bg.wasm'`.

The fix pulls the declaration into every program that compiles the file:

```ts
/// <reference path="../wasm.d.ts" />
import wasm from "@seomis/doom-fire/doom_fire_bg.wasm" with { type: "file" }
```

No runtime change; the directive only affects type resolution for downstream typechecks.

### How did you verify your code works?

Ran `bun typecheck` from the affected package directories; the TS2307 error on `fire.ts` is gone and CI typecheck passes on this branch.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
