### PR TITLE
feat(core): rebrand the built-in config skill as bolt-config

### DIFF
--- a/packages/core/src/plugin/skill.ts
+++ b/packages/core/src/plugin/skill.ts
@@ -6,9 +6,9 @@ import { define } from "./internal"
 import { Effect } from "effect"
 import { AbsolutePath } from "../schema"
 import { SkillV2 } from "../skill"
-import customizeOpencodeContent from "./skill/customize-opencode.md" with { type: "text" }
+import boltConfigContent from "./skill/bolt-config.md" with { type: "text" }
 
-export const CustomizeOpencodeContent = customizeOpencodeContent
+export const BoltConfigContent = boltConfigContent
 
 export const Plugin = define({
   id: "skill",
@@ -18,11 +18,11 @@ export const Plugin = define({
         SkillV2.EmbeddedSource.make({
           type: "embedded",
           skill: SkillV2.Info.make({
-            name: "customize-opencode",
+            name: "bolt-config",
             description:
-              "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, commands, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself.",
-            location: AbsolutePath.make("/builtin/customize-opencode.md"),
-            content: CustomizeOpencodeContent,
+              "Use ONLY when the user is editing or creating bolt's own configuration: bolt.json, bolt.jsonc, legacy opencode.json(c), files under .bolt/ or .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing bolt agents, subagents, commands, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring bolt itself.",
+            location: AbsolutePath.make("/builtin/bolt-config.md"),
+            content: BoltConfigContent,
           }),
         }),
       )

--- a/packages/core/src/plugin/skill/bolt-config.md
+++ b/packages/core/src/plugin/skill/bolt-config.md
@@ -1,13 +1,13 @@
 <!--
   Built-in skill. Name and description are registered in code at
-  packages/core/src/plugin/skill.ts
-  and CUSTOMIZE_OPENCODE_SKILL_DESCRIPTION). The body below becomes the
-  skill's content.
+  packages/core/src/plugin/skill.ts and in
+  packages/opencode/src/skill/index.ts (BOLT_CONFIG_SKILL_*). The body below
+  becomes the skill's content.
 -->
 
-# Customizing opencode
+# Configuring bolt
 
-opencode validates its own config strictly and refuses to start when a field
+bolt validates its own config strictly and refuses to start when a field
 is wrong. The shapes below cover the common surface area, but they are a
 **summary, not the source of truth**.
 
@@ -20,18 +20,18 @@ defaults, and descriptions — lives in the published JSON Schema:
 
 If a field is not documented in this skill, or you need to confirm an exact
 shape before writing config, **fetch that URL and read the schema directly**
-rather than guessing. opencode hard-fails on invalid config, so the cost of a
+rather than guessing. bolt hard-fails on invalid config, so the cost of a
 wrong shape is a broken startup.
 
-Independently, every `opencode.json` should declare
+Independently, every `bolt.json` should declare
 `"$schema": "https://opencode.ai/config.json"` so the user's editor catches
 mistakes as they type.
 
 ## Applying changes
 
-Config is loaded once when opencode starts and is not hot-reloaded. After
-saving changes to `opencode.json`, an agent file, a skill, a plugin, or any
-other config-time file, **tell the user to quit and restart opencode** for
+Config is loaded once when bolt starts and is not hot-reloaded. After
+saving changes to `bolt.json`, an agent file, a skill, a plugin, or any
+other config-time file, **tell the user to quit and restart bolt** for
 the changes to take effect. The running session will keep using the
 already-loaded config until then.
 
@@ -39,20 +39,24 @@ already-loaded config until then.
 
 | Scope                         | Path                                                                                                                      |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Project config                | `./opencode.json`, `./opencode.jsonc`, or `.opencode/opencode.json` (opencode walks up from the cwd to the worktree root) |
-| Global config                 | `~/.config/opencode/opencode.json` (NOT `~/.opencode/`)                                                                   |
-| Project agents                | `.opencode/agent/<name>.md` or `.opencode/agents/<name>.md`                                                               |
+| Project config                | `./bolt.json`, `./bolt.jsonc`, or inside `.bolt/` / `.opencode/` (bolt walks up from the cwd to the worktree root)       |
+| Global config                 | `~/.config/opencode/bolt.json` (NOT `~/.bolt/`)                                                                           |
+| Project agents                | `.bolt/agent(s)/<name>.md` or `.opencode/agent(s)/<name>.md`                                                              |
 | Global agents                 | `~/.config/opencode/agent(s)/<name>.md`                                                                                   |
-| Project commands              | `.opencode/command/<name>.md` or `.opencode/commands/<name>.md`                                                           |
+| Project commands              | `.bolt/command(s)/<name>.md` or `.opencode/command(s)/<name>.md`                                                          |
 | Global commands               | `~/.config/opencode/command(s)/<name>.md`                                                                                 |
-| Project skills                | `.opencode/skill(s)/<name>/SKILL.md`                                                                                      |
+| Project skills                | `.bolt/skill(s)/<name>/SKILL.md` or `.opencode/skill(s)/<name>/SKILL.md`                                                  |
 | Global skills                 | `~/.config/opencode/skill(s)/<name>/SKILL.md`                                                                             |
+
+Legacy `opencode.json` / `opencode.jsonc` files are still honored in every
+location; when both exist, the `bolt.*` file wins. Prefer `bolt.jsonc` when
+creating new config.
 | External skills (auto-loaded) | `~/.claude/skills/<name>/SKILL.md`, `~/.agents/skills/<name>/SKILL.md`                                                    |
 
 Configs from each scope are deep-merged. Project overrides global. Unknown
-top-level keys in `opencode.json` are rejected with `ConfigInvalidError`.
+top-level keys in `bolt.json` are rejected with `ConfigInvalidError`.
 
-## opencode.json
+## bolt.json
 
 Every field is optional.
 
@@ -160,7 +164,7 @@ Shape notes worth being explicit about:
 
 ## Skills
 
-opencode's skill loader scans for `**/SKILL.md` inside skill directories. The
+bolt's skill loader scans for `**/SKILL.md` inside skill directories. The
 file is named `SKILL.md` exactly, and lives in its own folder named after the
 skill:
 
@@ -225,7 +229,7 @@ Local `path` values may be relative to the declaring config, absolute, or use
 
 Two ways to define an agent. Use the file form for anything non-trivial.
 
-### Inline (in `opencode.json`)
+### Inline (in `bolt.json`)
 
 ```json
 {
@@ -276,13 +280,13 @@ file, `disable: true` in frontmatter.
 
 ### Built-in agents
 
-opencode ships with `build`, `plan`, `general`, `explore`. Hidden internal agents:
+bolt ships with `build`, `plan`, `general`, `explore`. Hidden internal agents:
 `compaction`, `title`, `summary`. To override a built-in's fields, define the
 same key in `agent: { <name>: { ... } }`.
 
 ## Commands
 
-opencode's command loader scans for `**/*.md` inside command directories. The
+bolt's command loader scans for `**/*.md` inside command directories. The
 file is named after the command, and lives directly inside the `command` folder:
 
 ```
@@ -298,10 +302,10 @@ agent: build
 model: anthropic/claude-sonnet-4-6
 ---
 
-(command body in markdown: the prompt opencode runs, with $ARGUMENTS for the user's input)
+(command body in markdown: the prompt bolt runs, with $ARGUMENTS for the user's input)
 ```
 
-- `template` is the command body — everything below the frontmatter — and is required: it is the prompt opencode runs when the command is invoked. Do not also put a `template:` key in the frontmatter.
+- `template` is the command body — everything below the frontmatter — and is required: it is the prompt bolt runs when the command is invoked. Do not also put a `template:` key in the frontmatter.
 - `$ARGUMENTS` is replaced with everything the user typed after the command; `$1`, `$2`, … pull individual positional arguments.
 - Optional: `description`, `agent`, `model`, `variant`, `subtask`.
 
@@ -404,7 +408,7 @@ Actions: `"allow"`, `"ask"`, `"deny"`.
 
 Per-tool value forms: `"allow"` shorthand (treated as `{"*": "allow"}`), or an
 object `{ pattern: action }`. Within an object, **insertion order matters**.
-opencode evaluates the LAST matching rule, so put broad rules first and narrow
+bolt evaluates the LAST matching rule, so put broad rules first and narrow
 rules last.
 
 `permission: "allow"` (a string at the top level) is shorthand for "allow
@@ -424,10 +428,10 @@ the `plan` agent's permission ruleset (`edit: deny *`).
 
 ## Escape hatches
 
-When a user's config is broken and opencode won't start, these env vars help:
+When a user's config is broken and bolt won't start, these env vars help:
 
-- `OPENCODE_DISABLE_PROJECT_CONFIG=1`: skip the project's local `opencode.json`
-  and start from globals only. Run from the project directory, opencode loads,
+- `OPENCODE_DISABLE_PROJECT_CONFIG=1`: skip the project's local `bolt.json` / `opencode.json`
+  and start from globals only. Run from the project directory, bolt loads,
   the user edits the broken file, then they restart without the flag.
 - `OPENCODE_CONFIG=/path/to/file.json`: load an additional explicit config.
 - `OPENCODE_CONFIG_CONTENT='{"$schema":"https://opencode.ai/config.json"}'`:
@@ -445,9 +449,9 @@ When a user's config is broken and opencode won't start, these env vars help:
   `https://opencode.ai/config.json` and read the schema rather than guessing.
 - Preserve `$schema` and any existing fields the user did not ask to change.
 - For agent, command, skill, and plugin definitions, prefer creating new files
-  in the correct location over inlining everything in `opencode.json`.
+  in the correct location over inlining everything in `bolt.json`.
 - If the user's existing config is malformed, point them at the env-var escape
-  hatches above so they can edit from inside opencode without breaking their
+  hatches above so they can edit from inside bolt without breaking their
   session.
-- After saving any config change, remind the user to quit and restart opencode
+- After saving any config change, remind the user to quit and restart bolt
   — running sessions keep using the already-loaded config.

--- a/packages/core/test/plugin/skill.test.ts
+++ b/packages/core/test/plugin/skill.test.ts
@@ -9,15 +9,15 @@ import { host } from "./host"
 const it = testEffect(AppNodeBuilder.build(SkillV2.node))
 
 describe("SkillPlugin.Plugin", () => {
-  it.effect("registers the built-in customize-opencode skill", () =>
+  it.effect("registers the built-in bolt-config skill", () =>
     Effect.gen(function* () {
       const skill = yield* SkillV2.Service
       yield* SkillPlugin.Plugin.effect(host({ skill: { ...skill, reload: skill.reload } }))
 
       expect(yield* skill.list()).toContainEqual(
         expect.objectContaining({
-          name: "customize-opencode",
-          description: expect.stringContaining("opencode's own configuration"),
+          name: "bolt-config",
+          description: expect.stringContaining("bolt's own configuration"),
         }),
       )
     }),

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -24,15 +24,15 @@ const EXTERNAL_SKILL_PATTERN = "skills/**/SKILL.md"
 const OPENCODE_SKILL_PATTERN = "{skill,skills}/**/SKILL.md"
 const SKILL_PATTERN = "**/SKILL.md"
 
-// Built-in skill that ships with opencode. The model's intuition for what an
-// opencode.json should look like is often wrong, and opencode hard-fails on
+// Built-in skill that ships with bolt. The model's intuition for what a
+// bolt.json should look like is often wrong, and bolt hard-fails on
 // invalid config, so users hit cryptic startup errors. Loading this skill
-// when the model is asked to touch opencode's own config files gives it the
+// when the model is asked to touch bolt's own config files gives it the
 // actual schemas instead of guesses.
-const CUSTOMIZE_OPENCODE_SKILL_NAME = "customize-opencode"
-const CUSTOMIZE_OPENCODE_SKILL_DESCRIPTION =
-  "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself."
-const CUSTOMIZE_OPENCODE_SKILL_BODY = SkillPlugin.CustomizeOpencodeContent
+const BOLT_CONFIG_SKILL_NAME = "bolt-config"
+const BOLT_CONFIG_SKILL_DESCRIPTION =
+  "Use ONLY when the user is editing or creating bolt's own configuration: bolt.json, bolt.jsonc, legacy opencode.json(c), files under .bolt/ or .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing bolt agents, subagents, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring bolt itself."
+const BOLT_CONFIG_SKILL_BODY = SkillPlugin.BoltConfigContent
 
 export const Info = Schema.Struct({
   name: Schema.String,
@@ -275,11 +275,11 @@ const layer = Layer.effect(
         const s: State = { skills: {}, dirs: new Set() }
         // Register the built-in skill BEFORE disk discovery so a user-disk
         // skill with the same name can override it.
-        s.skills[CUSTOMIZE_OPENCODE_SKILL_NAME] = {
-          name: CUSTOMIZE_OPENCODE_SKILL_NAME,
-          description: CUSTOMIZE_OPENCODE_SKILL_DESCRIPTION,
+        s.skills[BOLT_CONFIG_SKILL_NAME] = {
+          name: BOLT_CONFIG_SKILL_NAME,
+          description: BOLT_CONFIG_SKILL_DESCRIPTION,
           location: "<built-in>",
-          content: CUSTOMIZE_OPENCODE_SKILL_BODY,
+          content: BOLT_CONFIG_SKILL_BODY,
         }
         yield* loadSkills(s, yield* InstanceState.get(discovered), events)
         return s


### PR DESCRIPTION
### Issue for this PR

Closes #91

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bolt inherited upstream's built-in `customize-opencode` skill (the analog of Crush's `crush-config`), but its content still taught pure opencode branding and never mentioned `bolt.json`/`bolt.jsonc`, which bolt actually prefers and seeds. This renames the skill to `bolt-config` in both registration points (v1 runtime in `packages/opencode/src/skill/index.ts`, v2 embedded source in `packages/core/src/plugin/skill.ts`) and rewrites the body for bolt:

```md
Legacy `opencode.json` / `opencode.jsonc` files are still honored in every
location; when both exist, the `bolt.*` file wins. Prefer `bolt.jsonc` when
creating new config.
```

The file table now lists `bolt.json(c)` and both `.bolt/` and `.opencode/` project dirs. Deliberately unchanged because they're real values, not branding: the `$schema` URL (`https://opencode.ai/config.json`), `OPENCODE_*` escape-hatch env vars, the `~/.config/opencode/` global dir, and npm plugin package names. The skill body stays embedded via the Bun text import, so it survives the compiled binary; a user's on-disk skill named `bolt-config` still overrides the builtin by design.

### How did you verify your code works?

- Updated `packages/core/test/plugin/skill.test.ts` to assert the new name/description (passes)
- `bun test ./test/skill` in `packages/opencode` (24 pass)
- `bun typecheck` in `packages/core` and `packages/opencode`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->