### PR TITLE
feat(tui): add /plan to toggle plan mode

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -380,6 +380,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   const toast = useToast()
   const themeState = useTheme()
   const { theme, mode, setMode, locked, lock, unlock } = themeState
+  // Agent to restore when /plan toggles plan mode back off.
+  let prior: string | undefined
   const sync = useSync()
   const project = useProject()
   const exit = useExit()
@@ -684,6 +686,23 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         slashName: "agents",
         run: () => {
           dialog.replace(() => <DialogAgent />)
+        },
+      },
+      {
+        name: "agent.plan",
+        title: "Toggle plan mode",
+        category: "Agent",
+        slashName: "plan",
+        run: () => {
+          const current = local.agent.current()?.name
+          if (current === "plan") {
+            local.agent.set(prior ?? "build")
+            toast.show({ variant: "info", message: `Plan mode off, back to ${prior ?? "build"}`, duration: 3000 })
+            return
+          }
+          prior = current
+          local.agent.set("plan")
+          toast.show({ variant: "info", message: "Plan mode on, the agent will propose before changing files", duration: 3000 })
         },
       },
       {


### PR DESCRIPTION
### Issue for this PR

Closes #95

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Ports Codex CLI's plan-mode toggle. Bolt already ships a built-in `plan` agent, but flipping into it meant opening `/agents`, picking it, and doing the same dance to get back. `/plan` now toggles in one keystroke, remembering the agent you came from:

```tsx
run: () => {
  const current = local.agent.current()?.name
  if (current === "plan") {
    local.agent.set(prior ?? "build")
    toast.show({ variant: "info", message: `Plan mode off, back to ${prior ?? "build"}`, duration: 3000 })
    return
  }
  prior = current
  local.agent.set("plan")
  toast.show({ variant: "info", message: "Plan mode on, the agent will propose before changing files", duration: 3000 })
},
```

If a custom config removed the `plan` agent, `local.agent.set` already surfaces its "Agent not found" warning toast, so no extra guard is needed.

### How did you verify your code works?

- `bun typecheck` and `bun test` in `packages/tui` (198 pass)
- Ran the TUI: `/plan` switches to the plan agent with a toast, `/plan` again restores the prior agent (including non-default agents)

### Screenshots / recordings

Terminal UI change; behavior described above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->