### PR TITLE
feat(tui): /btw side questions without interrupting the task

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -570,13 +570,19 @@ export function Session() {
         // Fork the session so the side question sees the conversation so far;
         // the fork runs on its own per-session runner, so the original run
         // keeps streaming untouched.
-        const fork = await sdk.client.session.fork({ sessionID: route.sessionID }).catch(() => undefined)
+        const fork = await sdk.client.session.fork({ sessionID: route.sessionID }).catch((error) => {
+          toast.show({
+            variant: "error",
+            message: error instanceof Error ? `btw: ${error.message}` : "btw: failed to fork the session",
+            duration: 5000,
+          })
+        })
         const id = fork?.data?.id
         if (!id) {
-          toast.show({ variant: "error", message: "btw: failed to fork the session", duration: 5000 })
+          if (fork) toast.show({ variant: "error", message: "btw: failed to fork the session", duration: 5000 })
           return
         }
-        void sdk.client.session.update({ sessionID: id, title: `btw: ${label}` })
+        void sdk.client.session.update({ sessionID: id, title: `btw: ${label}` }).catch(() => {})
         toast.show({ variant: "info", message: `btw: thinking about "${label}"`, duration: 5000 })
         const result = await sdk.client.session
           .prompt({
@@ -588,8 +594,15 @@ export function Session() {
               },
             ],
           })
-          .catch(() => undefined)
-        const answer = (result?.data?.parts ?? [])
+          .catch((error) => {
+            toast.show({
+              variant: "error",
+              message: error instanceof Error ? `btw: ${error.message}` : "btw: no answer came back",
+              duration: 5000,
+            })
+          })
+        if (!result) return
+        const answer = (result.data?.parts ?? [])
           .flatMap((part) => (part.type === "text" ? [part.text] : []))
           .join("\n\n")
           .trim()

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -582,7 +582,8 @@ export function Session() {
           if (fork) toast.show({ variant: "error", message: "btw: failed to fork the session", duration: 5000 })
           return
         }
-        void sdk.client.session.update({ sessionID: id, title: `btw: ${label}` }).catch(() => {})
+        // Best-effort rename; a failed title update should not block the side question.
+        void sdk.client.session.update({ sessionID: id, title: `btw: ${label}` }).catch(() => undefined)
         toast.show({ variant: "info", message: `btw: thinking about "${label}"`, duration: 5000 })
         const result = await sdk.client.session
           .prompt({

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -53,6 +53,7 @@ import { DialogConfirm } from "../../ui/dialog-confirm"
 import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
+import { DialogPrompt } from "../../ui/dialog-prompt"
 import { Sidebar } from "./sidebar"
 import { SubagentFooter } from "./subagent-footer.tsx"
 import { filetype } from "../../util/filetype"
@@ -549,6 +550,54 @@ export function Session() {
             sessionID={route.sessionID}
           />
         ))
+      },
+    },
+    {
+      title: "Ask a side question",
+      value: "session.btw",
+      category: "Session",
+      slash: {
+        name: "btw",
+        aliases: ["aside"],
+      },
+      run: async () => {
+        const question = await DialogPrompt.show(dialog, "Side Question", {
+          placeholder: "Ask without interrupting the running task",
+        })
+        if (!question?.trim()) return
+        dialog.clear()
+        const label = question.length > 40 ? question.slice(0, 40) + "..." : question
+        // Fork the session so the side question sees the conversation so far;
+        // the fork runs on its own per-session runner, so the original run
+        // keeps streaming untouched.
+        const fork = await sdk.client.session.fork({ sessionID: route.sessionID }).catch(() => undefined)
+        const id = fork?.data?.id
+        if (!id) {
+          toast.show({ variant: "error", message: "btw: failed to fork the session", duration: 5000 })
+          return
+        }
+        void sdk.client.session.update({ sessionID: id, title: `btw: ${label}` })
+        toast.show({ variant: "info", message: `btw: thinking about "${label}"`, duration: 5000 })
+        const result = await sdk.client.session
+          .prompt({
+            sessionID: id,
+            parts: [
+              {
+                type: "text",
+                text: `The user has a side question about the work above. Answer it directly and concisely. Do not modify any files or continue the task; the original session is handling it.\n\n${question}`,
+              },
+            ],
+          })
+          .catch(() => undefined)
+        const answer = (result?.data?.parts ?? [])
+          .flatMap((part) => (part.type === "text" ? [part.text] : []))
+          .join("\n\n")
+          .trim()
+        if (!answer) {
+          toast.show({ variant: "error", message: "btw: no answer came back", duration: 5000 })
+          return
+        }
+        void DialogAlert.show(dialog, `btw: ${label}`, answer)
       },
     },
     {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -566,7 +566,7 @@ export function Session() {
         })
         if (!question?.trim()) return
         dialog.clear()
-        const label = question.length > 40 ? question.slice(0, 40) + "..." : question
+        const label = question.length > 40 ? `${question.slice(0, 40)}...` : question
         // Fork the session so the side question sees the conversation so far;
         // the fork runs on its own per-session runner, so the original run
         // keeps streaming untouched.


### PR DESCRIPTION
### Issue for this PR

Closes #71

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `/btw` (alias `/aside`) to the TUI: while the agent is mid-task, ask a question and get an answer without steering or interrupting the run. The command captures the question in a prompt dialog, forks the current session so the side question sees the conversation so far, and prompts the fork; run loops are keyed per session, so the fork answers concurrently while the original session keeps streaming untouched. The answer pops in an alert dialog when it arrives:

```tsx
// Fork the session so the side question sees the conversation so far;
// the fork runs on its own per-session runner, so the original run
// keeps streaming untouched.
const fork = await sdk.client.session.fork({ sessionID: route.sessionID })
// ...
const result = await sdk.client.session.prompt({
  sessionID: fork.data.id,
  parts: [{ type: "text", text: `The user has a side question about the work above. ...` }],
})
void DialogAlert.show(dialog, `btw: ${label}`, answer)
```

Details a reviewer can't infer from the diff:

- `session.fork` has no busy assertion server-side; mid-run it snapshots whatever messages are committed, which is exactly the context a side question wants.
- The fork inherits the model from the copied last user message (server model resolution), so no model wiring is needed; the question text also instructs the model to answer directly and not touch files, since the original session owns the task.
- The fork is retitled `btw: <question>`, so if the answer dialog is dismissed (or the toast is missed) the full markdown-rendered answer is one `/sessions` away.
- Failure modes degrade to toasts (fork failed, no answer came back); a dismissed or empty prompt dialog is a no-op.

### How did you verify your code works?

- `bunx tsgo --noEmit` in `packages/tui`: clean
- `bun test` in `packages/tui`: 198 pass

### Screenshots / recordings

N/A (uses the existing DialogPrompt / DialogAlert components)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/btw` and `/aside` commands for asking side questions during a session.
  * Side questions are handled separately without modifying files or interrupting the original task.
  * Added progress and completion feedback while side questions are processed.

* **Bug Fixes**
  * Added clear error notifications when side-question sessions fail or produce no response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->