### PR TITLE
fix(core): scope .boltignore to the repository root for nested searches

### DIFF
--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -45,7 +45,7 @@ function boltignore(cwd: string) {
     cwd: root,
     args: [`--ignore-file=${file}`],
     search: search || ".",
-    prefix: search ? search.replaceAll("\\", "/") + "/" : "",
+    prefix: search ? `${search.replaceAll("\\", "/")}/` : "",
   }
 }
 
@@ -55,8 +55,8 @@ function boltignore(cwd: string) {
 // the search directory.
 function reroot(glob: string, prefix: string): string {
   if (!prefix) return glob
-  if (glob.startsWith("!")) return "!" + reroot(glob.slice(1), prefix)
-  if (glob.startsWith("/")) return "/" + prefix + glob.slice(1)
+  if (glob.startsWith("!")) return `!${reroot(glob.slice(1), prefix)}`
+  if (glob.startsWith("/")) return `/${prefix}${glob.slice(1)}`
   if (glob.slice(0, -1).includes("/")) return prefix + glob
   return glob
 }

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -22,20 +22,51 @@ const MAX_RECORD_BYTES = 64 * 1024
 const MAX_SUBMATCHES = 100
 
 // Extra agent-only ignore rules: .boltignore uses .gitignore syntax and hides
-// committed files from search without touching .gitignore. Collected from the
-// search cwd up to the repo root so subdirectory searches still respect it.
-function ignores(cwd: string) {
-  const found: string[] = []
-  let dir = cwd
-  while (true) {
-    const file = path.join(dir, ".boltignore")
-    if (fs.existsSync(file)) found.push(`--ignore-file=${file}`)
-    if (fs.existsSync(path.join(dir, ".git"))) break
-    const parent = path.dirname(dir)
-    if (parent === dir) break
-    dir = parent
+// committed files from search without touching .gitignore. It lives at the
+// repository root only. Ripgrep resolves --ignore-file patterns relative to
+// its working directory, so when a search starts below the root the process
+// runs from the root instead (with the walk confined to the requested
+// directory) to keep root-anchored rules like `/src/generated/` correctly
+// scoped. User globs and output paths are translated between the two bases.
+function boltignore(cwd: string) {
+  const root = (() => {
+    let dir = cwd
+    while (true) {
+      if (fs.existsSync(path.join(dir, ".git"))) return dir
+      const parent = path.dirname(dir)
+      if (parent === dir) return cwd
+      dir = parent
+    }
+  })()
+  const file = path.join(root, ".boltignore")
+  if (!fs.existsSync(file)) return { cwd, args: [], search: ".", prefix: "" }
+  const search = path.relative(root, cwd)
+  return {
+    cwd: root,
+    args: [`--ignore-file=${file}`],
+    search: search || ".",
+    prefix: search ? search.replaceAll("\\", "/") + "/" : "",
   }
-  return found
+}
+
+// -g globs follow .gitignore rules relative to the ripgrep working directory:
+// slash-less globs match basenames at any depth and survive re-basing, while
+// globs with a non-trailing slash are anchored and must be re-anchored onto
+// the search directory.
+function reroot(glob: string, prefix: string): string {
+  if (!prefix) return glob
+  if (glob.startsWith("!")) return "!" + reroot(glob.slice(1), prefix)
+  if (glob.startsWith("/")) return "/" + prefix + glob.slice(1)
+  if (glob.slice(0, -1).includes("/")) return prefix + glob
+  return glob
+}
+
+// Normalizes a ripgrep output path and re-bases it from the process working
+// directory back onto the requested search cwd.
+function rebase(line: string, prefix: string) {
+  const normalized = line.replace(/^(?:\.[\\/])+/u, "").replaceAll("\\", "/")
+  const stripped = prefix && normalized.startsWith(prefix) ? normalized.slice(prefix.length) : normalized
+  return stripped.replace(/^\/+/u, "")
 }
 
 const RawMatch = Schema.Struct({
@@ -171,28 +202,23 @@ const layer = Layer.effect(
     }
 
     return Service.of({
-      glob: (input) =>
-        run<string>({
-          cwd: input.cwd,
+      glob: (input) => {
+        const scoped = boltignore(input.cwd)
+        return run<string>({
+          cwd: scoped.cwd,
           limit: input.limit,
           signal: input.signal,
           args: [
             "--no-config",
             "--files",
-            ...ignores(input.cwd),
+            ...scoped.args,
             ...(input.hidden ? ["--hidden"] : []),
             ...(input.follow ? ["--follow"] : []),
-            `--glob=${input.pattern}`,
+            `--glob=${reroot(input.pattern, scoped.prefix)}`,
             "--glob=!**/.git/**",
-            ".",
+            scoped.search,
           ],
-          parse: (line) =>
-            Effect.succeed(
-              line
-                .replace(/^(?:\.[\\/])+/u, "")
-                .replace(/^[\\/]+/u, "")
-                .replaceAll("\\", "/"),
-            ),
+          parse: (line) => Effect.succeed(rebase(line, scoped.prefix)),
         }).pipe(
           Effect.map((result) =>
             result.items.map((relative) =>
@@ -203,53 +229,57 @@ const layer = Layer.effect(
             ),
           ),
           Effect.catchTag("Ripgrep.InvalidPatternError", (cause) => Effect.fail(failure(cause.message, cause))),
-        ),
-      find: (input) =>
-        run<Entry>({
-          cwd: input.cwd,
+        )
+      },
+      find: (input) => {
+        const scoped = boltignore(input.cwd)
+        return run<Entry>({
+          cwd: scoped.cwd,
           limit: input.limit,
           signal: input.signal,
           args: [
             "--no-config",
             "--files",
-            ...ignores(input.cwd),
+            ...scoped.args,
             ...(input.hidden ? ["--hidden"] : []),
             ...(input.follow ? ["--follow"] : []),
-            ...(input.pattern === "*" ? [] : [`--glob=${input.pattern}`]),
+            ...(input.pattern === "*" ? [] : [`--glob=${reroot(input.pattern, scoped.prefix)}`]),
             "--glob=!**/.git/**",
-            ".",
+            scoped.search,
           ],
-          parse: (line) => {
-            const relative = line
-              .replace(/^(?:\.[\\/])+/u, "")
-              .replace(/^[\\/]+/u, "")
-              .replaceAll("\\", "/")
-            return Effect.succeed(
+          parse: (line) =>
+            Effect.succeed(
               Entry.make({
-                path: RelativePath.make(relative),
+                path: RelativePath.make(rebase(line, scoped.prefix)),
                 type: "file",
               }),
-            )
-          },
+            ),
           onItem: input.onEntry,
         }).pipe(
           Effect.map((result) => result.items),
           Effect.catchTag("Ripgrep.InvalidPatternError", (cause) => Effect.fail(failure(cause.message, cause))),
-        ),
-      grep: (input) =>
-        run<RawMatchData>({
-          ...input,
+        )
+      },
+      grep: (input) => {
+        const scoped = boltignore(input.cwd)
+        const target =
+          input.file && path.isAbsolute(input.file) ? input.file : path.join(scoped.search, input.file ?? ".")
+        return run<RawMatchData>({
+          cwd: scoped.cwd,
+          limit: input.limit,
+          signal: input.signal,
+          pattern: input.pattern,
           args: [
             "--no-config",
             "--json",
             "--hidden",
             "--no-messages",
-            ...ignores(input.cwd),
-            ...(input.include ? [`--glob=${input.include}`] : []),
+            ...scoped.args,
+            ...(input.include ? [`--glob=${reroot(input.include, scoped.prefix)}`] : []),
             "--glob=!**/.git/**",
             "--",
             input.pattern,
-            input.file ?? ".",
+            target,
           ],
           parse: (line) =>
             (Buffer.byteLength(line, "utf8") > MAX_RECORD_BYTES
@@ -275,10 +305,7 @@ const layer = Layer.effect(
         }).pipe(
           Effect.map((result) =>
             result.items.map((match) => {
-              const relative = match.path.text
-                .replace(/^(?:\.[\\/])+/u, "")
-                .replace(/^[\\/]+/u, "")
-                .replaceAll("\\", "/")
+              const relative = rebase(match.path.text, scoped.prefix)
               return Match.make({
                 entry: Entry.make({
                   path: RelativePath.make(relative),
@@ -295,7 +322,8 @@ const layer = Layer.effect(
               })
             }),
           ),
-        ),
+        )
+      },
     })
   }),
 )

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -36,24 +36,34 @@ describe("Ripgrep", () => {
       Effect.promise(() => tmpdir()),
       (tmp) =>
         Effect.gen(function* () {
-          yield* Effect.promise(() => fs.mkdir(path.join(tmp.path, "src")))
+          yield* Effect.promise(() => fs.mkdir(path.join(tmp.path, "src", "generated"), { recursive: true }))
           yield* Effect.promise(() => Bun.$`git init -q ${tmp.path}`)
-          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, ".boltignore"), "hidden.txt\n"))
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, ".boltignore"), "hidden.txt\n/src/generated/\n"))
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "src", "hidden.txt"), "needle\n"))
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "src", "shown.txt"), "needle\n"))
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "src", "generated", "gen.txt"), "needle\n"))
           const ripgrep = yield* Ripgrep.Service
 
           const files = yield* ripgrep.find({ cwd: tmp.path, pattern: "*", limit: 10 })
           expect(files.map((item) => item.path)).toContain(RelativePath.make("src/shown.txt"))
           expect(files.map((item) => item.path)).not.toContain(RelativePath.make("src/hidden.txt"))
