### PR TITLE
fix(tui): calm the fire while the autocomplete popup is open

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1398,6 +1398,10 @@ export function Prompt(props: PromptProps) {
     fire,
     () => rgbToHex(theme.primary),
   )
+  // The autocomplete popup floats over the fire strip; blank the flames while
+  // it is open (keeping the rows so the layout does not jump) so the list is
+  // readable, and let them roar back when it closes.
+  const calm = createMemo(() => (auto()?.visible ? flames().map((row) => row.map(() => ({ char: " " }))) : flames()))
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined
@@ -1440,7 +1444,7 @@ export function Prompt(props: PromptProps) {
     <>
       <box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
         <Show when={fire()}>
-          <FireStrip rows={flames()} />
+          <FireStrip rows={calm()} />
         </Show>
         <box
           width="100%"


### PR DESCRIPTION
### Issue for this PR

Closes #74

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Typing `/` while an agent is running opens the slash-command autocomplete popup right on top of the fire strip, with the flames animating behind the list. The popup is anchored above the input, and the fire strip occupies exactly that space.

The fix keeps the strip mounted but feeds it blank cells while the popup is open:

```tsx
const calm = createMemo(() => (auto()?.visible ? flames().map((row) => row.map(() => ({ char: " " }))) : flames()))
...
<FireStrip rows={calm()} />
```

Keeping the rows (rather than unmounting the strip) matters: unmounting would shrink the prompt block by 16 rows and reflow the whole transcript every time you type `/`. Blanking the cells keeps the layout stable, so the popup floats over quiet space and the flames come back the instant the popup closes. The fire engine keeps ticking behind the scenes, so there is no re-ignite delay.

### How did you verify your code works?

- `bun typecheck` in `packages/tui`
- Ran the TUI, started a run, typed `/` — the fire blanks out while the popup is open and resumes immediately on close, with no layout shift.

### Screenshots / recordings

Terminal UI change; behavior described above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->