### PR TITLE
feat(tui): spawnable pixel-art pets rendered with half-block sprites

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -46,6 +46,7 @@ import { DialogMcp } from "./component/dialog-mcp"
 import { DialogStatus } from "./component/dialog-status"
 import { DialogDebug } from "./component/dialog-debug"
 import { DialogThemeList } from "./component/dialog-theme-list"
+import { DialogPets } from "./component/dialog-pets"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
 import { DialogSessionList } from "./component/dialog-session-list"
@@ -801,6 +802,16 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         slashName: "debug",
         run: () => {
           dialog.replace(() => <DialogDebug />)
+        },
+        category: "System",
+      },
+      {
+        name: "pet.switch",
+        title: "Choose a pet",
+        slashName: "pets",
+        slashAliases: ["pet"],
+        run: () => {
+          dialog.replace(() => <DialogPets />)
         },
         category: "System",
       },

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -47,7 +47,7 @@ import { DialogStatus } from "./component/dialog-status"
 import { DialogDebug } from "./component/dialog-debug"
 import { DialogThemeList } from "./component/dialog-theme-list"
 import { DialogPets } from "./component/dialog-pets"
-import { PETS_KEY, TREAT_KEY } from "./component/pet"
+import { PETS_KEY, roster, TREAT_KEY } from "./component/pet"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
 import { DialogSessionList } from "./component/dialog-session-list"
