### PR TITLE
feat(tui): make /btw a sticky prompt mode instead of a question dialog

### DIFF
--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -182,7 +182,7 @@ export type TuiDialogSelectProps<Value = unknown> = {
 
 export type TuiPromptInfo = {
   input: string
-  mode?: "normal" | "shell"
+  mode?: "normal" | "shell" | "btw"
   parts: (
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -73,6 +73,7 @@ export type PromptProps = {
   visible?: boolean
   disabled?: boolean
   onSubmit?: () => void
+  onAside?: (question: string) => void
   ref?: (ref: PromptRef | undefined) => void
   hint?: JSX.Element
   right?: JSX.Element
@@ -102,6 +103,9 @@ export type PromptRef = {
   blur(): void
   focus(): void
   submit(): void
+  // Optional so plugin-provided prompt replacements without side-question
+  // support still satisfy the ref.
+  aside?(): void
 }
 
 const money = new Intl.NumberFormat("en-US", {
@@ -299,7 +303,7 @@ export function Prompt(props: PromptProps) {
 
   const [store, setStore] = createStore<{
     prompt: PromptInfo
-    mode: "normal" | "shell"
+    mode: "normal" | "shell" | "btw"
     extmarkToPartIndex: Map<number, number>
     interrupt: number
     placeholder: number
@@ -415,7 +419,7 @@ export function Prompt(props: PromptProps) {
           if (auto()?.visible) return
           if (!input.focused) return
           // TODO: this should be its own command
-          if (store.mode === "shell") {
+          if (store.mode !== "normal") {
             setStore("mode", "normal")
             return
           }
@@ -647,6 +651,10 @@ export function Prompt(props: PromptProps) {
     },
     submit() {
       void submit()
+    },
+    aside() {
+      setStore("mode", "btw")
+      input.focus()
     },
   }
 
@@ -884,8 +892,8 @@ export function Prompt(props: PromptProps) {
   useBindings(() => {
     return {
       target: inputTarget,
-      enabled: inputTarget() !== undefined && store.mode === "shell",
-      bindings: [{ key: "escape", desc: "Exit shell mode", group: "Prompt", cmd: () => setStore("mode", "normal") }],
+      enabled: inputTarget() !== undefined && store.mode !== "normal",
+      bindings: [{ key: "escape", desc: "Exit mode", group: "Prompt", cmd: () => setStore("mode", "normal") }],
     }
   })
 
@@ -894,9 +902,9 @@ export function Prompt(props: PromptProps) {
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
-        return inputTarget() !== undefined && store.mode === "shell" && input?.visualCursor.offset === 0
+        return inputTarget() !== undefined && store.mode !== "normal" && input?.visualCursor.offset === 0
       })(),
-      bindings: [{ key: "backspace", desc: "Exit shell mode", group: "Prompt", cmd: () => setStore("mode", "normal") }],
+      bindings: [{ key: "backspace", desc: "Exit mode", group: "Prompt", cmd: () => setStore("mode", "normal") }],
     }
   })
 
@@ -1122,7 +1130,12 @@ export function Prompt(props: PromptProps) {
           ]
         : []
 
-    if (store.mode === "shell") {
+    if (store.mode === "btw") {
+      // Sticky side-question mode: each submission becomes its own fork; the
+      // mode stays active until esc so follow-ups don't need /btw again.
+      if (!inputText.trim()) return true
+      props.onAside?.(inputText)
+    } else if (store.mode === "shell") {
       move.startSubmit()
       void sdk.client.session.shell({
         sessionID,
@@ -1405,6 +1418,7 @@ export function Prompt(props: PromptProps) {
       const example = shell()[store.placeholder % shell().length]
       return `Run a command... "${example}"`
     }
+    if (store.mode === "btw") return "Ask a side question... esc to exit"
     if (!list().length) return undefined
     return `Ask anything... "${list()[store.placeholder % list().length]}"`
   })
@@ -1548,7 +1562,7 @@ export function Prompt(props: PromptProps) {
                   {(agent) => (
                     <>
                       <text fg={fadeColor(highlight(), agentMetaAlpha())}>
-                        {store.mode === "shell" ? "Shell" : Locale.titlecase(agent().name)}
+                        {store.mode === "shell" ? "Shell" : store.mode === "btw" ? "Btw" : Locale.titlecase(agent().name)}
                       </text>
                       <Show when={store.mode === "normal" && local.permission.mode === "auto"}>
                         <text fg={fadeColor(theme.textMuted, agentMetaAlpha())}>auto</text>

--- a/packages/tui/src/prompt/history.tsx
+++ b/packages/tui/src/prompt/history.tsx
@@ -8,7 +8,7 @@ import { appendText, readText, writeText } from "../util/persistence"
 
 export type PromptInfo = {
   input: string
-  mode?: "normal" | "shell"
+  mode?: "normal" | "shell" | "btw"
   parts: (
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">

--- a/packages/tui/src/prompt/traits.ts
+++ b/packages/tui/src/prompt/traits.ts
@@ -1,6 +1,6 @@
 import type { EditorTraits } from "@opentui/core"
 
-export type PromptMode = "normal" | "shell"
+export type PromptMode = "normal" | "shell" | "btw"
 
 export interface PromptTraitsInput {
   mode: PromptMode
@@ -22,7 +22,7 @@ export function computePromptTraits(input: PromptTraitsInput): PromptTraits {
       : undefined
   return {
     capture,
-    status: input.mode === "shell" ? "SHELL" : undefined,
+    status: input.mode === "shell" ? "SHELL" : input.mode === "btw" ? "BTW" : undefined,
     owner: "opencode",
     role: "prompt",
   }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -54,7 +54,6 @@ import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
 
-import { DialogPrompt } from "../../ui/dialog-prompt"
 import { DialogTodos } from "../../component/dialog-todos"
 
 import { Sidebar } from "./sidebar"
@@ -256,6 +255,49 @@ export function Session() {
   // Side questions asked via /btw, rendered inline at the end of the transcript.
   const [asides, setAsides] = createSignal<{ id: number; question: string; answer?: string; error?: string }[]>([])
   let serial = 0
+  const aside = async (question: string) => {
+    const label = question.length > 40 ? `${question.slice(0, 40)}...` : question
+    const id = serial++
+    const patch = (delta: { answer?: string; error?: string }) =>
+      setAsides((list) => list.map((item) => (item.id === id ? { ...item, ...delta } : item)))
+    setAsides((list) => [...list, { id, question }])
+    // Fork the session so the side question sees the conversation so far;
+    // the fork runs on its own per-session runner, so the original run
+    // keeps streaming untouched.
+    const fork = await sdk.client.session.fork({ sessionID: route.sessionID }).catch((error) => {
+      patch({ error: error instanceof Error ? error.message : "failed to fork the session" })
+    })
+    const forkID = fork?.data?.id
+    if (!forkID) {
+      if (fork) patch({ error: "failed to fork the session" })
+      return
+    }
+    // Best-effort rename; a failed title update should not block the side question.
+    void sdk.client.session.update({ sessionID: forkID, title: `btw: ${label}` }).catch(() => undefined)
+    const result = await sdk.client.session
+      .prompt({
+        sessionID: forkID,
+        parts: [
+          {
+            type: "text",
+            text: `The user has a side question about the work above. Answer it directly and concisely. Do not modify any files or continue the task; the original session is handling it.\n\n${question}`,
+          },
+        ],
+      })
+      .catch((error) => {
+        patch({ error: error instanceof Error ? error.message : "no answer came back" })
+      })
+    if (!result) return
+    const answer = (result.data?.parts ?? [])
+      .flatMap((part) => (part.type === "text" ? [part.text] : []))
+      .join("\n\n")
+      .trim()
+    if (!answer) {
+      patch({ error: "no answer came back" })
+      return
+    }
+    patch({ answer })
+  }
   const thinking = useThinkingMode()
   const thinkingMode = thinking.mode
   const showThinking = createMemo(() => true)
@@ -578,53 +620,9 @@ export function Session() {
         name: "btw",
         aliases: ["aside"],
       },
-      run: async () => {
-        const question = await DialogPrompt.show(dialog, "Side Question", {
-          placeholder: "Ask without interrupting the running task",
-        })
-        if (!question?.trim()) return
+      run: () => {
         dialog.clear()
-        const label = question.length > 40 ? `${question.slice(0, 40)}...` : question
-        const id = serial++
-        const patch = (delta: { answer?: string; error?: string }) =>
-          setAsides((list) => list.map((item) => (item.id === id ? { ...item, ...delta } : item)))
-        setAsides((list) => [...list, { id, question }])
-        // Fork the session so the side question sees the conversation so far;
-        // the fork runs on its own per-session runner, so the original run
-        // keeps streaming untouched.
-        const fork = await sdk.client.session.fork({ sessionID: route.sessionID }).catch((error) => {
-          patch({ error: error instanceof Error ? error.message : "failed to fork the session" })
-        })
-        const forkID = fork?.data?.id
-        if (!forkID) {
-          if (fork) patch({ error: "failed to fork the session" })
-          return
-        }
-        // Best-effort rename; a failed title update should not block the side question.
-        void sdk.client.session.update({ sessionID: forkID, title: `btw: ${label}` }).catch(() => undefined)
-        const result = await sdk.client.session
-          .prompt({
-            sessionID: forkID,
-            parts: [
-              {
-                type: "text",
-                text: `The user has a side question about the work above. Answer it directly and concisely. Do not modify any files or continue the task; the original session is handling it.\n\n${question}`,
-              },
-            ],
-          })
-          .catch((error) => {
-            patch({ error: error instanceof Error ? error.message : "no answer came back" })
-          })
-        if (!result) return
-        const answer = (result.data?.parts ?? [])
-          .flatMap((part) => (part.type === "text" ? [part.text] : []))
-          .join("\n\n")
-          .trim()
-        if (!answer) {
-          patch({ error: "no answer came back" })
-          return
-        }
-        patch({ answer })
+        prompt?.aside?.()
       },
     },
     {
@@ -1420,6 +1418,10 @@ export function Session() {
                       disabled={disabled()}
                       onSubmit={() => {
                         toBottom()
+                      }}
+                      onAside={(question) => {
+                        toBottom()
+                        void aside(question)
                       }}
                       sessionID={route.sessionID}
                       right={<pluginRuntime.Slot name="session_prompt_right" session_id={route.sessionID} />}


### PR DESCRIPTION
### Issue for this PR

Closes #83

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`/btw` still popped a dialog to type the side question, and you had to re-run it for every question. Now `/btw` flips the normal chat box into a sticky "btw" mode, modeled on the existing shell mode:

```ts
if (store.mode === "btw") {
  // Sticky side-question mode: each submission becomes its own fork; the
  // mode stays active until esc so follow-ups don't need /btw again.
  if (!inputText.trim()) return true
  props.onAside?.(inputText)
}
```

While in btw mode the agent label reads "Btw", the placeholder says "Ask a side question... esc to exit", and every submitted line goes through the new `onAside` prop to the session route, which runs the same fork-and-ask flow as before and renders the answer inline in the transcript. The mode stays active across submissions so you can fire off several side questions; esc (or backspace on an empty prompt) returns to normal, matching shell-mode ergonomics, and interrupt-escape also exits the mode. The question dialog is gone entirely.

`aside()` was added to `PromptRef` as optional so plugin-provided prompt replacements (`TuiPromptRef` in `packages/plugin`) still satisfy the ref; the plugin's `TuiPromptInfo.mode` union gains `"btw"` so drafts saved from btw mode stay typed.

### How did you verify your code works?

- `bun typecheck` and `bun test` in `packages/tui` (198 pass), `bun run typecheck` in `packages/plugin`
- Ran the TUI: `/btw` switches the chat box into btw mode with no popup, multiple consecutive questions each fork and answer inline, esc returns to normal prompting.

### Screenshots / recordings

Terminal UI change; behavior described above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->