### PR TITLE
fix(tui): show /btw answers inline in the chat instead of a dialog

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -253,6 +253,9 @@ export function Session() {
   const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")
   const [sidebarOpen, setSidebarOpen] = createSignal(false)
   const [conceal, setConceal] = createSignal(true)
+  // Side questions asked via /btw, rendered inline at the end of the transcript.
+  const [asides, setAsides] = createSignal<{ id: number; question: string; answer?: string; error?: string }[]>([])
+  let serial = 0
   const thinking = useThinkingMode()
   const thinkingMode = thinking.mode
   const showThinking = createMemo(() => true)
@@ -582,27 +585,26 @@ export function Session() {
         if (!question?.trim()) return
         dialog.clear()
         const label = question.length > 40 ? `${question.slice(0, 40)}...` : question
+        const id = serial++
+        const patch = (delta: { answer?: string; error?: string }) =>
+          setAsides((list) => list.map((item) => (item.id === id ? { ...item, ...delta } : item)))
+        setAsides((list) => [...list, { id, question }])
         // Fork the session so the side question sees the conversation so far;
         // the fork runs on its own per-session runner, so the original run
         // keeps streaming untouched.
         const fork = await sdk.client.session.fork({ sessionID: route.sessionID }).catch((error) => {
-          toast.show({
-            variant: "error",
-            message: error instanceof Error ? `btw: ${error.message}` : "btw: failed to fork the session",
-            duration: 5000,
-          })
+          patch({ error: error instanceof Error ? error.message : "failed to fork the session" })
         })
-        const id = fork?.data?.id
-        if (!id) {
-          if (fork) toast.show({ variant: "error", message: "btw: failed to fork the session", duration: 5000 })
+        const forkID = fork?.data?.id
+        if (!forkID) {
+          if (fork) patch({ error: "failed to fork the session" })
           return
         }
         // Best-effort rename; a failed title update should not block the side question.
-        void sdk.client.session.update({ sessionID: id, title: `btw: ${label}` }).catch(() => undefined)
-        toast.show({ variant: "info", message: `btw: thinking about "${label}"`, duration: 5000 })
+        void sdk.client.session.update({ sessionID: forkID, title: `btw: ${label}` }).catch(() => undefined)
         const result = await sdk.client.session
           .prompt({
-            sessionID: id,
+            sessionID: forkID,
             parts: [
               {
                 type: "text",
@@ -611,11 +613,7 @@ export function Session() {
             ],
           })
           .catch((error) => {
-            toast.show({
-              variant: "error",
-              message: error instanceof Error ? `btw: ${error.message}` : "btw: no answer came back",
-              duration: 5000,
-            })
+            patch({ error: error instanceof Error ? error.message : "no answer came back" })
           })
         if (!result) return
         const answer = (result.data?.parts ?? [])
@@ -623,10 +621,10 @@ export function Session() {
           .join("\n\n")
           .trim()
         if (!answer) {
-          toast.show({ variant: "error", message: "btw: no answer came back", duration: 5000 })
+          patch({ error: "no answer came back" })
           return
         }
-        void DialogAlert.show(dialog, `btw: ${label}`, answer)
+        patch({ answer })
       },
     },
     {
@@ -1357,6 +1355,36 @@ export function Session() {
                         />
                       </Match>
                     </Switch>
+                  )}
+                </For>
+                <For each={asides()}>
+                  {(item) => (
+                    <box
+                      marginTop={1}
+                      flexShrink={0}
+                      border={["left"]}
+                      customBorderChars={SplitBorder.customBorderChars}
+                      borderColor={theme.backgroundPanel}
+                    >
+                      <box paddingTop={1} paddingBottom={1} paddingLeft={2} backgroundColor={theme.backgroundPanel}>
+                        <text fg={theme.textMuted}>
+                          btw: <span style={{ fg: theme.text }}>{item.question}</span>
+                        </text>
+                        <box marginTop={1}>
+                          <Switch>
+                            <Match when={item.error}>
+                              <text fg={theme.error}>{item.error}</text>
+                            </Match>
+                            <Match when={item.answer}>
+                              <text fg={theme.text}>{item.answer}</text>
+                            </Match>
+                            <Match when={true}>
+                              <text fg={theme.textMuted}>thinking...</text>
+                            </Match>
+                          </Switch>
+                        </box>
+                      </box>
+                    </box>
                   )}
                 </For>
               </scrollbox>


### PR DESCRIPTION
### Issue for this PR

Closes #76

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`/btw` answered side questions in a modal alert dialog: it blocked the view of the running session and the answer vanished on dismiss. Now each side question becomes an inline block appended to the end of the transcript, tracked in a small signal on the session route:

```tsx
const [asides, setAsides] = createSignal<{ id: number; question: string; answer?: string; error?: string }[]>([])
```

The command pushes an entry as soon as the question is submitted (shown as `btw: <question>` with a "thinking..." state), then patches it in place with the answer or an error message when the forked session responds. The block is rendered inside the scrollbox after the messages, styled like the existing revert notice, so it scrolls with the conversation and the sticky-bottom scroll keeps it in view while the main run streams. The fork/prompt flow itself is unchanged; the error and "thinking" toasts are gone since the inline block covers both states.

Entries are client-side only and reset when you leave the session — same lifetime the dialog had, minus the interruption.

### How did you verify your code works?

- `bun typecheck` and `bun test` in `packages/tui` (198 pass)
- Ran the TUI, asked `/btw` questions during a run: the block appears at the bottom of the chat with "thinking...", fills in with the answer, and error paths (fork/prompt failure) render inline.

### Screenshots / recordings

Terminal UI change; behavior described above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->