+          expect(files.map((item) => item.path)).not.toContain(RelativePath.make("src/generated/gen.txt"))
 
           const matches = yield* ripgrep.grep({ cwd: tmp.path, pattern: "needle", limit: 10 })
           expect(matches.map((item) => item.entry.path)).toContain(RelativePath.make("src/shown.txt"))
           expect(matches.map((item) => item.entry.path)).not.toContain(RelativePath.make("src/hidden.txt"))
 
+          // Root-anchored rules keep their repository-root scope even when the
+          // search starts in a subdirectory.
           const nested = yield* ripgrep.find({ cwd: path.join(tmp.path, "src"), pattern: "*", limit: 10 })
           expect(nested.map((item) => item.path)).toContain(RelativePath.make("shown.txt"))
           expect(nested.map((item) => item.path)).not.toContain(RelativePath.make("hidden.txt"))
+          expect(nested.map((item) => item.path)).not.toContain(RelativePath.make("generated/gen.txt"))
+
+          const nestedMatches = yield* ripgrep.grep({ cwd: path.join(tmp.path, "src"), pattern: "needle", limit: 10 })
+          expect(nestedMatches.map((item) => item.entry.path)).toContain(RelativePath.make("shown.txt"))
+          expect(nestedMatches.map((item) => item.entry.path)).not.toContain(RelativePath.make("hidden.txt"))
+          expect(nestedMatches.map((item) => item.entry.path)).not.toContain(RelativePath.make("generated/gen.txt"))
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -71,6 +71,15 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
           const raw = yield* FSUtil.Service
           const location = yield* Location.Service
           const ignored = ignore()
