### PR TITLE
feat(tui): /todos command to view the agent task list

### DIFF
--- a/packages/tui/src/component/dialog-todos.tsx
+++ b/packages/tui/src/component/dialog-todos.tsx
@@ -1,0 +1,43 @@
+import { TextAttributes } from "@opentui/core"
+import { For, Show, createMemo } from "solid-js"
+import { useTheme } from "../context/theme"
+import { useDialog } from "../ui/dialog"
+import { useSync } from "../context/sync"
+import { TodoItem } from "./todo-item"
+
+export type DialogTodosProps = {
+  sessionID: string
+}
+
+// Live view of the agent's task list for a session. todo.updated events write
+// straight into the sync store, so the dialog refreshes in place while the
+// agent works. Unlike the sidebar panel, this shows the full list, including
+// completed items, and works on narrow terminals.
+export function DialogTodos(props: DialogTodosProps) {
+  const sync = useSync()
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  const todos = createMemo(() => sync.data.todo[props.sessionID] ?? [])
+  const done = createMemo(() => todos().filter((item) => item.status === "completed").length)
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          Todos
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+          esc
+        </text>
+      </box>
+      <Show when={todos().length > 0} fallback={<text fg={theme.textMuted}>No todos in this session yet</text>}>
+        <box>
+          <For each={todos()}>{(item) => <TodoItem status={item.status} content={item.content} />}</For>
+        </box>
+        <text fg={theme.textMuted}>
+          {done()}/{todos().length} completed
+        </text>
+      </Show>
+    </box>
+  )
+}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -53,6 +53,7 @@ import { DialogConfirm } from "../../ui/dialog-confirm"
 import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
+import { DialogTodos } from "../../component/dialog-todos"
 import { Sidebar } from "./sidebar"
 import { SubagentFooter } from "./subagent-footer.tsx"
 import { filetype } from "../../util/filetype"
@@ -505,6 +506,18 @@ export function Session() {
       },
       run: () => {
         dialog.replace(() => <DialogSessionRename session={route.sessionID} />)
+      },
+    },
+    {
+      title: "View todos",
+      value: "session.todos",
+      category: "Session",
+      slash: {
+        name: "todos",
+        aliases: ["todo"],
+      },
+      run: () => {
+        dialog.replace(() => <DialogTodos sessionID={route.sessionID} />)
       },
     },
     {


### PR DESCRIPTION
### Issue for this PR

Closes #70

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `/todos` (alias `/todo`) to the TUI: a dialog showing the agent's live task list for the current session. Everything below the dialog already existed (the `todowrite` tool, the `todo` table, the `todo.updated` SSE event, and the sync store's `todo` map), so the dialog is a pure read of reactive state and updates in place while the agent works, no polling:

```tsx
const todos = createMemo(() => sync.data.todo[props.sessionID] ?? [])
// ...
<Show when={todos().length > 0} fallback={<text fg={theme.textMuted}>No todos in this session yet</text>}>
  <box>
    <For each={todos()}>{(item) => <TodoItem status={item.status} content={item.content} />}</For>
  </box>
  <text fg={theme.textMuted}>{done()}/{todos().length} completed</text>
</Show>
```

Unlike the existing sidebar todo panel, which hides itself once every item is completed and needs a wide terminal (or the overlay toggle), the dialog shows the full list including completed items and works at any width. Rows reuse the existing `TodoItem` component so styling stays consistent with the sidebar and transcript renderings.

### How did you verify your code works?

- `bunx tsgo --noEmit` in `packages/tui`: clean
- `bun test` in `packages/tui`: 198 pass

### Screenshots / recordings

N/A (dialog reuses the existing TodoItem rows; no new visual language)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live todo list dialog for sessions, showing completed items and progress counts.
  * Added `/todos` and `/todo` commands to open the todo list for the current session.
  * Added an empty state and escape control for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->