### PR TITLE
feat(cli): add bolt logs command with tail and follow

### DIFF
--- a/packages/opencode/src/cli/cmd/logs.ts
+++ b/packages/opencode/src/cli/cmd/logs.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs"
+import path from "node:path"
+import { Effect } from "effect"
+import { Global } from "@opencode-ai/core/global"
+import { effectCmd, fail } from "../effect-cmd"
+
+const FILE = path.join(Global.Path.log, "opencode.log")
+
+export const LogsCommand = effectCmd({
+  command: "logs",
+  describe: "print the agent log",
+  instance: false,
+  builder: (yargs) =>
+    yargs
+      .option("tail", {
+        describe: "number of trailing lines to print",
+        type: "number",
+        default: 1000,
+      })
+      .option("follow", {
+        alias: "f",
+        describe: "stream new log lines as they are written",
+        type: "boolean",
+        default: false,
+      }),
+  handler: Effect.fn("Cli.logs")(function* (args) {
+    if (!fs.existsSync(FILE)) return yield* fail(`no log file at ${FILE}`)
+    const text = yield* Effect.promise(() => Bun.file(FILE).text())
+    const lines = text.split("\n")
+    if (lines.at(-1) === "") lines.pop()
+    const count = Math.max(0, Math.floor(args.tail))
+    for (const line of lines.slice(-count)) console.log(line)
+    if (!args.follow) return
+    // Follow by re-reading appended bytes whenever the file changes; the log
+    // is append-only so the previous size is always a valid resume offset.
+    let offset = Buffer.byteLength(text)
+    yield* Effect.callback<void>(() => {
+      const watcher = fs.watch(path.dirname(FILE), (_, name) => {
+        if (name !== path.basename(FILE)) return
+        const size = fs.statSync(FILE, { throwIfNoEntry: false })?.size ?? 0
+        if (size <= offset) {
+          offset = size
+          return
+        }
+        const stream = fs.createReadStream(FILE, { start: offset, end: size - 1, encoding: "utf8" })
+        stream.on("data", (chunk) => process.stdout.write(chunk))
+        offset = size
+      })
+      return Effect.sync(() => watcher.close())
+    })
+  }),
+})

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -14,6 +14,7 @@ import { FormatError } from "./cli/error"
 import { ServeCommand } from "./cli/cmd/serve"
 import { DebugCommand } from "./cli/cmd/debug"
 import { StatsCommand } from "./cli/cmd/stats"
+import { LogsCommand } from "./cli/cmd/logs"
 import { McpCommand } from "./cli/cmd/mcp"
 import { GithubCommand } from "./cli/cmd/github"
 import { ExportCommand } from "./cli/cmd/export"
@@ -94,6 +95,7 @@ const cli = yargs(args)
   .command(WebCommand)
   .command(ModelsCommand)
   .command(StatsCommand)
+  .command(LogsCommand)
   .command(ExportCommand)
   .command(ImportCommand)
   .command(GithubCommand)


### PR DESCRIPTION
### Issue for this PR

Closes #88

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Ports Crush's `crush logs` to bolt. The agent appends everything to one file (`~/.local/share/opencode/log/opencode.log` via `Global.Path.log`), but until now there was no CLI to read it. `bolt logs` prints the last 1000 lines (`--tail <n>` to change), and `--follow`/`-f` streams new lines. It's an `instance: false` command so it skips project bootstrap entirely.

Follow mode leans on the log being append-only:

```ts
// Follow by re-reading appended bytes whenever the file changes; the log
// is append-only so the previous size is always a valid resume offset.
let offset = Buffer.byteLength(text)
yield* Effect.callback<void>(() => {
  const watcher = fs.watch(path.dirname(FILE), (_, name) => {
    if (name !== path.basename(FILE)) return
    const size = fs.statSync(FILE, { throwIfNoEntry: false })?.size ?? 0
    // ... stream bytes from offset to size
  })
  return Effect.sync(() => watcher.close())
})
```

Watching the directory rather than the file handles the file being recreated, and a shrinking size resets the offset instead of streaming garbage. Missing log file fails with a clear message via `fail()`.

### How did you verify your code works?

- `bun run typecheck` in `packages/opencode`
- Ran `bun src/index.ts logs --tail 2` against a seeded log file and got exactly the last two lines; missing-file path prints the error and exits non-zero

### Screenshots / recordings

CLI output only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `logs` command to view recent application log entries.
  * Supports limiting output to a specified number of lines.
  * Added follow mode to display new log entries as they are written.
  * Provides a clear error when the configured log file is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->