### PR TITLE
feat(core): support .boltignore for agent file search

### DIFF
--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -1,5 +1,7 @@
 export * as Ripgrep from "./ripgrep"
 
+import fs from "node:fs"
+import path from "node:path"
 import { Context, Effect, Fiber, Layer, Schema, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { Entry, Match } from "@opencode-ai/schema/filesystem"
@@ -18,6 +20,23 @@ import { RipgrepBinary } from "./ripgrep/binary"
 const ERROR_BYTES = 8 * 1024
 const MAX_RECORD_BYTES = 64 * 1024
 const MAX_SUBMATCHES = 100
+
+// Extra agent-only ignore rules: .boltignore uses .gitignore syntax and hides
+// committed files from search without touching .gitignore. Collected from the
+// search cwd up to the repo root so subdirectory searches still respect it.
+function ignores(cwd: string) {
+  const found: string[] = []
+  let dir = cwd
+  while (true) {
+    const file = path.join(dir, ".boltignore")
+    if (fs.existsSync(file)) found.push(`--ignore-file=${file}`)
+    if (fs.existsSync(path.join(dir, ".git"))) break
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return found
+}
 
 const RawMatch = Schema.Struct({
   type: Schema.Literal("match"),
@@ -160,6 +179,7 @@ const layer = Layer.effect(
           args: [
             "--no-config",
             "--files",
+            ...ignores(input.cwd),
             ...(input.hidden ? ["--hidden"] : []),
             ...(input.follow ? ["--follow"] : []),
             `--glob=${input.pattern}`,
@@ -192,6 +212,7 @@ const layer = Layer.effect(
           args: [
             "--no-config",
             "--files",
+            ...ignores(input.cwd),
             ...(input.hidden ? ["--hidden"] : []),
             ...(input.follow ? ["--follow"] : []),
             ...(input.pattern === "*" ? [] : [`--glob=${input.pattern}`]),
@@ -223,6 +244,7 @@ const layer = Layer.effect(
             "--json",
             "--hidden",
             "--no-messages",
+            ...ignores(input.cwd),
             ...(input.include ? [`--glob=${input.include}`] : []),
             "--glob=!**/.git/**",
             "--",

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -31,6 +31,34 @@ describe("Ripgrep", () => {
     ),
   )
 
+  it.live("respects .boltignore for find and grep, including from subdirectories", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => fs.mkdir(path.join(tmp.path, "src")))
+          yield* Effect.promise(() => Bun.$`git init -q ${tmp.path}`)
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, ".boltignore"), "hidden.txt\n"))
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "src", "hidden.txt"), "needle\n"))
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "src", "shown.txt"), "needle\n"))
+          const ripgrep = yield* Ripgrep.Service
+
+          const files = yield* ripgrep.find({ cwd: tmp.path, pattern: "*", limit: 10 })
+          expect(files.map((item) => item.path)).toContain(RelativePath.make("src/shown.txt"))
+          expect(files.map((item) => item.path)).not.toContain(RelativePath.make("src/hidden.txt"))
+
+          const matches = yield* ripgrep.grep({ cwd: tmp.path, pattern: "needle", limit: 10 })
+          expect(matches.map((item) => item.entry.path)).toContain(RelativePath.make("src/shown.txt"))
+          expect(matches.map((item) => item.entry.path)).not.toContain(RelativePath.make("src/hidden.txt"))
+
+          const nested = yield* ripgrep.find({ cwd: path.join(tmp.path, "src"), pattern: "*", limit: 10 })
+          expect(nested.map((item) => item.path)).toContain(RelativePath.make("shown.txt"))
+          expect(nested.map((item) => item.path)).not.toContain(RelativePath.make("hidden.txt"))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("never includes git metadata", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -79,6 +79,10 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
             .readFileString(path.join(location.project.directory, ".ignore"))
             .pipe(Effect.catch(() => Effect.succeed("")))
           if (ignorefile) ignored.add(ignorefile)
+          const boltignore = yield* raw
+            .readFileString(path.join(location.project.directory, ".boltignore"))
+            .pipe(Effect.catch(() => Effect.succeed("")))
+          if (boltignore) ignored.add(boltignore)
           return (yield* fs.list({ path: RelativePath.make(ctx.query.path) })).map((item) => ({
             name: path.basename(item.path),
             path: item.path,


### PR DESCRIPTION
### Issue for this PR

Closes #86

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `.boltignore` (inspired by Crush's `.crushignore`): a `.gitignore`-syntax file for things you *do* commit but don't want the agent to read as context (fixtures, generated snapshots, vendored blobs). All agent search funnels through the `Ripgrep` service, so the change is one helper wired into the three arg builders (glob/find/grep):

```ts
// Extra agent-only ignore rules: .boltignore uses .gitignore syntax and hides
// committed files from search without touching .gitignore. Collected from the
// search cwd up to the repo root so subdirectory searches still respect it.
function ignores(cwd: string) {
  const found: string[] = []
  let dir = cwd
  while (true) {
    const file = path.join(dir, ".boltignore")
    if (fs.existsSync(file)) found.push(`--ignore-file=${file}`)
    if (fs.existsSync(path.join(dir, ".git"))) break
    const parent = path.dirname(dir)
    if (parent === dir) break
    dir = parent
  }
  return found
}
```

Walking up to the repo root matters because the grep/glob tools can search from a subdirectory; a root-level `.boltignore` still applies there. The HTTP `file.list` handler also reads `.boltignore` next to its existing `.gitignore`/`.ignore` reads so the file tree flags matching entries as ignored.

Known limitation: the fff fuzzy-find fast path picks its layer at startup without location context, so UI fuzzy file search doesn't consult `.boltignore` yet; the agent-facing grep/glob/find tools all go through ripgrep and do.

### How did you verify your code works?

- New test in `packages/core/test/ripgrep.test.ts` covering find, grep, and a subdirectory search picking up the parent `.boltignore` (3/3 pass)
- Verified the raw rg flag behavior manually (`--ignore-file` hides matching files, absent flag leaks them)
- `bun typecheck` in `packages/core` and `packages/opencode`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `.boltignore` support for file search, discovery, and listing operations.
  * Ignore rules apply from the search location through the repository root, including nested directories.
  * Existing `.gitignore` behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->