### PR TITLE
fix(tui): anchor the slash palette to the input, not above the fire

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1442,10 +1442,14 @@ export function Prompt(props: PromptProps) {
 
   return (
     <>
+      {/* Outside the anchor box on purpose: the autocomplete palette renders
+          above the anchor, so keeping the fire out of it lets the palette sit
+          flush against the input and overlay the (calmed) flames instead of
+          floating above the whole strip. */}
+      <Show when={props.visible !== false && fire()}>
+        <FireStrip rows={calm()} />
+      </Show>
       <box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
-        <Show when={fire()}>
-          <FireStrip rows={calm()} />
-        </Show>
         <box
           width="100%"
           border={["left"]}

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1398,11 +1398,6 @@ export function Prompt(props: PromptProps) {
     fire,
     () => rgbToHex(theme.primary),
   )
-  // The autocomplete popup floats over the fire strip; blank the flames while
-  // it is open (keeping the rows so the layout does not jump) so the list is
-  // readable, and let them roar back when it closes.
-  const calm = createMemo(() => (auto()?.visible ? flames().map((row) => row.map(() => ({ char: " " }))) : flames()))
-
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined
     if (store.mode === "shell") {
@@ -1444,10 +1439,10 @@ export function Prompt(props: PromptProps) {
     <>
       {/* Outside the anchor box on purpose: the autocomplete palette renders
           above the anchor, so keeping the fire out of it lets the palette sit
-          flush against the input and overlay the (calmed) flames instead of
-          floating above the whole strip. */}
+          flush against the input and cover the flames instead of floating
+          above the whole strip. */}
       <Show when={props.visible !== false && fire()}>
-        <FireStrip rows={calm()} />
+        <FireStrip rows={flames()} />
       </Show>
       <box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
         <box


### PR DESCRIPTION
### Issue for this PR

Closes #80

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The autocomplete palette positions itself above its anchor box (`top = anchor.y - height` in `autocomplete.tsx`), and the fire strip lived *inside* that anchor box. So while an agent is running, the palette floated 16 rows above the input, stacked on top of the whole fire strip instead of sitting next to the prompt.

The fix moves the FireStrip out of the anchor box, making it a preceding sibling:

```tsx
<Show when={props.visible !== false && fire()}>
  <FireStrip rows={flames()} />
</Show>
<box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
```

The anchor now starts at the input box, so the palette renders flush against the input and covers the fire rows behind its background. This also reverts the flame-blanking from #75: the fire keeps burning at full intensity around and above the palette, which was the preferred look; the palette's solid background is what keeps the list readable. The palette repositions automatically when the fire ignites or dies since the autocomplete already polls anchor coordinates.

### How did you verify your code works?

- `bun typecheck` and `bun test` in `packages/tui` (198 pass)
- Ran the TUI with a run in progress, typed `/`: the palette sits directly above the input over the fire area with the flames still burning around it, no more floating gap.

### Screenshots / recordings

Terminal UI change; behavior described above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt animations by positioning the fire effect outside the prompt’s anchor area.
  * The fire effect now appears only when the prompt is visible and animations are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->