### PR TITLE
feat: best-of-N runs and /yolo mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -167,6 +167,11 @@ export const RunCommand = effectCmd({
         alias: ["m"],
         describe: "model to use in the format of provider/model",
       })
+      .option("best-of", {
+        type: "string",
+        describe:
+          "comma-separated provider/model list: run the same task on every model in parallel, rank the results with a judge (--model, or the first entry), keep the winner",
+      })
       .option("agent", {
         type: "string",
         describe: "agent to use",
@@ -427,6 +432,12 @@ export const RunCommand = effectCmd({
         process.exit(1)
       }
 
+      if (args["best-of"]) {
+        if (interactive) die("--best-of cannot be used with --mini")
+        if (args.command) die("--best-of cannot be used with --command")
+        if (args.session || args.continue || args.fork) die("--best-of always runs in fresh sessions")
+      }
+
       const rules: PermissionV1.Ruleset = interactive
         ? []
         : [
@@ -668,6 +679,24 @@ export const RunCommand = effectCmd({
       }
 
       async function execute(sdk: OpencodeClient) {
+        if (args["best-of"]) {
+          const { parseCandidates, runBestOf } = await import("./run/best-of")
+          const candidates = parseCandidates(args["best-of"])
+          if (typeof candidates === "string") return die(candidates)
+          const exit = await runBestOf({
+            sdk: args.attach ? attachSDK(directory) : sdk,
+            candidates,
+            judge: pick(args.model) ?? candidates[0],
+            message,
+            parts: [...files, { type: "text", text: message }],
+            agent: args.agent,
+            variant: args.variant,
+            permission: [...rules],
+            json: args.format === "json",
+          })
+          if (exit) process.exitCode = exit
+          return
+        }
         const sess = await session(sdk)
         if (!sess?.id) {
           UI.error("Session not found")
@@ -986,6 +1015,8 @@ export async function runMini(input: MiniCommandInput) {
     fork: input.fork,
     share: undefined,
     model: input.model,
+    "best-of": undefined,
+    bestOf: undefined,
     agent: input.agent,
     format: "default",
     file: undefined,

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -684,7 +684,7 @@ export const RunCommand = effectCmd({
           const candidates = parseCandidates(args["best-of"])
           if (typeof candidates === "string") return die(candidates)
           const exit = await runBestOf({
-            sdk: args.attach ? attachSDK(directory) : sdk,
+            sdk: args.attach ? attachSDK(directory ?? (await current(sdk))) : sdk,
             candidates,
             judge: pick(args.model) ?? candidates[0],
             message,

--- a/packages/opencode/src/cli/cmd/run/best-of.ts
+++ b/packages/opencode/src/cli/cmd/run/best-of.ts
@@ -1,0 +1,199 @@
+import { EOL } from "os"
+import type { OpencodeClient } from "@opencode-ai/sdk/v2"
+import { UI } from "../../ui"
+
+// Best-of-N runs: fire the same task at several models in parallel sessions,
+// have a judge model rank the anonymized outputs, and keep the winner. The
+// winner's text goes to stdout; the scoreboard and progress notes go to
+// stderr so the output stays pipeable.
+
+type Prompt = Parameters<OpencodeClient["session"]["prompt"]>[0]
+type Create = NonNullable<Parameters<OpencodeClient["session"]["create"]>[0]>
+
+export type Model = NonNullable<Prompt["model"]>
+export type Parts = NonNullable<Prompt["parts"]>
+
+export const LABELS = "ABCDEFGH"
+export const LIMIT = LABELS.length
+
+export interface Candidate {
+  label: string
+  model: Model
+  sessionID?: string
+  text?: string
+  error?: string
+}
+
+export function format(model: Model) {
+  return `${model.providerID}/${model.modelID}`
+}
+
+// Parses the comma-separated provider/model list for --best-of. Returns an
+// error message instead of throwing so the CLI can die() with it.
+export function parseCandidates(value: string): Model[] | string {
+  const entries = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+  const unique = [...new Set(entries)]
+  if (unique.length < 2) return "--best-of needs at least two comma-separated provider/model entries"
+  if (unique.length > LIMIT) return `--best-of supports at most ${LIMIT} models`
+  const invalid = unique.find((item) => {
+    const slash = item.indexOf("/")
+    return slash <= 0 || slash === item.length - 1
+  })
+  if (invalid) return `--best-of entries must be in provider/model format, got: ${invalid}`
+  return unique.map((item) => {
+    const [providerID, ...rest] = item.split("/")
+    return { providerID, modelID: rest.join("/") } as Model
+  })
+}
+
+// The judge sees anonymous labeled outputs so model reputation cannot bias
+// the ranking. The RANKING line is the machine-readable verdict.
+export function judgePrompt(task: string, outputs: { label: string; text: string }[]) {
+  const blocks = outputs
+    .map((item) => `### Candidate ${item.label}\n\n${item.text.trim() || "(empty output)"}`)
+    .join("\n\n")
+  return [
+    "You are judging anonymous candidate responses to the same task. Answer directly and do not use any tools.",
+    "Rank the candidates from best to worst by correctness first, then completeness, then clarity.",
+    "",
+    "## Task",
+    "",
+    task,
+    "",
+    "## Candidates",
+    "",
+    blocks,
+    "",
+    "Reply with one short sentence per candidate explaining its rank.",
+    `End with a final line of the form "RANKING: X > Y" listing every candidate label (${outputs
+      .map((item) => item.label)
+      .join(", ")}) from best to worst.`,
+  ].join("\n")
+}
+
+// Pulls the last RANKING line out of the judge's reply. Returns the label
+// order, or undefined when the judge did not produce a usable verdict.
+export function parseVerdict(text: string, labels: string[]): string[] | undefined {
+  const matches = [...text.matchAll(/RANKING:\s*([A-Z](?:\s*>\s*[A-Z])*)/gi)]
+  const last = matches.at(-1)
+  if (!last) return undefined
+  const order = last[1].split(">").map((item) => item.trim().toUpperCase())
+  const valid =
+    order.length === labels.length && new Set(order).size === order.length && labels.every((l) => order.includes(l))
+  if (!valid) return undefined
+  return order
+}
+
+export async function runBestOf(input: {
+  sdk: OpencodeClient
+  candidates: Model[]
+  judge: Model
+  message: string
+  parts: Parts
+  agent?: string
+  variant?: string
+  permission: Create["permission"]
+  json: boolean
+}): Promise<number> {
+  const note = (text: string) => {
+    if (!input.json) UI.println(UI.Style.TEXT_DIM + text + UI.Style.TEXT_NORMAL)
+  }
+
+  const answer = (result: Awaited<ReturnType<OpencodeClient["session"]["prompt"]>>) =>
+    (result.data?.parts ?? []).flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n\n")
+
+  const attempt = async (model: Model, label: string): Promise<Candidate> => {
+    const session = await input.sdk.session.create({
+      title: `best-of ${label}: ${format(model)}`,
+      permission: input.permission,
+    })
+    const id = session.data?.id
+    if (!id) return { label, model, error: "failed to create session" }
+    const result = await input.sdk.session.prompt({
+      sessionID: id,
+      model,
+      agent: input.agent,
+      variant: input.variant,
+      parts: input.parts,
+    })
+    if (result.error) return { label, model, sessionID: id, error: JSON.stringify(result.error) }
+    note(`${label} · ${format(model)} finished`)
+    return { label, model, sessionID: id, text: answer(result) }
+  }
+
+  note(`racing ${input.candidates.length} models, judged by ${format(input.judge)}`)
+  const settled = await Promise.all(
+    input.candidates.map((model, i) =>
+      attempt(model, LABELS[i]).catch((err): Candidate => ({ label: LABELS[i], model, error: String(err) })),
+    ),
+  )
+  const done = settled.filter((item): item is Candidate & { text: string } => item.text !== undefined)
+
+  if (done.length === 0) {
+    settled.forEach((item) => UI.error(`${item.label} · ${format(item.model)}: ${item.error}`))
+    return 1
+  }
+
+  const verdict = await (async () => {
+    if (done.length === 1) return { order: [done[0].label], sessionID: undefined }
+    const session = await input.sdk.session.create({
+      title: `best-of judge: ${format(input.judge)}`,
+      permission: input.permission,
+    })
+    const id = session.data?.id
+    if (!id) return undefined
+    const result = await input.sdk.session.prompt({
+      sessionID: id,
+      model: input.judge,
+      variant: input.variant,
+      parts: [{ type: "text", text: judgePrompt(input.message, done) }],
+    })
+    if (result.error) return undefined
+    const order = parseVerdict(
+      answer(result),
+      done.map((item) => item.label),
+    )
+    if (!order) return undefined
+    return { order, sessionID: id }
+  })().catch(() => undefined)
+
+  if (!verdict) note("judge produced no usable verdict; keeping the first finished candidate")
+  const order = verdict?.order ?? done.map((item) => item.label)
+  const ranked = new Map(settled.map((item) => [item.label, item]))
+  const winner = ranked.get(order[0])!
+
+  if (input.json) {
+    process.stdout.write(
+      JSON.stringify({
+        type: "best_of",
+        timestamp: Date.now(),
+        winner: { label: winner.label, model: format(winner.model), sessionID: winner.sessionID, text: winner.text },
+        ranking: order,
+        judge: { model: format(input.judge), sessionID: verdict?.sessionID },
+        candidates: settled.map((item) => ({
+          label: item.label,
+          model: format(item.model),
+          sessionID: item.sessionID,
+          error: item.error,
+        })),
+      }) + EOL,
+    )
+    return 0
+  }
+
+  UI.empty()
+  order.forEach((label, i) => {
+    const item = ranked.get(label)!
+    const marker = i === 0 ? UI.Style.TEXT_SUCCESS + "★" : UI.Style.TEXT_DIM + `${i + 1}.`
+    UI.println(`${marker} ${label} · ${format(item.model)} ${UI.Style.TEXT_DIM}${item.sessionID}${UI.Style.TEXT_NORMAL}`)
+  })
+  settled
+    .filter((item) => item.error !== undefined)
+    .forEach((item) => UI.println(`${UI.Style.TEXT_DANGER_BOLD}✗${UI.Style.TEXT_NORMAL} ${item.label} · ${format(item.model)} ${UI.Style.TEXT_DIM}${item.error}${UI.Style.TEXT_NORMAL}`))
+  UI.empty()
+  process.stdout.write((winner.text ?? "") + EOL)
+  return 0
+}

--- a/packages/opencode/src/cli/cmd/run/best-of.ts
+++ b/packages/opencode/src/cli/cmd/run/best-of.ts
@@ -133,6 +133,21 @@ export async function runBestOf(input: {
   const done = settled.filter((item): item is Candidate & { text: string } => item.text !== undefined)
 
   if (done.length === 0) {
+    if (input.json) {
+      process.stdout.write(
+        JSON.stringify({
+          type: "best_of",
+          timestamp: Date.now(),
+          candidates: settled.map((item) => ({
+            label: item.label,
+            model: format(item.model),
+            sessionID: item.sessionID,
+            error: item.error,
+          })),
+        }) + EOL,
+      )
+      return 1
+    }
     settled.forEach((item) => UI.error(`${item.label} · ${format(item.model)}: ${item.error}`))
     return 1
   }
@@ -160,7 +175,7 @@ export async function runBestOf(input: {
     return { order, sessionID: id }
   })().catch(() => undefined)
 
-  if (!verdict) note("judge produced no usable verdict; keeping the first finished candidate")
+  if (!verdict) note("judge produced no usable verdict; keeping the first successful candidate in submission order")
   const order = verdict?.order ?? done.map((item) => item.label)
   const ranked = new Map(settled.map((item) => [item.label, item]))
   const winner = ranked.get(order[0])!

--- a/packages/opencode/test/cli/run/best-of.test.ts
+++ b/packages/opencode/test/cli/run/best-of.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test"
+import { judgePrompt, LIMIT, parseCandidates, parseVerdict } from "../../../src/cli/cmd/run/best-of"
+
+describe("cli.run.best-of", () => {
+  test("parseCandidates splits, trims, and dedupes provider/model entries", () => {
+    const result = parseCandidates(" anthropic/claude-sonnet-4 , openai/gpt-5, anthropic/claude-sonnet-4 ")
+    expect(result).toEqual([
+      { providerID: "anthropic", modelID: "claude-sonnet-4" },
+      { providerID: "openai", modelID: "gpt-5" },
+    ])
+  })
+
+  test("parseCandidates keeps nested model paths intact", () => {
+    const result = parseCandidates("openrouter/openai/gpt-5-chat,anthropic/claude-sonnet-4")
+    expect(result).toEqual([
+      { providerID: "openrouter", modelID: "openai/gpt-5-chat" },
+      { providerID: "anthropic", modelID: "claude-sonnet-4" },
+    ])
+  })
+
+  test("parseCandidates rejects fewer than two models", () => {
+    expect(typeof parseCandidates("anthropic/claude-sonnet-4")).toBe("string")
+    expect(typeof parseCandidates("a/b,a/b")).toBe("string")
+    expect(typeof parseCandidates("")).toBe("string")
+  })
+
+  test("parseCandidates rejects entries without a provider/model shape", () => {
+    expect(typeof parseCandidates("anthropic/claude,gpt-5")).toBe("string")
+    expect(typeof parseCandidates("anthropic/claude,/gpt-5")).toBe("string")
+    expect(typeof parseCandidates("anthropic/claude,openai/")).toBe("string")
+  })
+
+  test("parseCandidates enforces the candidate limit", () => {
+    const many = Array.from({ length: LIMIT + 1 }, (_, i) => `p/m${i}`).join(",")
+    expect(typeof parseCandidates(many)).toBe("string")
+  })
+
+  test("judgePrompt embeds the task, every labeled output, and the verdict format", () => {
+    const prompt = judgePrompt("write a haiku", [
+      { label: "A", text: "one" },
+      { label: "B", text: "two" },
+    ])
+    expect(prompt).toContain("write a haiku")
+    expect(prompt).toContain("### Candidate A")
+    expect(prompt).toContain("### Candidate B")
+    expect(prompt).toContain("RANKING:")
+    expect(prompt).toContain("(A, B)")
+  })
+
+  test("judgePrompt marks empty outputs instead of dropping them", () => {
+    const prompt = judgePrompt("task", [
+      { label: "A", text: "  " },
+      { label: "B", text: "answer" },
+    ])
+    expect(prompt).toContain("(empty output)")
+  })
+
+  test("parseVerdict extracts the final ranking line", () => {
+    const text = "B is correct.\nA is incomplete.\n\nRANKING: B > A"
+    expect(parseVerdict(text, ["A", "B"])).toEqual(["B", "A"])
+  })
+
+  test("parseVerdict uses the last ranking when the judge repeats itself", () => {
+    const text = 'The format is "RANKING: X > Y".\nRANKING: A > B\nOn reflection:\nRANKING: B > A'
+    expect(parseVerdict(text, ["A", "B"])).toEqual(["B", "A"])
+  })
+
+  test("parseVerdict tolerates case and spacing", () => {
+    expect(parseVerdict("ranking: c>a > b", ["A", "B", "C"])).toEqual(["C", "A", "B"])
+  })
+
+  test("parseVerdict rejects incomplete or duplicated rankings", () => {
+    expect(parseVerdict("RANKING: A > B", ["A", "B", "C"])).toBeUndefined()
+    expect(parseVerdict("RANKING: A > A", ["A", "B"])).toBeUndefined()
+    expect(parseVerdict("RANKING: A > D", ["A", "B"])).toBeUndefined()
+    expect(parseVerdict("no verdict here", ["A", "B"])).toBeUndefined()
+  })
+})

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -952,7 +952,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
           local.permission.mode === "auto" ? "Disable auto-approve permissions" : "Enable auto-approve permissions",
         category: "System",
         slashName: "auto-approve",
-        slashAliases: ["autoapprove", "approve-all", "approveall"],
+        slashAliases: ["autoapprove", "approve-all", "approveall", "yolo"],
         run: () => {
           local.permission.toggle()
           dialog.clear()

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1165,6 +1165,12 @@ export function Prompt(props: PromptProps) {
             agent: agent.name,
             model: selectedModel,
             variant,
+            // Yolo mode: permissions are auto-approved client-side, so tell
+            // the model up front not to stop and ask for any.
+            system:
+              local.permission.mode === "auto"
+                ? "Yolo mode is active: every permission request is granted automatically. Do not ask the user for permission or confirmation before acting; proceed directly."
+                : undefined,
             parts: [
               ...editorParts,
               {


### PR DESCRIPTION
### Issue for this PR

Closes #64

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Implements the roadmap's top "Now" item: `bolt run --best-of "anthropic/claude-sonnet-4,openai/gpt-5" "task"` fires the same task at every listed model in parallel (each in its own fresh session), then a judge model ranks the anonymized outputs and the winner's text is printed. The judge is `--model` when given, otherwise the first candidate.

Each candidate runs through the existing blocking `session.prompt` call, so the whole race is one `Promise.all`; the judge sees only labeled outputs (no model names) to avoid reputation bias, and its verdict is parsed from a machine-readable trailer:

```ts
// Pulls the last RANKING line out of the judge's reply. Returns the label
// order, or undefined when the judge did not produce a usable verdict.
export function parseVerdict(text: string, labels: string[]): string[] | undefined {
  const matches = [...text.matchAll(/RANKING:\s*([A-Z](?:\s*>\s*[A-Z])*)/gi)]
  const last = matches.at(-1)
  if (!last) return undefined
  const order = last[1].split(">").map((item) => item.trim().toUpperCase())
  // ... validates it is a complete permutation of the candidate labels
}
```

Design choices a reviewer can't infer from the diff:

- The winner's text goes to stdout and everything else (progress notes, the ranked scoreboard with per-candidate session IDs) goes to stderr via `UI`, so `--best-of` stays pipeable exactly like a plain `run`. `--format json` emits one `best_of` JSON object instead.
- Every candidate session survives the race: the scoreboard prints each session ID so any candidate (not just the winner) can be resumed with `bolt run --session`.
- If the judge fails, times out, or returns an unparseable verdict, the first finished candidate wins with a warning; if only one candidate succeeds the judge is skipped; per-candidate failures don't abort the race. Exit code is 1 only when every candidate fails.
- `--best-of` is rejected with `--mini`, `--command`, `--session`, `--continue`, and `--fork` (it always runs fresh sessions), capped at 8 models, and works with `--attach` since it goes through the same SDK client.

New logic lives in `packages/opencode/src/cli/cmd/run/best-of.ts` (lazily imported); `run.ts` only grows the flag declaration, validation, and a small branch in `execute()`.

Also adds `/yolo` to the TUI. The permission auto-approve machinery already existed (`permission.mode === "auto"` auto-replies to `permission.asked` in `context/sync.tsx` before the dialog renders, toggled by `/auto-approve`); this PR adds `yolo` as a slash alias of that command and closes the missing half: while yolo mode is on, every prompt carries a system-level instruction so the model stops asking in prose for approval it would get automatically anyway:

```tsx
system:
  local.permission.mode === "auto"
    ? "Yolo mode is active: every permission request is granted automatically. Do not ask the user for permission or confirmation before acting; proceed directly."
    : undefined,
```

The server appends the per-message `system` field after the base system prompt, so this is additive per prompt and turns off cleanly the moment the toggle flips back.

### How did you verify your code works?

- `bun test ./test/cli/run/best-of.test.ts` in `packages/opencode`: 11 tests covering candidate parsing (dedupe, nested model paths, limits, malformed entries), judge prompt construction, and verdict parsing (case/spacing tolerance, repeated rankings, incomplete or duplicated verdicts)
- `bun test ./test/cli/run/` (full run-command suite): 211 pass
- `bun typecheck` in `packages/opencode`: clean
- `bunx tsgo --noEmit` and `bun test` in `packages/tui` for the /yolo change: 198 pass

### Screenshots / recordings

N/A (CLI; end-to-end output requires live provider credentials)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--best-of` option to compare responses from multiple model candidates.
  * Runs candidates in parallel and selects the strongest response through automated ranking.
  * Supports human-readable and JSON output, with fallback handling when ranking is unavailable.
  * Validates candidate lists and prevents use with incompatible interactive or session modes.

* **Tests**
  * Added coverage for candidate parsing, ranking, output selection, and invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