+          // .boltignore comes first so .gitignore/.ignore rules keep higher
+          // precedence, mirroring ripgrep's lowest-priority --ignore-file
+          // semantics. Only a missing file means an empty policy; any other
+          // read failure dies instead of silently exposing excluded files.
+          const boltignore = yield* raw.readFileString(path.join(location.project.directory, ".boltignore")).pipe(
+            Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed("")),
+            Effect.orDie,
+          )
+          if (boltignore) ignored.add(boltignore)
           const gitignore = yield* raw
             .readFileString(path.join(location.project.directory, ".gitignore"))
             .pipe(Effect.catch(() => Effect.succeed("")))
@@ -79,10 +88,6 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
             .readFileString(path.join(location.project.directory, ".ignore"))
             .pipe(Effect.catch(() => Effect.succeed("")))
           if (ignorefile) ignored.add(ignorefile)
-          const boltignore = yield* raw
-            .readFileString(path.join(location.project.directory, ".boltignore"))
-            .pipe(Effect.catch(() => Effect.succeed("")))
-          if (boltignore) ignored.add(boltignore)
           return (yield* fs.list({ path: RelativePath.make(ctx.query.path) })).map((item) => ({
             name: path.basename(item.path),
             path: item.path,


### PR DESCRIPTION
### Issue for this PR

Closes #93

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Follow-up to #87, addressing the review findings that landed after merge. Ripgrep resolves `--ignore-file` patterns relative to its working directory, so a root `.boltignore` rule like `/src/generated/` matched the wrong path whenever grep/glob/find ran from a subdirectory, and the child-to-root argument order gave parent files higher precedence than nearer ones.

`.boltignore` is now repository-root-only, and when a search starts below the root, rg runs from the root with the walk confined to the requested directory, so root-anchored rules keep their scope:

```ts
function boltignore(cwd: string) {
  const root = /* nearest ancestor with .git, else cwd */
  const file = path.join(root, ".boltignore")
  if (!fs.existsSync(file)) return { cwd, args: [], search: ".", prefix: "" }
  const search = path.relative(root, cwd)
  return {
    cwd: root,
    args: [`--ignore-file=${file}`],
    search: search || ".",
    prefix: search ? search.replaceAll("\\", "/") + "/" : "",
  }
}
```

User globs with a non-trailing slash are re-anchored onto the search directory (slash-less globs match basenames at any depth and need no translation), and output paths are re-based onto the requested cwd, so callers see the same relative paths as before.

In the HTTP `file.list` handler, a `.boltignore` read failure no longer silently becomes an empty policy: only `NotFound` yields an empty policy, anything else dies instead of exposing files the policy should hide. `.boltignore` rules are also added before `.gitignore`/`.ignore` so those keep higher precedence, mirroring rg's lowest-priority `--ignore-file` semantics.

### How did you verify your code works?

- Extended `packages/core/test/ripgrep.test.ts` with a root-anchored `/src/generated/` rule checked from both the root and a subdirectory, for find and grep (3/3 pass)
- `bun typecheck` in `packages/core` and `packages/opencode`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->