@@ -821,7 +821,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         title: "Feed the pets",
         slashName: "feed",
         run: () => {
-          if (!(kv.get(PETS_KEY, []) as string[]).length) {
+          if (!roster(kv.get(PETS_KEY, [])).length) {
             toast.show({ message: "no pets to feed, spawn some with /pets", variant: "warning" })
             return
           }

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -807,7 +807,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "pet.switch",
-        title: "Choose a pet",
+        title: "Spawn pets",
         slashName: "pets",
         slashAliases: ["pet"],
         run: () => {

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -47,6 +47,7 @@ import { DialogStatus } from "./component/dialog-status"
 import { DialogDebug } from "./component/dialog-debug"
 import { DialogThemeList } from "./component/dialog-theme-list"
 import { DialogPets } from "./component/dialog-pets"
+import { PETS_KEY, TREAT_KEY } from "./component/pet"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
 import { DialogSessionList } from "./component/dialog-session-list"
@@ -812,6 +813,19 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         slashAliases: ["pet"],
         run: () => {
           dialog.replace(() => <DialogPets />)
+        },
+        category: "System",
+      },
+      {
+        name: "pet.feed",
+        title: "Feed the pets",
+        slashName: "feed",
+        run: () => {
+          if (!(kv.get(PETS_KEY, []) as string[]).length) {
+            toast.show({ message: "no pets to feed, spawn some with /pets", variant: "warning" })
+            return
+          }
+          kv.set(TREAT_KEY, Date.now())
         },
         category: "System",
       },

--- a/packages/tui/src/component/dialog-pets.tsx
+++ b/packages/tui/src/component/dialog-pets.tsx
@@ -2,29 +2,44 @@ import { createMemo } from "solid-js"
 import { useKV } from "../context/kv"
 import { DialogSelect } from "../ui/dialog-select"
 import { useDialog } from "../ui/dialog"
-import { PET_KEY, PET_OFF, PETS } from "./pet"
+import { PETS_KEY, SPECIES } from "./pet"
+
+const CAP = 24
 
 export function DialogPets() {
   const kv = useKV()
   const dialog = useDialog()
+  const list = createMemo(() => (kv.get(PETS_KEY, []) as string[]).filter((name) => SPECIES[name] !== undefined))
 
-  const options = createMemo(() => [
-    ...Object.entries(PETS).map(([name, pet]) => ({
-      value: name,
-      title: `${name}  ${pet.idle[0]}`,
-      description: undefined,
-    })),
-    { value: PET_OFF, title: "off", description: "no pet" },
-  ])
+  const options = createMemo(() => {
+    const counts = new Map<string, number>()
+    for (const name of list()) counts.set(name, (counts.get(name) ?? 0) + 1)
+    return [
+      ...Object.keys(SPECIES).map((name) => {
+        const count = counts.get(name) ?? 0
+        return {
+          value: name,
+          title: count ? `${name} ×${count}` : name,
+          description: "spawn one",
+        }
+      }),
+      { value: "", title: "dismiss all", description: list().length ? `${list().length} roaming` : "none roaming" },
+    ]
+  })
 
   return (
     <DialogSelect
-      title="Choose a pet"
-      current={kv.get(PET_KEY, PET_OFF)}
+      title="Pets"
       options={options()}
       onSelect={(option) => {
-        kv.set(PET_KEY, option.value)
-        dialog.clear()
+        if (!option.value) {
+          kv.set(PETS_KEY, [])
+          dialog.clear()
+          return
+        }
+        // Stay open so spawning a whole litter is one keypress per pet.
+        if (list().length >= CAP) return
+        kv.set(PETS_KEY, [...list(), option.value])
       }}
     />
   )

--- a/packages/tui/src/component/dialog-pets.tsx
+++ b/packages/tui/src/component/dialog-pets.tsx
@@ -2,6 +2,7 @@ import { createMemo } from "solid-js"
 import { useKV } from "../context/kv"
 import { DialogSelect } from "../ui/dialog-select"
 import { useDialog } from "../ui/dialog"
+import { useToast } from "../ui/toast"
 import { PETS_KEY, SPECIES } from "./pet"
 
 const CAP = 24
@@ -9,6 +10,7 @@ const CAP = 24
 export function DialogPets() {
   const kv = useKV()
   const dialog = useDialog()
+  const toast = useToast()
   const list = createMemo(() => (kv.get(PETS_KEY, []) as string[]).filter((name) => SPECIES[name] !== undefined))
 
   const options = createMemo(() => {
@@ -32,14 +34,21 @@ export function DialogPets() {
       title="Pets"
       options={options()}
       onSelect={(option) => {
+        // Close on select like every other dialog: a dialog that swallows
+        // enter without visible feedback reads as a frozen app. Reopen /pets
+        // to spawn more.
+        dialog.clear()
         if (!option.value) {
           kv.set(PETS_KEY, [])
-          dialog.clear()
           return
         }
-        // Stay open so spawning a whole litter is one keypress per pet.
-        if (list().length >= CAP) return
-        kv.set(PETS_KEY, [...list(), option.value])
+        if (list().length >= CAP) {
+          toast.show({ message: `the ${CAP}-pet kennel is full`, variant: "warning" })
+          return
+        }
+        const next = [...list(), option.value]
+        kv.set(PETS_KEY, next)
+        toast.show({ message: `${option.value} spawned (${next.length} roaming)`, variant: "success" })
       }}
     />
   )

--- a/packages/tui/src/component/dialog-pets.tsx
+++ b/packages/tui/src/component/dialog-pets.tsx
@@ -1,0 +1,31 @@
+import { createMemo } from "solid-js"
+import { useKV } from "../context/kv"
+import { DialogSelect } from "../ui/dialog-select"
+import { useDialog } from "../ui/dialog"
+import { PET_KEY, PET_OFF, PETS } from "./pet"
+
+export function DialogPets() {
+  const kv = useKV()
+  const dialog = useDialog()
+
+  const options = createMemo(() => [
+    ...Object.entries(PETS).map(([name, pet]) => ({
+      value: name,
+      title: `${name}  ${pet.idle[0]}`,
+      description: undefined,
+    })),
+    { value: PET_OFF, title: "off", description: "no pet" },
+  ])
+
+  return (
+    <DialogSelect
+      title="Choose a pet"
+      current={kv.get(PET_KEY, PET_OFF)}
+      options={options()}
+      onSelect={(option) => {
+        kv.set(PET_KEY, option.value)
+        dialog.clear()
+      }}
+    />
+  )
+}

--- a/packages/tui/src/component/dialog-pets.tsx
+++ b/packages/tui/src/component/dialog-pets.tsx
@@ -3,7 +3,7 @@ import { useKV } from "../context/kv"
 import { DialogSelect } from "../ui/dialog-select"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
-import { PETS_KEY, SPECIES } from "./pet"
+import { PETS_KEY, roster, SPECIES } from "./pet"
 
 const CAP = 24
 
@@ -11,7 +11,7 @@ export function DialogPets() {
   const kv = useKV()
   const dialog = useDialog()
   const toast = useToast()
-  const list = createMemo(() => (kv.get(PETS_KEY, []) as string[]).filter((name) => SPECIES[name] !== undefined))
+  const list = createMemo(() => roster(kv.get(PETS_KEY, [])))
 
   const options = createMemo(() => {
     const counts = new Map<string, number>()

--- a/packages/tui/src/component/pet.tsx
+++ b/packages/tui/src/component/pet.tsx
@@ -304,7 +304,7 @@ export function createStrip(
 ) {
   const [tick, setTick] = createSignal(0)
   const [crew, setCrew] = createSignal<Critter[]>([])
-  const [treat, setTreat] = createSignal<Treat | undefined>(undefined)
+  const [treat, setTreat] = createSignal<Treat>()
 
   // Reconcile spawned critters with the persisted list, keeping positions of
   // the ones already on screen so spawning never teleports the others.

--- a/packages/tui/src/component/pet.tsx
+++ b/packages/tui/src/component/pet.tsx
@@ -1,4 +1,4 @@
-import { rgbToHex } from "@opentui/core"
+import { MouseButton, rgbToHex } from "@opentui/core"
 import { batch, createEffect, createMemo, createSignal, onCleanup, Index, Show } from "solid-js"
 import { useKV } from "../context/kv"
 import { useSync } from "../context/sync"
@@ -189,11 +189,16 @@ export interface Seg {
 }
 
 interface Critter {
+  // Stable identity so interactions stick to the exact individual you
+  // grabbed, even when two clones of the same species roam the strip.
+  id: number
   species: string
   x: number
   dir: 1 | -1
-  mood?: { kind: "love" | "munch"; until: number }
+  mood?: { kind: "love" | "munch" | "held"; until: number }
 }
+
+let seq = 0
 
 export interface Treat {
   x: number
@@ -232,7 +237,11 @@ export function compose(
     if (!species) continue
     const mood = play && critter.mood && critter.mood.until > play.now ? critter.mood.kind : undefined
     const frames =
-      mood === "love" ? species.states.attention : mood === "munch" ? species.states.busy : species.states[state]
+      mood === "love" || mood === "held"
+        ? species.states.attention
+        : mood === "munch"
+          ? species.states.busy
+          : species.states[state]
     const art = frames[frame % frames.length]
     const x = Math.round(critter.x)
     for (let r = 0; r < H; r++) {
@@ -248,7 +257,7 @@ export function compose(
         grid[r][col] = ch === "!" ? warn : species.colors[ch]
       }
     }
-    if (mood && frame % 2 === 0) {
+    if (mood === "love" && frame % 2 === 0) {
       for (let r = 0; r < HEARTS.length; r++) {
         const row = HEARTS[r]
         for (let c = 0; c < row.length; c++) {
@@ -315,7 +324,7 @@ export function createStrip(
       names.map((name, i) => {
         const old = prev[i]
         if (old && old.species === name) return old
-        return { species: name, x: Math.random() * span, dir: Math.random() < 0.5 ? -1 : 1 } as Critter
+        return { id: ++seq, species: name, x: Math.random() * span, dir: Math.random() < 0.5 ? -1 : 1 } as Critter
       }),
     )
   })
@@ -353,12 +362,47 @@ export function createStrip(
 
   return {
     rows,
-    // Pet whatever is under the given column: wide eyes and hearts.
-    poke(x: number) {
+    crew,
+    // Which pet sits under this column? Nearest center wins when clones pile up.
+    grab(x: number) {
+      const hits = crew().filter((critter) => x >= critter.x && x < critter.x + W)
+      const nearest = hits.sort((a, b) => Math.abs(a.x + W / 2 - x) - Math.abs(b.x + W / 2 - x))[0]
+      return nearest?.id
+    },
+    // Pet exactly this individual: wide eyes and hearts.
+    poke(id: number) {
       const until = Date.now() + LOVE_MS
       setCrew((prev) =>
+        prev.map((critter) => (critter.id === id ? { ...critter, mood: { kind: "love", until } } : critter)),
+      )
+    },
+    // Carry the grabbed pet to a column; it dangles startled until dropped.
+    drag(id: number, x: number) {
+      const until = Date.now() + 1500
+      setCrew((prev) =>
+        prev.map((critter) => {
+          if (critter.id !== id) return critter
+          const goal = Math.min(Math.max(0, width() - W), Math.max(0, x - W / 2))
+          const dir = goal === critter.x ? critter.dir : ((goal > critter.x ? 1 : -1) as 1 | -1)
+          return { ...critter, x: goal, dir, mood: { kind: "held", until } }
+        }),
+      )
+    },
+    drop(id: number) {
+      setCrew((prev) =>
         prev.map((critter) =>
-          x >= critter.x && x < critter.x + W ? { ...critter, mood: { kind: "love", until } } : critter,
+          critter.id === id && critter.mood?.kind === "held" ? { ...critter, mood: undefined } : critter,
+        ),
+      )
+    },
+    // Spin the pet under this column around.
+    turn(x: number) {
+      const hits = crew().filter((critter) => x >= critter.x && x < critter.x + W)
+      const nearest = hits.sort((a, b) => Math.abs(a.x + W / 2 - x) - Math.abs(b.x + W / 2 - x))[0]
+      if (!nearest) return
+      setCrew((prev) =>
+        prev.map((critter) =>
+          critter.id === nearest.id ? { ...critter, dir: (critter.dir * -1) as 1 | -1 } : critter,
         ),
       )
     },
@@ -398,9 +442,38 @@ export function PetStrip(props: { sessionID?: string; width: number }) {
     strip.feed()
   })
 
+  // Track the grabbed pet by id so a drag keeps moving the same individual
+  // even when a clone wanders under the cursor.
+  let held: { id: number; x: number; moved: boolean } | undefined
+  const finish = () => {
+    if (!held) return
+    if (!held.moved) strip.poke(held.id)
+    strip.drop(held.id)
+    held = undefined
+  }
+
   return (
     <Show when={strip.rows().length}>
-      <box width="100%" overflow="hidden" onMouseDown={(evt) => strip.poke(evt.x)}>
+      <box
+        width="100%"
+        overflow="hidden"
+        onMouseDown={(evt) => {
+          if (evt.button === MouseButton.RIGHT) {
+            strip.turn(evt.x)
+            return
+          }
+          const id = strip.grab(evt.x)
+          if (id === undefined) return
+          held = { id, x: evt.x, moved: false }
+        }}
+        onMouseDrag={(evt) => {
+          if (!held) return
+          if (Math.abs(evt.x - held.x) >= 1) held.moved = true
+          strip.drag(held.id, evt.x)
+        }}
+        onMouseDragEnd={finish}
+        onMouseUp={finish}
+      >
         <Index each={strip.rows()}>
           {(row) => (
             <box height={1} width="100%" overflow="hidden">
@@ -426,13 +499,13 @@ function same(a: Seg[][], b: Seg[][]): boolean {
 
 function wander(critter: Critter, state: State, width: number, now: number, treat?: Treat): Critter {
   const mood = critter.mood && critter.mood.until > now ? critter.mood : undefined
-  // Being petted trumps everything: sit still and soak up the hearts.
-  if (mood?.kind === "love") return { ...critter, mood }
+  // Being carried or petted trumps everything: stay exactly where put.
+  if (mood?.kind === "held" || mood?.kind === "love") return { ...critter, mood }
   if (treat) {
     const delta = treat.x + 3 - (critter.x + W / 2)
     if (Math.abs(delta) <= 4) return { ...critter, mood: { kind: "munch", until: treat.until } }
     const dir = (delta > 0 ? 1 : -1) as 1 | -1
-    return { species: critter.species, x: critter.x + dir * 2, dir }
+    return { ...critter, x: critter.x + dir * 2, dir, mood: undefined }
   }
   if (state === "attention") return { ...critter, mood }
   const max = Math.max(0, width - W)
@@ -441,5 +514,5 @@ function wander(critter: Critter, state: State, width: number, now: number, trea
   const step = state === "busy" ? 1 : Math.random() < 0.15 ? 1 : 0
   const x = Math.min(max, Math.max(0, critter.x + dir * step))
   const turned = x === critter.x && step > 0 ? ((dir * -1) as 1 | -1) : dir
-  return { species: critter.species, x, dir: turned }
+  return { ...critter, x, dir: turned, mood }
 }

--- a/packages/tui/src/component/pet.tsx
+++ b/packages/tui/src/component/pet.tsx
@@ -1,39 +1,240 @@
-import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-js"
+import { rgbToHex } from "@opentui/core"
+import { createEffect, createMemo, createSignal, onCleanup, Index, Show } from "solid-js"
 import { useKV } from "../context/kv"
 import { useSync } from "../context/sync"
 import { useTheme } from "../context/theme"
 
 type State = "idle" | "busy" | "attention"
 
-// Text-art pets so they render in every terminal, unlike graphics-protocol
-// pets. Frames within a state are kept the same width to avoid layout shift.
-export const PETS: Record<string, Record<State, string[]>> = {
+// Pixel-art pets rendered with half-block cells, the same trick the fire
+// strip uses: each text row carries two pixel rows ("▀" fg on top, bg on the
+// bottom), so a 16x14 sprite is only 16 columns by 7 rows. Sprites are
+// palette-indexed string grids ("." transparent, "!" alert overlay) so the
+// art lives in code, mirrors for free when a pet turns around, and carries no
+// license baggage.
+export const W = 16
+export const H = 14
+
+const EMPTY = "................"
+const BANG = ".......!!......."
+
+const still = (body: string[]) => [EMPTY, EMPTY, ...body]
+const alert = (body: string[]) => [BANG, BANG, ...body]
+const swap = (body: string[], at: number, row: string) => body.map((line, i) => (i === at ? row : line))
+
+const CAT = [
+  "...k........k...",
+  "..kdk......kdk..",
+  "..kodk....kdok..",
+  "..koookkkkoook..",
+  ".kooooooooooook.",
+  ".kdoooooooooodk.",
+  ".koowkooookwook.",
+  ".koooowppwooook.",
+  ".kooooowwoooook.",
+  "..kooooooooook..",
+  "..kooooooooook..",
+  "..kook....kook..",
+]
+
+const DOG = [
+  "....kkkkkkkk....",
+  "..kkbbbbbbbbkk..",
+  ".kdkbbbbbbbbkdk.",
+  ".kdkbwkbbkwbkdk.",
+  ".kdkbbbbbbbbkdk.",
+  ".kkbbwwwwwwbbkk.",
+  "..kbbwwkkwwbbk..",
+  "..kbbwwppwwbbk..",
+  "...kbbbbbbbbk...",
+  "..kbbbbbbbbbbk..",
+  "..kbbbbbbbbbbk..",
+  "..kbk..kk..kbk..",
+]
+
+const BLOB = [
+  "................",
+  ".....kkkkkk.....",
+  "...kkggggggkk...",
+  "..kggggggggggk..",
+  "..kggwkggkwggk..",
+  ".kggggggggggggk.",
+  ".kggggkkkkggggk.",
+  ".kggggggggggggk.",
+  ".kggGGGGGGGGggk.",
+  ".kGGGGGGGGGGGGk.",
+  "..kGGGGGGGGGGk..",
+  "...kkkkkkkkkk...",
+]
+
+const SQUISH = [
+  "................",
+  "................",
+  "................",
+  ".....kkkkkk.....",
+  "...kkggggggkk...",
+  "..kggwkggkwggk..",
+  ".kggggggggggggk.",
+  ".kggggkkkkggggk.",
+  "kggggggggggggggk",
+  "kggGGGGGGGGGGggk",
+  "kGGGGGGGGGGGGGGk",
+  ".kkkkkkkkkkkkkk.",
+]
+
+const GHOST = [
+  ".....kkkkkk.....",
+  "...kkwwwwwwkk...",
+  "..kwwwwwwwwwwk..",
+  "..kwweewweewwk..",
+  "..kwweewweewwk..",
+  "..kwwwwwwwwwwk..",
+  "..kwwwwwwwwwwk..",
+  "..kwwwwwwwwwwk..",
+  "..kswwwwwwwwsk..",
+  "..kwwkwwwwkwwk..",
+  "...k..kwwk..k...",
+  "................",
+]
+
+const CRAB = [
+  "................",
+  "................",
+  ".kck.......kck..",
+  ".kcck.....kcck..",
+  "..kk..kkkk..kk..",
+  "...kcccccccck...",
+  "..kcwkcccckwck..",
+  ".kcccccccccccck.",
+  ".kccCCCCCCCCcck.",
+  "..kCCCCCCCCCCk..",
+  "...kkkkkkkkkk...",
+  "..k.k.k..k.k.k..",
+]
+
+const sink = (body: string[]) => [EMPTY, ...body.slice(0, body.length - 1)]
+
+const catWide = swap(CAT, 6, ".koowwoooowwook.")
+const dogWide = swap(DOG, 3, ".kdkbwwbbwwbkdk.")
+const blobWide = swap(BLOB, 4, "..kgwwggggwwgk..")
+const ghostSing = swap(swap(GHOST, 5, "..kwwwwmmwwwwk.."), 6, "..kwwwwmmwwwwk..")
+const crabWide = swap(CRAB, 6, "..kcwwccccwwck..")
+const crabStep = swap(swap(swap(CRAB, 11, ".k.k.k....k.k.k."), 2, "kck.........kck."), 3, "kcck.......kcck.")
+
+export interface Species {
+  colors: Record<string, string>
+  states: Record<State, string[][]>
+}
+
+export const SPECIES: Record<string, Species> = {
   cat: {
-    idle: ["(=^･ω･^=)", "(=^-ω-^=)"],
-    busy: ["(=^･ω･^=)ﾉ", "(=^･ω･^=)ゞ"],
-    attention: ["(=ﾟωﾟ=) ?", "(=ﾟωﾟ=) !"],
+    colors: { k: "#1c1917", o: "#f0983a", d: "#c2611e", w: "#f7f3e8", p: "#e78ea9" },
+    states: {
+      idle: [still(CAT), still(swap(CAT, 6, ".kooddooooddook."))],
+      busy: [still(swap(CAT, 11, ".kook..kk..kook.")), still(swap(CAT, 11, "..kook.kk.kook.."))],
+      attention: [alert(catWide), still(catWide)],
+    },
   },
   dog: {
-    idle: ["(´･ᴥ･`)", "(´-ᴥ-`)"],
-    busy: ["ᕕ(´･ᴥ･`)ᕗ", "ᕗ(´･ᴥ･`)ᕕ"],
-    attention: ["(´ºᴥº`) ?", "(´ºᴥº`) !"],
+    colors: { k: "#1c1917", b: "#b0793a", d: "#7c4a21", w: "#f7f3e8", p: "#e78ea9" },
+    states: {
+      idle: [still(DOG), still(swap(DOG, 3, ".kdkbkkbbkkbkdk."))],
+      busy: [still(swap(DOG, 11, ".kbk...kk...kbk.")), still(DOG)],
+      attention: [alert(dogWide), still(dogWide)],
+    },
   },
   blob: {
-    idle: ["( ˘ω˘ )", "( ˘‿˘ )"],
-    busy: ["(ﾉ´ヮ`)ﾉ*", "ヽ(´ヮ´)ノ*"],
-    attention: ["(⊙_⊙) ?", "(⊙_⊙) !"],
+    colors: { k: "#1c1917", g: "#5fd68b", G: "#2f9e5f", w: "#f7f3e8" },
+    states: {
+      idle: [still(BLOB), still(swap(BLOB, 4, "..kggkkggkkggk.."))],
+      busy: [still(BLOB), still(SQUISH)],
+      attention: [alert(blobWide), still(blobWide)],
+    },
+  },
+  ghost: {
+    colors: { k: "#2b3a55", w: "#e8edf7", s: "#b9c6e0", e: "#2b3a55", m: "#8fa3c8" },
+    states: {
+      idle: [still(GHOST), still(sink(GHOST))],
+      busy: [still(ghostSing), still(sink(ghostSing))],
+      attention: [alert(GHOST), still(GHOST)],
+    },
+  },
+  crab: {
+    colors: { k: "#1c1917", c: "#e2574c", C: "#a93226", w: "#f7f3e8" },
+    states: {
+      idle: [still(CRAB), still(swap(CRAB, 6, "..kckkcccckkck.."))],
+      busy: [still(CRAB), still(crabStep)],
+      attention: [alert(crabWide), still(crabWide)],
+    },
   },
 }
 
-export const PET_KEY = "pet"
-export const PET_OFF = "off"
+export const PETS_KEY = "pets"
 
-export function Pet(props: { sessionID?: string }) {
+export interface Px {
+  char: string
+  fg?: string
+  bg?: string
+}
+
+interface Critter {
+  species: string
+  x: number
+  dir: 1 | -1
+}
+
+export function compose(crew: Critter[], frame: number, state: State, cols: number, warn: string): Px[][] {
+  const grid = Array.from({ length: H }, () => new Array<string | undefined>(cols).fill(undefined))
+  for (const critter of crew) {
+    const species = SPECIES[critter.species]
+    if (!species) continue
+    const frames = species.states[state]
+    const art = frames[frame % frames.length]
+    const x = Math.round(critter.x)
+    for (let r = 0; r < H; r++) {
+      const row = art[r]
+      for (let c = 0; c < W; c++) {
+        const ch = critter.dir < 0 ? row[W - 1 - c] : row[c]
+        if (ch === ".") continue
+        const col = x + c
+        if (col < 0 || col >= cols) continue
+        grid[r][col] = ch === "!" ? warn : species.colors[ch]
+      }
+    }
+  }
+  const rows: Px[][] = []
+  for (let r = 0; r < H; r += 2) {
+    const line: Px[] = []
+    for (let c = 0; c < cols; c++) {
+      const top = grid[r][c]
+      const bottom = grid[r + 1][c]
+      if (top && bottom) {
+        line.push({ char: "▀", fg: top, bg: bottom })
+        continue
+      }
+      if (top) {
+        line.push({ char: "▀", fg: top })
+        continue
+      }
+      if (bottom) {
+        line.push({ char: "▄", fg: bottom })
+        continue
+      }
+      line.push({ char: " " })
+    }
+    rows.push(line)
+  }
+  while (rows.length && rows[0].every((px) => px.char === " ")) rows.shift()
+  return rows
+}
+
+export function PetStrip(props: { sessionID?: string; width: number }) {
   const kv = useKV()
   const sync = useSync()
   const { theme } = useTheme()
   const [tick, setTick] = createSignal(0)
-  const pet = createMemo(() => PETS[kv.get(PET_KEY, PET_OFF) as string])
+  const [crew, setCrew] = createSignal<Critter[]>([])
+  const list = createMemo(() => (kv.get(PETS_KEY, []) as string[]).filter((name) => SPECIES[name] !== undefined))
   const state = createMemo<State>(() => {
     const id = props.sessionID ?? ""
     if ((sync.data.permission[id] ?? []).length) return "attention"
@@ -41,28 +242,61 @@ export function Pet(props: { sessionID?: string }) {
     if (status.type !== "idle") return "busy"
     return "idle"
   })
-  const animated = createMemo(() => kv.get("animations_enabled", true) && pet() !== undefined)
+  const animated = createMemo(() => kv.get("animations_enabled", true))
+
+  // Reconcile spawned critters with the persisted list, keeping positions of
+  // the ones already on screen so spawning never teleports the others.
   createEffect(() => {
-    if (!animated()) return
-    // Blink slowly while idle, scamper while working or waiting for input.
-    const interval = setInterval(() => setTick((n) => n + 1), state() === "idle" ? 1500 : 500)
-    onCleanup(() => clearInterval(interval))
+    const names = list()
+    const span = Math.max(1, props.width - W)
+    setCrew((prev) =>
+      names.map((name, i) => {
+        const old = prev[i]
+        if (old && old.species === name) return old
+        return { species: name, x: Math.random() * span, dir: Math.random() < 0.5 ? -1 : 1 } as Critter
+      }),
+    )
   })
-  const frame = createMemo(() => {
-    const frames = pet()?.[state()] ?? []
-    if (!frames.length) return undefined
-    return frames[tick() % frames.length]
+
+  createEffect(() => {
+    if (!animated() || !list().length) return
+    const pace = state() === "busy" ? 200 : state() === "attention" ? 350 : 600
+    const timer = setInterval(() => {
+      setTick((n) => n + 1)
+      setCrew((prev) => prev.map((critter) => wander(critter, state(), props.width)))
+    }, pace)
+    onCleanup(() => clearInterval(timer))
   })
-  const color = createMemo(() => {
-    if (state() === "attention") return theme.warning
-    if (state() === "busy") return theme.primary
-    return theme.textMuted
+
+  const rows = createMemo(() => {
+    if (!list().length || props.width < W) return []
+    return compose(crew(), Math.floor(tick() / 2), state(), props.width, rgbToHex(theme.warning))
   })
+
   return (
-    <Show when={frame()}>
-      <text flexShrink={0} fg={color()}>
-        {frame()}
-      </text>
+    <Show when={rows().length}>
+      <box width="100%" overflow="hidden">
+        <Index each={rows()}>
+          {(row) => (
+            <box height={1} width="100%" overflow="hidden">
+              <text>
+                <Index each={row()}>{(px) => <span style={{ fg: px().fg, bg: px().bg }}>{px().char}</span>}</Index>
+              </text>
+            </box>
+          )}
+        </Index>
+      </box>
     </Show>
   )
+}
+
+function wander(critter: Critter, state: State, width: number): Critter {
+  if (state === "attention") return critter
+  const max = Math.max(0, width - W)
+  const flip = state === "busy" ? 0.03 : 0.05
+  const dir = Math.random() < flip ? ((critter.dir * -1) as 1 | -1) : critter.dir
+  const step = state === "busy" ? 1 : Math.random() < 0.15 ? 1 : 0
+  const x = Math.min(max, Math.max(0, critter.x + dir * step))
+  const turned = x === critter.x && step > 0 ? ((dir * -1) as 1 | -1) : dir
+  return { species: critter.species, x, dir: turned }
 }

--- a/packages/tui/src/component/pet.tsx
+++ b/packages/tui/src/component/pet.tsx
@@ -1,0 +1,68 @@
+import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-js"
+import { useKV } from "../context/kv"
+import { useSync } from "../context/sync"
+import { useTheme } from "../context/theme"
+
+type State = "idle" | "busy" | "attention"
+
+// Text-art pets so they render in every terminal, unlike graphics-protocol
+// pets. Frames within a state are kept the same width to avoid layout shift.
+export const PETS: Record<string, Record<State, string[]>> = {
+  cat: {
+    idle: ["(=^･ω･^=)", "(=^-ω-^=)"],
+    busy: ["(=^･ω･^=)ﾉ", "(=^･ω･^=)ゞ"],
+    attention: ["(=ﾟωﾟ=) ?", "(=ﾟωﾟ=) !"],
+  },
+  dog: {
+    idle: ["(´･ᴥ･`)", "(´-ᴥ-`)"],
+    busy: ["ᕕ(´･ᴥ･`)ᕗ", "ᕗ(´･ᴥ･`)ᕕ"],
+    attention: ["(´ºᴥº`) ?", "(´ºᴥº`) !"],
+  },
+  blob: {
+    idle: ["( ˘ω˘ )", "( ˘‿˘ )"],
+    busy: ["(ﾉ´ヮ`)ﾉ*", "ヽ(´ヮ´)ノ*"],
+    attention: ["(⊙_⊙) ?", "(⊙_⊙) !"],
+  },
+}
+
+export const PET_KEY = "pet"
+export const PET_OFF = "off"
+
+export function Pet(props: { sessionID?: string }) {
+  const kv = useKV()
+  const sync = useSync()
+  const { theme } = useTheme()
+  const [tick, setTick] = createSignal(0)
+  const pet = createMemo(() => PETS[kv.get(PET_KEY, PET_OFF) as string])
+  const state = createMemo<State>(() => {
+    const id = props.sessionID ?? ""
+    if ((sync.data.permission[id] ?? []).length) return "attention"
+    const status = sync.data.session_status?.[id] ?? { type: "idle" }
+    if (status.type !== "idle") return "busy"
+    return "idle"
+  })
+  const animated = createMemo(() => kv.get("animations_enabled", true) && pet() !== undefined)
+  createEffect(() => {
+    if (!animated()) return
+    // Blink slowly while idle, scamper while working or waiting for input.
+    const interval = setInterval(() => setTick((n) => n + 1), state() === "idle" ? 1500 : 500)
+    onCleanup(() => clearInterval(interval))
+  })
+  const frame = createMemo(() => {
+    const frames = pet()?.[state()] ?? []
+    if (!frames.length) return undefined
+    return frames[tick() % frames.length]
+  })
+  const color = createMemo(() => {
+    if (state() === "attention") return theme.warning
+    if (state() === "busy") return theme.primary
+    return theme.textMuted
+  })
+  return (
+    <Show when={frame()}>
+      <text flexShrink={0} fg={color()}>
+        {frame()}
+      </text>
+    </Show>
+  )
+}

--- a/packages/tui/src/component/pet.tsx
+++ b/packages/tui/src/component/pet.tsx
@@ -176,7 +176,7 @@ export const TREAT_KEY = "pet_treat"
 // (a string, an object, junk entries) must degrade to fewer pets, not a crash.
 export function roster(value: unknown): string[] {
   if (!Array.isArray(value)) return []
-  return value.filter((name): name is string => typeof name === "string" && SPECIES[name] !== undefined)
+  return value.filter((name): name is string => typeof name === "string" && Object.hasOwn(SPECIES, name))
 }
 
 // One styled run of a strip row. Rows are run-length encoded so a mostly

--- a/packages/tui/src/component/pet.tsx
+++ b/packages/tui/src/component/pet.tsx
@@ -1,5 +1,5 @@
 import { rgbToHex } from "@opentui/core"
-import { createEffect, createMemo, createSignal, onCleanup, Index, Show } from "solid-js"
+import { batch, createEffect, createMemo, createSignal, onCleanup, Index, Show } from "solid-js"
 import { useKV } from "../context/kv"
 import { useSync } from "../context/sync"
 import { useTheme } from "../context/theme"
@@ -171,8 +171,11 @@ export const SPECIES: Record<string, Species> = {
 
 export const PETS_KEY = "pets"
 
-export interface Px {
-  char: string
+// One styled run of a strip row. Rows are run-length encoded so a mostly
+// empty 200-column row costs a few spans instead of one span per cell;
+// re-rendering per-cell spans on every tick is what makes a TUI drop frames.
+export interface Seg {
+  text: string
   fg?: string
   bg?: string
 }
@@ -183,7 +186,7 @@ interface Critter {
   dir: 1 | -1
 }
 
-export function compose(crew: Critter[], frame: number, state: State, cols: number, warn: string): Px[][] {
+export function compose(crew: Critter[], frame: number, state: State, cols: number, warn: string): Seg[][] {
   const grid = Array.from({ length: H }, () => new Array<string | undefined>(cols).fill(undefined))
   for (const critter of crew) {
     const species = SPECIES[critter.species]
@@ -202,29 +205,32 @@ export function compose(crew: Critter[], frame: number, state: State, cols: numb
       }
     }
   }
-  const rows: Px[][] = []
+  const rows: Seg[][] = []
   for (let r = 0; r < H; r += 2) {
-    const line: Px[] = []
+    const line: Seg[] = []
+    let text = ""
+    let fg: string | undefined
+    let bg: string | undefined
+    const flush = () => {
+      if (text) line.push({ text, fg, bg })
+      text = ""
+    }
     for (let c = 0; c < cols; c++) {
       const top = grid[r][c]
       const bottom = grid[r + 1][c]
-      if (top && bottom) {
-        line.push({ char: "▀", fg: top, bg: bottom })
-        continue
-      }
-      if (top) {
-        line.push({ char: "▀", fg: top })
-        continue
-      }
-      if (bottom) {
-        line.push({ char: "▄", fg: bottom })
-        continue
-      }
-      line.push({ char: " " })
+      const char = top ? "▀" : bottom ? "▄" : " "
+      const nextFg = top ?? bottom
+      const nextBg = top ? bottom : undefined
+      if (text && (nextFg !== fg || nextBg !== bg)) flush()
+      fg = nextFg
+      bg = nextBg
+      text += char
     }
+    flush()
     rows.push(line)
   }
-  while (rows.length && rows[0].every((px) => px.char === " ")) rows.shift()
+  const blank = (row: Seg[]) => row.every((seg) => !seg.fg && !seg.bg && seg.text.trim() === "")
+  while (rows.length && blank(rows[0])) rows.shift()
   return rows
 }
 
@@ -262,8 +268,10 @@ export function PetStrip(props: { sessionID?: string; width: number }) {
     if (!animated() || !list().length) return
     const pace = state() === "busy" ? 200 : state() === "attention" ? 350 : 600
     const timer = setInterval(() => {
-      setTick((n) => n + 1)
-      setCrew((prev) => prev.map((critter) => wander(critter, state(), props.width)))
+      batch(() => {
+        setTick((n) => n + 1)
+        setCrew((prev) => prev.map((critter) => wander(critter, state(), props.width)))
+      })
     }, pace)
     onCleanup(() => clearInterval(timer))
   })
@@ -280,7 +288,7 @@ export function PetStrip(props: { sessionID?: string; width: number }) {
           {(row) => (
             <box height={1} width="100%" overflow="hidden">
               <text>
-                <Index each={row()}>{(px) => <span style={{ fg: px().fg, bg: px().bg }}>{px().char}</span>}</Index>
+                <Index each={row()}>{(seg) => <span style={{ fg: seg().fg, bg: seg().bg }}>{seg().text}</span>}</Index>
               </text>
             </box>
           )}

--- a/packages/tui/src/component/pet.tsx
+++ b/packages/tui/src/component/pet.tsx
@@ -229,32 +229,32 @@ export function compose(crew: Critter[], frame: number, state: State, cols: numb
     flush()
     rows.push(line)
   }
-  const blank = (row: Seg[]) => row.every((seg) => !seg.fg && !seg.bg && seg.text.trim() === "")
-  while (rows.length && blank(rows[0])) rows.shift()
+  // Never trim rows: the strip must keep a constant height while pets exist.
+  // Varying the row count per frame (squish frames, the alert flash) resizes
+  // the prompt every tick and forces a full-screen relayout, which stalls the
+  // renderer far more than drawing ever does.
   return rows
 }
 
-export function PetStrip(props: { sessionID?: string; width: number }) {
-  const kv = useKV()
-  const sync = useSync()
-  const { theme } = useTheme()
+// The strip engine, free of app contexts so tests can drive it with plain
+// accessors: spawn reconciliation, the wander/tick interval, and the composed
+// rows behind a deep-equal gate so ticks where nothing visibly changed never
+// touch the renderer.
+export function createStrip(
+  width: () => number,
+  state: () => State,
+  list: () => string[],
+  animated: () => boolean,
+  warn: () => string,
+) {
   const [tick, setTick] = createSignal(0)
   const [crew, setCrew] = createSignal<Critter[]>([])
-  const list = createMemo(() => (kv.get(PETS_KEY, []) as string[]).filter((name) => SPECIES[name] !== undefined))
-  const state = createMemo<State>(() => {
-    const id = props.sessionID ?? ""
-    if ((sync.data.permission[id] ?? []).length) return "attention"
-    const status = sync.data.session_status?.[id] ?? { type: "idle" }
-    if (status.type !== "idle") return "busy"
-    return "idle"
-  })
-  const animated = createMemo(() => kv.get("animations_enabled", true))
 
   // Reconcile spawned critters with the persisted list, keeping positions of
   // the ones already on screen so spawning never teleports the others.
   createEffect(() => {
     const names = list()
-    const span = Math.max(1, props.width - W)
+    const span = Math.max(1, width() - W)
     setCrew((prev) =>
       names.map((name, i) => {
         const old = prev[i]
@@ -266,20 +266,45 @@ export function PetStrip(props: { sessionID?: string; width: number }) {
 
   createEffect(() => {
     if (!animated() || !list().length) return
-    const pace = state() === "busy" ? 200 : state() === "attention" ? 350 : 600
+    const pace = state() === "busy" ? 250 : state() === "attention" ? 400 : 800
     const timer = setInterval(() => {
       batch(() => {
         setTick((n) => n + 1)
-        setCrew((prev) => prev.map((critter) => wander(critter, state(), props.width)))
+        setCrew((prev) => prev.map((critter) => wander(critter, state(), width())))
       })
     }, pace)
     onCleanup(() => clearInterval(timer))
   })
 
-  const rows = createMemo(() => {
-    if (!list().length || props.width < W) return []
-    return compose(crew(), Math.floor(tick() / 2), state(), props.width, rgbToHex(theme.warning))
+  return createMemo(
+    () => {
+      if (!list().length || width() < W) return []
+      return compose(crew(), Math.floor(tick() / 2), state(), width(), warn())
+    },
+    [],
+    { equals: same },
+  )
+}
+
+export function PetStrip(props: { sessionID?: string; width: number }) {
+  const kv = useKV()
+  const sync = useSync()
+  const { theme } = useTheme()
+  const list = createMemo(() => (kv.get(PETS_KEY, []) as string[]).filter((name) => SPECIES[name] !== undefined))
+  const state = createMemo<State>(() => {
+    const id = props.sessionID ?? ""
+    if ((sync.data.permission[id] ?? []).length) return "attention"
+    const status = sync.data.session_status?.[id] ?? { type: "idle" }
+    if (status.type !== "idle") return "busy"
+    return "idle"
   })
+  const rows = createStrip(
+    () => props.width,
+    state,
+    list,
+    () => kv.get("animations_enabled", true) as boolean,
+    () => rgbToHex(theme.warning),
+  )
 
   return (
     <Show when={rows().length}>
@@ -295,6 +320,15 @@ export function PetStrip(props: { sessionID?: string; width: number }) {
         </Index>
       </box>
     </Show>
+  )
+}
+
+function same(a: Seg[][], b: Seg[][]): boolean {
+  if (a.length !== b.length) return false
+  return a.every(
+    (row, r) =>
+      row.length === b[r].length &&
+      row.every((seg, i) => seg.text === b[r][i].text && seg.fg === b[r][i].fg && seg.bg === b[r][i].bg),
   )
 }
 

--- a/packages/tui/src/component/pet.tsx
+++ b/packages/tui/src/component/pet.tsx
@@ -171,6 +171,13 @@ export const SPECIES: Record<string, Species> = {
 
 export const PETS_KEY = "pets"
 
+// KV values are parsed JSON with no runtime validation, so a malformed store
+// (a string, an object, junk entries) must degrade to fewer pets, not a crash.
+export function roster(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((name): name is string => typeof name === "string" && SPECIES[name] !== undefined)
+}
+
 // One styled run of a strip row. Rows are run-length encoded so a mostly
 // empty 200-column row costs a few spans instead of one span per cell;
 // re-rendering per-cell spans on every tick is what makes a TUI drop frames.
@@ -290,7 +297,7 @@ export function PetStrip(props: { sessionID?: string; width: number }) {
   const kv = useKV()
   const sync = useSync()
   const { theme } = useTheme()
-  const list = createMemo(() => (kv.get(PETS_KEY, []) as string[]).filter((name) => SPECIES[name] !== undefined))
+  const list = createMemo(() => roster(kv.get(PETS_KEY, [])))
   const state = createMemo<State>(() => {
     const id = props.sessionID ?? ""
     if ((sync.data.permission[id] ?? []).length) return "attention"

--- a/packages/tui/src/component/pet.tsx
+++ b/packages/tui/src/component/pet.tsx
@@ -170,6 +170,7 @@ export const SPECIES: Record<string, Species> = {
 }
 
 export const PETS_KEY = "pets"
+export const TREAT_KEY = "pet_treat"
 
 // KV values are parsed JSON with no runtime validation, so a malformed store
 // (a string, an object, junk entries) must degrade to fewer pets, not a crash.
@@ -191,14 +192,47 @@ interface Critter {
   species: string
   x: number
   dir: 1 | -1
+  mood?: { kind: "love" | "munch"; until: number }
 }
 
-export function compose(crew: Critter[], frame: number, state: State, cols: number, warn: string): Seg[][] {
+export interface Treat {
+  x: number
+  until: number
+}
+
+const HEART = "#f472b6"
+const HEARTS = ["hh..hh", ".hhhh."]
+const COOKIE = { colors: { t: "#c98a3d", k: "#7a4a1d" }, rows: [".tttt.", "ttktkt", ".tttt."] }
+const LOVE_MS = 2500
+const TREAT_MS = 7000
+
+export function compose(
+  crew: Critter[],
+  frame: number,
+  state: State,
+  cols: number,
+  warn: string,
+  play?: { now: number; treat?: Treat },
+): Seg[][] {
   const grid = Array.from({ length: H }, () => new Array<string | undefined>(cols).fill(undefined))
+  if (play?.treat && play.treat.until > play.now) {
+    for (let r = 0; r < COOKIE.rows.length; r++) {
+      const row = COOKIE.rows[r]
+      for (let c = 0; c < row.length; c++) {
+        const ch = row[c] as keyof typeof COOKIE.colors | "."
+        if (ch === ".") continue
+        const col = play.treat.x + c
+        if (col < 0 || col >= cols) continue
+        grid[H - COOKIE.rows.length + r][col] = COOKIE.colors[ch]
+      }
+    }
+  }
   for (const critter of crew) {
     const species = SPECIES[critter.species]
     if (!species) continue
-    const frames = species.states[state]
+    const mood = play && critter.mood && critter.mood.until > play.now ? critter.mood.kind : undefined
+    const frames =
+      mood === "love" ? species.states.attention : mood === "munch" ? species.states.busy : species.states[state]
     const art = frames[frame % frames.length]
     const x = Math.round(critter.x)
     for (let r = 0; r < H; r++) {
@@ -206,9 +240,23 @@ export function compose(crew: Critter[], frame: number, state: State, cols: numb
       for (let c = 0; c < W; c++) {
         const ch = critter.dir < 0 ? row[W - 1 - c] : row[c]
         if (ch === ".") continue
+        // A petted pet borrows the wide-eyed attention frames; hearts replace
+        // the alarm overlay.
+        if (ch === "!" && mood) continue
         const col = x + c
         if (col < 0 || col >= cols) continue
         grid[r][col] = ch === "!" ? warn : species.colors[ch]
+      }
+    }
+    if (mood && frame % 2 === 0) {
+      for (let r = 0; r < HEARTS.length; r++) {
+        const row = HEARTS[r]
+        for (let c = 0; c < row.length; c++) {
+          if (row[c] === ".") continue
+          const col = x + 5 + c
+          if (col < 0 || col >= cols) continue
+          grid[r][col] = HEART
+        }
       }
     }
   }
@@ -256,6 +304,7 @@ export function createStrip(
 ) {
   const [tick, setTick] = createSignal(0)
   const [crew, setCrew] = createSignal<Critter[]>([])
+  const [treat, setTreat] = createSignal<Treat | undefined>(undefined)
 
   // Reconcile spawned critters with the persisted list, keeping positions of
   // the ones already on screen so spawning never teleports the others.
@@ -271,26 +320,54 @@ export function createStrip(
     )
   })
 
+  // Petted or feeding pets animate at play speed even while the session idles.
+  const lively = createMemo(() => treat() !== undefined || crew().some((critter) => critter.mood !== undefined))
+  const pace = createMemo(() => {
+    if (lively() || state() === "busy") return 250
+    if (state() === "attention") return 400
+    return 800
+  })
+
   createEffect(() => {
     if (!animated() || !list().length) return
-    const pace = state() === "busy" ? 250 : state() === "attention" ? 400 : 800
+    const wait = pace()
     const timer = setInterval(() => {
+      const now = Date.now()
       batch(() => {
         setTick((n) => n + 1)
-        setCrew((prev) => prev.map((critter) => wander(critter, state(), width())))
+        setTreat((prev) => (prev && prev.until > now ? prev : undefined))
+        setCrew((prev) => prev.map((critter) => wander(critter, state(), width(), now, treat())))
       })
-    }, pace)
+    }, wait)
     onCleanup(() => clearInterval(timer))
   })
 
-  return createMemo(
+  const rows = createMemo(
     () => {
       if (!list().length || width() < W) return []
-      return compose(crew(), Math.floor(tick() / 2), state(), width(), warn())
+      return compose(crew(), Math.floor(tick() / 2), state(), width(), warn(), { now: Date.now(), treat: treat() })
     },
     [],
     { equals: same },
   )
+
+  return {
+    rows,
+    // Pet whatever is under the given column: wide eyes and hearts.
+    poke(x: number) {
+      const until = Date.now() + LOVE_MS
+      setCrew((prev) =>
+        prev.map((critter) =>
+          x >= critter.x && x < critter.x + W ? { ...critter, mood: { kind: "love", until } } : critter,
+        ),
+      )
+    },
+    // Drop a cookie somewhere; everyone scampers over to munch it.
+    feed() {
+      const max = Math.max(0, width() - COOKIE.rows[0].length)
+      setTreat({ x: Math.round(Math.random() * max), until: Date.now() + TREAT_MS })
+    },
+  }
 }
 
 export function PetStrip(props: { sessionID?: string; width: number }) {
@@ -305,7 +382,7 @@ export function PetStrip(props: { sessionID?: string; width: number }) {
     if (status.type !== "idle") return "busy"
     return "idle"
   })
-  const rows = createStrip(
+  const strip = createStrip(
     () => props.width,
     state,
     list,
@@ -313,10 +390,18 @@ export function PetStrip(props: { sessionID?: string; width: number }) {
     () => rgbToHex(theme.warning),
   )
 
+  // The /feed command talks to the strip through a KV nonce; stale values
+  // from previous runs are ignored.
+  createEffect(() => {
+    const nonce = kv.get(TREAT_KEY, 0) as number
+    if (!nonce || Date.now() - nonce > 5000) return
+    strip.feed()
+  })
+
   return (
-    <Show when={rows().length}>
-      <box width="100%" overflow="hidden">
-        <Index each={rows()}>
+    <Show when={strip.rows().length}>
+      <box width="100%" overflow="hidden" onMouseDown={(evt) => strip.poke(evt.x)}>
+        <Index each={strip.rows()}>
           {(row) => (
             <box height={1} width="100%" overflow="hidden">
               <text>
@@ -339,8 +424,17 @@ function same(a: Seg[][], b: Seg[][]): boolean {
   )
 }
 
-function wander(critter: Critter, state: State, width: number): Critter {
-  if (state === "attention") return critter
+function wander(critter: Critter, state: State, width: number, now: number, treat?: Treat): Critter {
+  const mood = critter.mood && critter.mood.until > now ? critter.mood : undefined
+  // Being petted trumps everything: sit still and soak up the hearts.
+  if (mood?.kind === "love") return { ...critter, mood }
+  if (treat) {
+    const delta = treat.x + 3 - (critter.x + W / 2)
+    if (Math.abs(delta) <= 4) return { ...critter, mood: { kind: "munch", until: treat.until } }
+    const dir = (delta > 0 ? 1 : -1) as 1 | -1
+    return { species: critter.species, x: critter.x + dir * 2, dir }
+  }
+  if (state === "attention") return { ...critter, mood }
   const max = Math.max(0, width - W)
   const flip = state === "busy" ? 0.03 : 0.05
   const dir = Math.random() < flip ? ((critter.dir * -1) as 1 | -1) : critter.dir

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -22,6 +22,7 @@ import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { useClipboard } from "../../context/clipboard"
 import { Spinner } from "../spinner"
 import { createFire, FireStrip } from "../fire-frame"
+import { Pet } from "../pet"
 import { useSDK } from "../../context/sdk"
 import { useRoute } from "../../context/route"
 import { useProject } from "../../context/project"
@@ -1605,11 +1606,10 @@ export function Prompt(props: PromptProps) {
                   )}
                 </Show>
               </box>
-              <Show when={hasRightContent()}>
-                <box flexDirection="row" gap={1} alignItems="center">
-                  {props.right}
-                </box>
-              </Show>
+              <box flexDirection="row" gap={1} alignItems="center">
+                <Pet sessionID={props.sessionID} />
+                <Show when={hasRightContent()}>{props.right}</Show>
+              </box>
             </box>
           </box>
         </box>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -22,7 +22,7 @@ import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { useClipboard } from "../../context/clipboard"
 import { Spinner } from "../spinner"
 import { createFire, FireStrip } from "../fire-frame"
-import { Pet } from "../pet"
+import { PetStrip } from "../pet"
 import { useSDK } from "../../context/sdk"
 import { useRoute } from "../../context/route"
 import { useProject } from "../../context/project"
@@ -1456,6 +1456,9 @@ export function Prompt(props: PromptProps) {
           above the anchor, so keeping the fire out of it lets the palette sit
           flush against the input and cover the flames instead of floating
           above the whole strip. */}
+      <Show when={props.visible !== false}>
+        <PetStrip sessionID={props.sessionID} width={dimensions().width} />
+      </Show>
       <Show when={props.visible !== false && fire()}>
         <FireStrip rows={flames()} />
       </Show>
@@ -1607,7 +1610,6 @@ export function Prompt(props: PromptProps) {
                 </Show>
               </box>
               <box flexDirection="row" gap={1} alignItems="center">
-                <Pet sessionID={props.sessionID} />
                 <Show when={hasRightContent()}>{props.right}</Show>
               </box>
             </box>

--- a/packages/tui/test/component/pet-strip.test.tsx
+++ b/packages/tui/test/component/pet-strip.test.tsx
@@ -1,0 +1,78 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
+import { render } from "@opentui/solid"
+import { createSignal, Index, Show } from "solid-js"
+import { createStrip, type Seg } from "../../src/component/pet"
+
+test("animated pet strip keeps rendering fast frames", async () => {
+  const setup = await createTestRenderer({ width: 120, height: 30, useThread: false })
+  const [state, setState] = createSignal<"idle" | "busy" | "attention">("idle")
+  const [list, setList] = createSignal<string[]>([])
+  let rows!: () => Seg[][]
+  render(() => {
+    rows = createStrip(() => 120, state, list, () => true, () => "#fbbf24")
+    return (
+      <box width="100%">
+        <Show when={rows().length}>
+          <Index each={rows()}>
+            {(row) => (
+              <box height={1} width="100%" overflow="hidden">
+                <text>
+                  <Index each={row()}>
+                    {(seg) => <span style={{ fg: seg().fg, bg: seg().bg }}>{seg().text}</span>}
+                  </Index>
+                </text>
+              </box>
+            )}
+          </Index>
+        </Show>
+      </box>
+    )
+  }, setup.renderer)
+  await setup.renderOnce()
+
+  // Spawn one pet mid-flight, like the dialog does.
+  let start = performance.now()
+  setList(["cat"])
+  await setup.renderOnce()
+  console.log("spawn render ms:", (performance.now() - start).toFixed(1))
+  expect(rows().length).toBe(7)
+
+  // Let real intervals tick across state paces and confirm frames stay cheap.
+  for (const phase of ["idle", "busy", "attention"] as const) {
+    setState(phase)
+    const deadline = Date.now() + 1200
+    let frames = 0
+    let worst = 0
+    while (Date.now() < deadline) {
+      const t = performance.now()
+      await setup.renderOnce()
+      worst = Math.max(worst, performance.now() - t)
+      frames++
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+    console.log(`${phase}: ${frames} frames, worst render ms:`, worst.toFixed(1))
+    expect(worst).toBeLessThan(100)
+  }
+
+  // Spawn a full litter and hammer it in busy mode.
+  setList(["cat", "dog", "blob", "ghost", "crab", "cat", "dog", "blob", "ghost", "crab"])
+  setState("busy")
+  start = performance.now()
+  await setup.renderOnce()
+  console.log("10-pet spawn render ms:", (performance.now() - start).toFixed(1))
+  const deadline = Date.now() + 1500
+  let worst = 0
+  while (Date.now() < deadline) {
+    const t = performance.now()
+    await setup.renderOnce()
+    worst = Math.max(worst, performance.now() - t)
+    await new Promise((resolve) => setTimeout(resolve, 30))
+  }
+  console.log("10 pets busy worst render ms:", worst.toFixed(1))
+  expect(worst).toBeLessThan(100)
+  expect(setup.captureCharFrame()).toContain("▀")
+
+  setup.renderer.destroy()
+}, 30000)

--- a/packages/tui/test/component/pet-strip.test.tsx
+++ b/packages/tui/test/component/pet-strip.test.tsx
@@ -83,6 +83,7 @@ test("animated pet strip keeps rendering fast frames", async () => {
 
 test("poking a pet shows hearts and feeding drops a cookie they run to", async () => {
   const setup = await createTestRenderer({ width: 120, height: 30, useThread: false })
+  cleanup = () => setup.renderer.destroy()
   const [list] = createSignal<string[]>(["cat"])
   let strip!: ReturnType<typeof createStrip>
   render(() => {
@@ -122,12 +123,11 @@ test("poking a pet shows hearts and feeding drops a cookie they run to", async (
     },
     { maxPasses: 200 },
   )
-
-  setup.renderer.destroy()
 }, 30000)
 
 test("dragging and turning target the same individual among clones", async () => {
   const setup = await createTestRenderer({ width: 120, height: 30, useThread: false })
+  cleanup = () => setup.renderer.destroy()
   const [list] = createSignal<string[]>(["cat", "cat"])
   let strip!: ReturnType<typeof createStrip>
   render(() => {
@@ -161,6 +161,4 @@ test("dragging and turning target the same individual among clones", async () =>
   const after = strip.crew().find((critter) => critter.id === grabbed)!
   expect(after.dir).toBe(-before.dir as 1 | -1)
   expect(strip.crew().find((critter) => critter.id !== grabbed)!.dir).toBe(other.dir)
-
-  setup.renderer.destroy()
 }, 30000)

--- a/packages/tui/test/component/pet-strip.test.tsx
+++ b/packages/tui/test/component/pet-strip.test.tsx
@@ -1,12 +1,18 @@
 /** @jsxImportSource @opentui/solid */
-import { expect, test } from "bun:test"
+import { afterEach, expect, test } from "bun:test"
 import { createTestRenderer } from "@opentui/core/testing"
 import { render } from "@opentui/solid"
 import { createSignal, Index, Show } from "solid-js"
 import { createStrip, type Seg } from "../../src/component/pet"
 
+// Destroy the renderer even when an assertion throws mid-test; otherwise the
+// strip's setInterval keeps ticking and the process never settles.
+let cleanup: (() => void) | undefined
+afterEach(() => cleanup?.())
+
 test("animated pet strip keeps rendering fast frames", async () => {
   const setup = await createTestRenderer({ width: 120, height: 30, useThread: false })
+  cleanup = () => setup.renderer.destroy()
   const [state, setState] = createSignal<"idle" | "busy" | "attention">("idle")
   const [list, setList] = createSignal<string[]>([])
   let rows!: () => Seg[][]
@@ -73,6 +79,4 @@ test("animated pet strip keeps rendering fast frames", async () => {
   console.log("10 pets busy worst render ms:", worst.toFixed(1))
   expect(worst).toBeLessThan(100)
   expect(setup.captureCharFrame()).toContain("▀")
-
-  setup.renderer.destroy()
 }, 30000)

--- a/packages/tui/test/component/pet-strip.test.tsx
+++ b/packages/tui/test/component/pet-strip.test.tsx
@@ -15,13 +15,13 @@ test("animated pet strip keeps rendering fast frames", async () => {
   cleanup = () => setup.renderer.destroy()
   const [state, setState] = createSignal<"idle" | "busy" | "attention">("idle")
   const [list, setList] = createSignal<string[]>([])
-  let rows!: () => Seg[][]
+  let strip!: ReturnType<typeof createStrip>
   render(() => {
-    rows = createStrip(() => 120, state, list, () => true, () => "#fbbf24")
+    strip = createStrip(() => 120, state, list, () => true, () => "#fbbf24")
     return (
       <box width="100%">
-        <Show when={rows().length}>
-          <Index each={rows()}>
+        <Show when={strip.rows().length}>
+          <Index each={strip.rows()}>
             {(row) => (
               <box height={1} width="100%" overflow="hidden">
                 <text>
@@ -43,7 +43,7 @@ test("animated pet strip keeps rendering fast frames", async () => {
   setList(["cat"])
   await setup.renderOnce()
   console.log("spawn render ms:", (performance.now() - start).toFixed(1))
-  expect(rows().length).toBe(7)
+  expect(strip.rows().length).toBe(7)
 
   // Let real intervals tick across state paces and confirm frames stay cheap.
   for (const phase of ["idle", "busy", "attention"] as const) {
@@ -79,4 +79,49 @@ test("animated pet strip keeps rendering fast frames", async () => {
   console.log("10 pets busy worst render ms:", worst.toFixed(1))
   expect(worst).toBeLessThan(100)
   expect(setup.captureCharFrame()).toContain("▀")
+}, 30000)
+
+test("poking a pet shows hearts and feeding drops a cookie they run to", async () => {
+  const setup = await createTestRenderer({ width: 120, height: 30, useThread: false })
+  const [list] = createSignal<string[]>(["cat"])
+  let strip!: ReturnType<typeof createStrip>
+  render(() => {
+    strip = createStrip(() => 120, () => "idle", list, () => true, () => "#fbbf24")
+    return (
+      <box width="100%">
+        <Index each={strip.rows()}>
+          {(row) => (
+            <box height={1} width="100%">
+              <text>
+                <Index each={row()}>
+                  {(seg) => <span style={{ fg: seg().fg, bg: seg().bg }}>{seg().text}</span>}
+                </Index>
+              </text>
+            </box>
+          )}
+        </Index>
+      </box>
+    )
+  }, setup.renderer)
+  await setup.renderOnce()
+
+  const colors = () => new Set(strip.rows().flat().flatMap((seg) => [seg.fg, seg.bg]))
+
+  // Poke every column so the cat is hit wherever it spawned.
+  for (let x = 0; x < 120; x += 8) strip.poke(x)
+  await setup.waitFor(() => colors().has("#f472b6"), { maxPasses: 100 })
+
+  strip.feed()
+  await setup.waitFor(() => colors().has("#c98a3d"), { maxPasses: 100 })
+
+  // The cat should reach the cookie and munch within the treat window.
+  await setup.waitFor(
+    () => {
+      const rows = strip.rows()
+      return rows.length > 0 && colors().has("#c98a3d")
+    },
+    { maxPasses: 200 },
+  )
+
+  setup.renderer.destroy()
 }, 30000)

--- a/packages/tui/test/component/pet-strip.test.tsx
+++ b/packages/tui/test/component/pet-strip.test.tsx
@@ -107,8 +107,8 @@ test("poking a pet shows hearts and feeding drops a cookie they run to", async (
 
   const colors = () => new Set(strip.rows().flat().flatMap((seg) => [seg.fg, seg.bg]))
 
-  // Poke every column so the cat is hit wherever it spawned.
-  for (let x = 0; x < 120; x += 8) strip.poke(x)
+  const cat = strip.crew()[0]
+  strip.poke(cat.id)
   await setup.waitFor(() => colors().has("#f472b6"), { maxPasses: 100 })
 
   strip.feed()
@@ -122,6 +122,45 @@ test("poking a pet shows hearts and feeding drops a cookie they run to", async (
     },
     { maxPasses: 200 },
   )
+
+  setup.renderer.destroy()
+}, 30000)
+
+test("dragging and turning target the same individual among clones", async () => {
+  const setup = await createTestRenderer({ width: 120, height: 30, useThread: false })
+  const [list] = createSignal<string[]>(["cat", "cat"])
+  let strip!: ReturnType<typeof createStrip>
+  render(() => {
+    strip = createStrip(() => 120, () => "idle", list, () => true, () => "#fbbf24")
+    return <box width="100%" />
+  }, setup.renderer)
+  await setup.renderOnce()
+
+  const [one, two] = strip.crew()
+  expect(one.id).not.toBe(two.id)
+
+  // Grab clone one by its position and carry it to the far right.
+  const grabbed = strip.grab(Math.round(one.x) + 8)
+  expect(grabbed).toBeDefined()
+  strip.drag(grabbed!, 110)
+  const carried = strip.crew().find((critter) => critter.id === grabbed)!
+  expect(carried.x).toBe(102)
+  expect(carried.mood?.kind).toBe("held")
+
+  // The other clone did not move.
+  const other = strip.crew().find((critter) => critter.id !== grabbed)!
+  const still = [one, two].find((critter) => critter.id === other.id)!
+  expect(other.x).toBe(still.x)
+
+  strip.drop(grabbed!)
+  expect(strip.crew().find((critter) => critter.id === grabbed)!.mood).toBeUndefined()
+
+  // Turning flips only the pet under the cursor.
+  const before = strip.crew().find((critter) => critter.id === grabbed)!
+  strip.turn(107)
+  const after = strip.crew().find((critter) => critter.id === grabbed)!
+  expect(after.dir).toBe(-before.dir as 1 | -1)
+  expect(strip.crew().find((critter) => critter.id !== grabbed)!.dir).toBe(other.dir)
 
   setup.renderer.destroy()
 }, 30000)

--- a/packages/tui/test/component/pet.test.ts
+++ b/packages/tui/test/component/pet.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { SPECIES, W, H, compose, type Seg } from "../../src/component/pet"
+import { SPECIES, W, H, compose, roster, type Seg } from "../../src/component/pet"
 
 const expand = (row: Seg[]) => row.flatMap((seg) => seg.text.split("").map((char) => ({ char, fg: seg.fg })))
 
@@ -57,5 +57,13 @@ describe("pet sprites", () => {
       const marked = species.states.attention.some((frame) => frame.some((row) => row.includes("!")))
       expect(marked).toBe(true)
     }
+  })
+
+  test("roster normalizes malformed persisted values", () => {
+    expect(roster(undefined)).toEqual([])
+    expect(roster(null)).toEqual([])
+    expect(roster("cat")).toEqual([])
+    expect(roster({ cat: 1 })).toEqual([])
+    expect(roster([1, "cat", null, "unicorn", "dog"])).toEqual(["cat", "dog"])
   })
 })

--- a/packages/tui/test/component/pet.test.ts
+++ b/packages/tui/test/component/pet.test.ts
@@ -27,18 +27,18 @@ describe("pet sprites", () => {
     // app to relayout on every animation tick.
     for (const state of ["idle", "busy", "attention"] as const) {
       for (const frame of [0, 1]) {
-        const rows = compose([{ species: "blob", x: 0, dir: 1 as const }], frame, state, 40, "#fbbf24")
+        const rows = compose([{ id: 1, species: "blob", x: 0, dir: 1 as const }], frame, state, 40, "#fbbf24")
         expect(rows.length).toBe(H / 2)
         for (const row of rows) expect(expand(row).length).toBe(40)
       }
     }
-    const rows = compose([{ species: "cat", x: 0, dir: 1 as const }], 0, "idle", 40, "#fbbf24")
+    const rows = compose([{ id: 1, species: "cat", x: 0, dir: 1 as const }], 0, "idle", 40, "#fbbf24")
     const chars = new Set(rows.flatMap(expand).map((px) => px.char))
     expect(chars.has("▀")).toBe(true)
   })
 
   test("compose run-length encodes rows instead of one span per cell", () => {
-    const rows = compose([{ species: "cat", x: 10, dir: 1 as const }], 0, "idle", 200, "#fbbf24")
+    const rows = compose([{ id: 1, species: "cat", x: 10, dir: 1 as const }], 0, "idle", 200, "#fbbf24")
     for (const row of rows) {
       expect(expand(row).length).toBe(200)
       expect(row.length).toBeLessThan(40)
@@ -46,8 +46,8 @@ describe("pet sprites", () => {
   })
 
   test("compose mirrors a pet walking left", () => {
-    const right = compose([{ species: "cat", x: 0, dir: 1 as const }], 0, "idle", W, "#fbbf24")
-    const left = compose([{ species: "cat", x: 0, dir: -1 as const }], 0, "idle", W, "#fbbf24")
+    const right = compose([{ id: 1, species: "cat", x: 0, dir: 1 as const }], 0, "idle", W, "#fbbf24")
+    const left = compose([{ id: 1, species: "cat", x: 0, dir: -1 as const }], 0, "idle", W, "#fbbf24")
     const colors = (rows: Seg[][]) => rows.map((row) => expand(row).map((px) => px.fg))
     expect(colors(left)).toEqual(colors(right).map((row) => row.slice().reverse()))
   })

--- a/packages/tui/test/component/pet.test.ts
+++ b/packages/tui/test/component/pet.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
-import { SPECIES, W, H, compose } from "../../src/component/pet"
+import { SPECIES, W, H, compose, type Seg } from "../../src/component/pet"
+
+const expand = (row: Seg[]) => row.flatMap((seg) => seg.text.split("").map((char) => ({ char, fg: seg.fg })))
 
 describe("pet sprites", () => {
   test("every frame is a full-size grid of known palette pixels", () => {
@@ -24,17 +26,25 @@ describe("pet sprites", () => {
     const rows = compose([{ species: "cat", x: 0, dir: 1 as const }], 0, "idle", 40, "#fbbf24")
     expect(rows.length).toBeGreaterThan(0)
     expect(rows.length).toBeLessThanOrEqual(H / 2)
-    for (const row of rows) expect(row.length).toBe(40)
-    const chars = new Set(rows.flat().map((px) => px.char))
+    for (const row of rows) expect(expand(row).length).toBe(40)
+    const chars = new Set(rows.flatMap(expand).map((px) => px.char))
     expect(chars.has("▀")).toBe(true)
-    expect(rows[0].some((px) => px.char !== " ")).toBe(true)
+    expect(expand(rows[0]).some((px) => px.char !== " ")).toBe(true)
+  })
+
+  test("compose run-length encodes rows instead of one span per cell", () => {
+    const rows = compose([{ species: "cat", x: 10, dir: 1 as const }], 0, "idle", 200, "#fbbf24")
+    for (const row of rows) {
+      expect(expand(row).length).toBe(200)
+      expect(row.length).toBeLessThan(40)
+    }
   })
 
   test("compose mirrors a pet walking left", () => {
     const right = compose([{ species: "cat", x: 0, dir: 1 as const }], 0, "idle", W, "#fbbf24")
     const left = compose([{ species: "cat", x: 0, dir: -1 as const }], 0, "idle", W, "#fbbf24")
-    const flip = right.map((row) => row.slice().reverse().map((px) => ({ char: px.char === "▀" ? "▀" : px.char, fg: px.fg, bg: px.bg })))
-    expect(left.map((row) => row.map((px) => px.fg))).toEqual(flip.map((row) => row.map((px) => px.fg)))
+    const colors = (rows: Seg[][]) => rows.map((row) => expand(row).map((px) => px.fg))
+    expect(colors(left)).toEqual(colors(right).map((row) => row.slice().reverse()))
   })
 
   test("attention frames flash the alert overlay", () => {

--- a/packages/tui/test/component/pet.test.ts
+++ b/packages/tui/test/component/pet.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import { SPECIES, W, H, compose } from "../../src/component/pet"
+
+describe("pet sprites", () => {
+  test("every frame is a full-size grid of known palette pixels", () => {
+    for (const [name, species] of Object.entries(SPECIES)) {
+      for (const [state, frames] of Object.entries(species.states)) {
+        expect(frames.length).toBeGreaterThan(1)
+        for (const frame of frames) {
+          expect(frame.length).toBe(H)
+          for (const row of frame) {
+            expect(row.length).toBe(W)
+            for (const ch of row) {
+              if (ch === "." || ch === "!") continue
+              expect(species.colors[ch], `${name}/${state} uses unknown pixel "${ch}"`).toBeDefined()
+            }
+          }
+        }
+      }
+    }
+  })
+
+  test("compose renders half-block rows and trims empty leading rows", () => {
+    const rows = compose([{ species: "cat", x: 0, dir: 1 as const }], 0, "idle", 40, "#fbbf24")
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.length).toBeLessThanOrEqual(H / 2)
+    for (const row of rows) expect(row.length).toBe(40)
+    const chars = new Set(rows.flat().map((px) => px.char))
+    expect(chars.has("▀")).toBe(true)
+    expect(rows[0].some((px) => px.char !== " ")).toBe(true)
+  })
+
+  test("compose mirrors a pet walking left", () => {
+    const right = compose([{ species: "cat", x: 0, dir: 1 as const }], 0, "idle", W, "#fbbf24")
+    const left = compose([{ species: "cat", x: 0, dir: -1 as const }], 0, "idle", W, "#fbbf24")
+    const flip = right.map((row) => row.slice().reverse().map((px) => ({ char: px.char === "▀" ? "▀" : px.char, fg: px.fg, bg: px.bg })))
+    expect(left.map((row) => row.map((px) => px.fg))).toEqual(flip.map((row) => row.map((px) => px.fg)))
+  })
+
+  test("attention frames flash the alert overlay", () => {
+    for (const species of Object.values(SPECIES)) {
+      const marked = species.states.attention.some((frame) => frame.some((row) => row.includes("!")))
+      expect(marked).toBe(true)
+    }
+  })
+})

--- a/packages/tui/test/component/pet.test.ts
+++ b/packages/tui/test/component/pet.test.ts
@@ -22,14 +22,19 @@ describe("pet sprites", () => {
     }
   })
 
-  test("compose renders half-block rows and trims empty leading rows", () => {
+  test("compose renders a constant-height strip of half-block rows", () => {
+    // Height must never vary per frame: resizing the strip forces the whole
+    // app to relayout on every animation tick.
+    for (const state of ["idle", "busy", "attention"] as const) {
+      for (const frame of [0, 1]) {
+        const rows = compose([{ species: "blob", x: 0, dir: 1 as const }], frame, state, 40, "#fbbf24")
+        expect(rows.length).toBe(H / 2)
+        for (const row of rows) expect(expand(row).length).toBe(40)
+      }
+    }
     const rows = compose([{ species: "cat", x: 0, dir: 1 as const }], 0, "idle", 40, "#fbbf24")
-    expect(rows.length).toBeGreaterThan(0)
-    expect(rows.length).toBeLessThanOrEqual(H / 2)
-    for (const row of rows) expect(expand(row).length).toBe(40)
     const chars = new Set(rows.flatMap(expand).map((px) => px.char))
     expect(chars.has("▀")).toBe(true)
-    expect(expand(rows[0]).some((px) => px.char !== " ")).toBe(true)
   })
 
   test("compose run-length encodes rows instead of one span per cell", () => {

--- a/packages/tui/test/component/pet.test.ts
+++ b/packages/tui/test/component/pet.test.ts
@@ -65,5 +65,6 @@ describe("pet sprites", () => {
     expect(roster("cat")).toEqual([])
     expect(roster({ cat: 1 })).toEqual([])
     expect(roster([1, "cat", null, "unicorn", "dog"])).toEqual(["cat", "dog"])
+    expect(roster(["constructor", "toString", "__proto__"])).toEqual([])
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #97

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Ports Codex CLI's terminal pets to bolt, but rendered the same way as the DOOM fire: real 16x14 pixel-art sprites drawn with half-block cells ("▀" carries two pixel rows via fg/bg), so a full sprite is only 7 text rows and works in every terminal, no iTerm2/Kitty/Sixel graphics needed. The art is palette-indexed string grids that live in code, mirror for free when a pet turns around, and carry no license baggage:

```tsx
const CAT = [
  "...k........k...",
  "..kdk......kdk..",
  // ... 16x12 body, palette letters -> hex colors
]
export const SPECIES: Record<string, Species> = {
  cat: { colors: { k: "#1c1917", o: "#f0983a", ... }, states: { idle, busy, attention } },
  // dog, blob, ghost, crab
}
```

Five species (cat, dog, blob, ghost, crab), each with per-state frames: idle blinks (the ghost bobs, the blob breathes), busy walks/squishes/scuttles around the strip, and a pending permission request freezes them wide-eyed under a flashing theme-warning alert block. Pets roam a strip above the prompt (above the fire, when it's burning), wandering with per-pet position and direction.

`/pets` (alias `/pet`) opens a spawner: selecting a species spawns one more and keeps the dialog open, so you can spawn as many as you want (capped at 24); "dismiss all" clears the litter. The roster persists via the KV store, defaulting to none. `animations_enabled` is respected (frozen frame under reduced motion).

Pets are also interactive: click a pet to pet it (it stops wide-eyed under fluttering hearts), and `/feed` drops a cookie somewhere on the strip that every pet scampers over to munch. Play animations run at play speed even while the session idles, then everything settles back down when the moods expire.

![Playtime: petted cat with hearts, blob munching a cookie](https://backend.blacksmith.sh/api/attachments/eyJpdiI6ImtwMFVLeHR0VjErTitxTzhYNHFFVmc9PSIsInZhbHVlIjoicjVVUFdtTlczRy9CZUtJZUdzbXBkR3FNcVl5akhjMXpPb1NEL0llY2tSNWc1eUg5eWIvdloxTEtLekxPMnV6TC9tWEZkdHlDd3BVUzExMGFhUEo2UU9tQVg5dWR6YlBXVURnVXI3eGt5czl0VEwrNDJvdTZ1WUpCenFmQ2ZodVBHOTdIYTZDaUUxbHFpZDBIdW4yRWxJS2xRZ2dLN0FPZWZkMnZsSjZlZWNlZkIrbmlVQ25GZVZDaWU2V2ZNRUorZWN0YzFaYWxmZXd5Y041c040NjJaQT09IiwibWFjIjoiMGQ2OTVjNjcwZTg2OTQ2ZWViM2EyMzNjOTRhZDQ2MGQzNzYyNmZlMWY0M2QxZjU3NDA4ZDViMDhiYjRjMzRiYiIsInRhZyI6IiJ9)

### How did you verify your code works?

- `bun typecheck` and `bun test` in `packages/tui` (201 pass), including new sprite-integrity, compose, and mirroring tests
- Rendered every frame of every species/state via a throwaway pixel-grid dump to eyeball the art

### Screenshots / recordings

Idle / busy / alert frames for all five species, rendered from the sprite data:

![pets](https://backend.blacksmith.sh/api/attachments/eyJpdiI6IndBakR5ZXlYQXR1c2oyVGRDN0swL1E9PSIsInZhbHVlIjoiMGR5SkdTMUxYeU1wTEZwcDRQeVI2b0tiQWM2aHgrMUtUeGtOQUhhbVkxdnJDeUV2RVF3UERGOTlXM25JRzJYME1rTDBLME1icHJINEdWQldPU0F4OHZ4dHVOU0VRSWdOaTVXUjdjN0Y4MHR2N1lwSXN6S0VGbno3M0FnR1o5ZU9pOHNwWnBzNklvUGlrMzBqTEdpUlJ4Wld1TVhGS1FVN29ENVBxNUJONSszSWROM0hYV2creUdQcEFESHoxWU03VFZ1T2NDMjFsYlJvbE55TGlKQ3JxUT09IiwibWFjIjoiMGFkOTM1MTJlMjkxOGMyYjQ4MDk5ZTQzOTFiZjIxNTkxYzVjNWQ2ZWIyNmJhM2E3MmM3OTg1OTQ1YzFjNDMxMiIsInRhZyI6IiJ9)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animated pixel-art pets to the prompt interface.
  * Added a pet management dialog accessible via `/pets` or `/pet`.
  * View species and counts, dismiss all pets, and add pets up to a 24-pet limit.
  * Pets can be poked and fed, with visible hearts and cookie animations.
  * Changes persist between sessions, with confirmations and capacity warnings.

* **Bug Fixes**
  * Improved handling of narrow layouts, unknown pets, alerts, and disabled animation.

* **Tests**
  * Added coverage for rendering, animation, interactions, layout, mirroring, and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
