### PR TITLE
feat(memory): per-session memory controls

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -8,6 +8,8 @@ import {
   isContextOverflowFailure,
   type ProviderErrorEvent,
 } from "@opencode-ai/llm"
+import { MemoryControls } from "@opencode-ai/memory/controls"
+import { eq } from "drizzle-orm"
 import { Cause, DateTime, Effect, FiberSet, Layer, Option, Semaphore, Stream } from "effect"
 import { AgentV2 } from "../../agent"
 import { Config } from "../../config"
@@ -19,6 +21,7 @@ import { PermissionV2 } from "../../permission"
 import { ProviderV2 } from "../../provider"
 import { QuestionV2 } from "../../question"
 import { SystemContext } from "../../system-context/index"
+import { SystemContextBuiltIns } from "../../system-context/builtins"
 import { SystemContextRegistry } from "../../system-context/registry"
 import { SkillGuidance } from "../../skill/guidance"
 import { ReferenceGuidance } from "../../reference/guidance"
@@ -31,6 +34,7 @@ import { SessionHistory } from "../history"
 import { SessionInput } from "../input"
 import { SessionSchema } from "../schema"
 import { SessionStore } from "../store"
+import { SessionTable } from "../sql"
 import { type RunError, Service } from "./index"
 import { SessionRunnerModel } from "./model"
 import { createLLMEventPublisher } from "./publish-llm-event"
@@ -165,10 +169,29 @@ const layer = Layer.effect(
     const continueAfterOverflowCompaction = (step: number) =>
       new TurnTransitionError({ _tag: "ContinueAfterOverflowCompaction", step })
 
-    const loadSystemContext = (agent: AgentV2.Selection) =>
-      Effect.all([systemContext.load(), skillGuidance.load(agent), referenceGuidance.load()], {
-        concurrency: "unbounded",
-      }).pipe(Effect.map(SystemContext.combine))
+    // Sessions that opted out of memory use via the /memory controls drop the injected
+    // memory source before the context epoch snapshots the baseline.
+    const loadSystemContext = (agent: AgentV2.Selection, sessionID: SessionSchema.ID) =>
+      Effect.all(
+        [
+          systemContext.load(),
+          skillGuidance.load(agent),
+          referenceGuidance.load(),
+          db
+            .select({ metadata: SessionTable.metadata })
+            .from(SessionTable)
+            .where(eq(SessionTable.id, sessionID))
+            .get()
+            .pipe(Effect.orDie),
+        ],
+        { concurrency: "unbounded" },
+      ).pipe(
+        Effect.map(([registered, skills, references, row]) => {
+          const combined = SystemContext.combine([registered, skills, references])
+          if (MemoryControls.use(row?.metadata)) return combined
+          return SystemContext.omit(combined, SystemContextBuiltIns.memoryKey)
+        }),
+      )
 
     const runTurnAttempt = Effect.fn("SessionRunner.runTurn")(function* (
       sessionID: SessionSchema.ID,
@@ -180,7 +203,7 @@ const layer = Layer.effect(
       if (session.location.directory !== location.directory || session.location.workspaceID !== location.workspaceID)
         return yield* Effect.interrupt
       const agent = yield* agents.select(session.agent)
-      const initialized = yield* SessionContextEpoch.initialize(db, loadSystemContext(agent), session.id)
+      const initialized = yield* SessionContextEpoch.initialize(db, loadSystemContext(agent, session.id), session.id)
       const toolFibers = yield* FiberSet.make<void, ToolOutputStore.Error>()
       let needsContinuation = false
       let currentStep = step
@@ -195,7 +218,7 @@ const layer = Layer.effect(
         if (promoted > 0) currentStep = 1
       }
       const system =
-        initialized ?? (yield* SessionContextEpoch.prepare(db, events, loadSystemContext(agent), session.id))
+        initialized ?? (yield* SessionContextEpoch.prepare(db, events, loadSystemContext(agent, session.id), session.id))
       const model = yield* models.resolve(session)
       const entries = yield* SessionHistory.entriesForRunner(db, session.id, system.baselineSeq)
       const context = entries.map((entry) => entry.message)

--- a/packages/core/src/system-context/builtins.ts
+++ b/packages/core/src/system-context/builtins.ts
@@ -10,7 +10,7 @@ import { SystemContextRegistry } from "./registry"
 import { FSUtil } from "../fs-util"
 import { Global } from "../global"
 
-const memory = SystemContext.Key.make("core/memory")
+export const memoryKey = SystemContext.Key.make("core/memory")
 
 // Emit the memory guidance once per prompt, ahead of the injected index blocks.
 const guidance = [
@@ -64,7 +64,7 @@ const builtIns = Layer.effectDiscard(
     // record:false keeps startup context building free of stat writes and events.
     const ctx = { directory: location.directory, worktree: location.project.directory }
     yield* registry.register({
-      key: memory,
+      key: memoryKey,
       load: Effect.tryPromise(() => BoltMemory.context({ ctx, record: false })).pipe(
         Effect.map((result) => {
           const text = result.blocks
@@ -73,7 +73,7 @@ const builtIns = Layer.effectDiscard(
             .join("\n\n")
           if (!text) return SystemContext.empty
           return SystemContext.make({
-            key: memory,
+            key: memoryKey,
             codec: Schema.toCodecJson(Schema.String),
             load: Effect.succeed(text),
             baseline: render,

--- a/packages/core/src/system-context/index.ts
+++ b/packages/core/src/system-context/index.ts
@@ -179,6 +179,11 @@ export function combine(values: ReadonlyArray<SystemContext>): SystemContext {
   return context(sources)
 }
 
+/** Removes one source, e.g. when a session opts out of memory injection. */
+export function omit(value: SystemContext, key: Key): SystemContext {
+  return context(value[ContextTypeId].filter((source) => source.key !== key))
+}
+
 const observe = (value: SystemContext) =>
   Effect.forEach(
     value[ContextTypeId],

--- a/packages/core/src/tool/memory-recall.ts
+++ b/packages/core/src/tool/memory-recall.ts
@@ -1,12 +1,16 @@
 export * as MemoryRecallTool from "./memory-recall"
 
 import { ToolFailure } from "@opencode-ai/llm"
+import { MemoryControls } from "@opencode-ai/memory/controls"
 import { MemoryService } from "@opencode-ai/memory/effect/service"
 import { MemoryTool } from "@opencode-ai/memory/tool"
+import { eq } from "drizzle-orm"
 import { Effect, Layer, Schema } from "effect"
+import { Database } from "../database/database"
 import { makeLocationNode } from "../effect/app-node"
 import { Location } from "../location"
 import { PermissionV2 } from "../permission"
+import { SessionTable } from "../session/sql"
 import { ToolRegistry } from "./registry"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
@@ -32,6 +36,7 @@ const layer = Layer.effectDiscard(
     const tools = yield* Tools.Service
     const location = yield* Location.Service
     const permission = yield* PermissionV2.Service
+    const { db } = yield* Database.Service
     const memory = MemoryService.make()
     const ctx = { directory: location.directory, worktree: location.project.directory }
 
@@ -44,6 +49,18 @@ const layer = Layer.effectDiscard(
           toModelOutput: ({ output }) => [{ type: "text", text: output.output }],
           execute: (input, context) =>
             Effect.gen(function* () {
+              const row = yield* db
+                .select({ metadata: SessionTable.metadata })
+                .from(SessionTable)
+                .where(eq(SessionTable.id, context.sessionID))
+                .get()
+                .pipe(Effect.orDie)
+              if (!MemoryControls.use(row?.metadata))
+                return {
+                  title: "Bolt memory: off for this session",
+                  output: "Memory use is turned off for this session. Turn it back on with /memory use on.",
+                  metadata: { sources: [], count: 0 },
+                }
               // The engine reports disabled memory as a regular tool result, so only an
               // enabled store prompts for approval.
               const enabled = yield* memory.prepare({ ctx }).pipe(
@@ -81,5 +98,5 @@ const layer = Layer.effectDiscard(
 export const node = makeLocationNode({
   name: "tool/memory-recall",
   layer,
-  deps: [ToolRegistry.node, PermissionV2.node, Location.node],
+  deps: [ToolRegistry.node, PermissionV2.node, Location.node, Database.node],
 })

--- a/packages/core/src/tool/memory-save.ts
+++ b/packages/core/src/tool/memory-save.ts
@@ -1,12 +1,16 @@
 export * as MemorySaveTool from "./memory-save"
 
 import { ToolFailure } from "@opencode-ai/llm"
+import { MemoryControls } from "@opencode-ai/memory/controls"
 import { MemoryService } from "@opencode-ai/memory/effect/service"
 import { MemoryTool } from "@opencode-ai/memory/tool"
+import { eq } from "drizzle-orm"
 import { Effect, Layer, Schema } from "effect"
+import { Database } from "../database/database"
 import { makeLocationNode } from "../effect/app-node"
 import { Location } from "../location"
 import { PermissionV2 } from "../permission"
+import { SessionTable } from "../session/sql"
 import { ToolRegistry } from "./registry"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
@@ -32,6 +36,7 @@ const layer = Layer.effectDiscard(
     const tools = yield* Tools.Service
     const location = yield* Location.Service
     const permission = yield* PermissionV2.Service
+    const { db } = yield* Database.Service
     const memory = MemoryService.make()
     const ctx = { directory: location.directory, worktree: location.project.directory }
 
@@ -44,6 +49,18 @@ const layer = Layer.effectDiscard(
           toModelOutput: ({ output }) => [{ type: "text", text: output.output }],
           execute: (input, context) =>
             Effect.gen(function* () {
+              const row = yield* db
+                .select({ metadata: SessionTable.metadata })
+                .from(SessionTable)
+                .where(eq(SessionTable.id, context.sessionID))
+                .get()
+                .pipe(Effect.orDie)
+              if (!MemoryControls.contribute(row?.metadata))
+                return {
+                  title: "Bolt memory: off for this session",
+                  output: "Memory contribution is turned off for this session. Turn it back on with /memory contribute on.",
+                  metadata: { sources: [] },
+                }
               // The engine reports disabled memory as a regular tool result, so only an
               // enabled store prompts for approval.
               const enabled = yield* memory.prepare({ ctx }).pipe(
@@ -81,5 +98,5 @@ const layer = Layer.effectDiscard(
 export const node = makeLocationNode({
   name: "tool/memory-save",
   layer,
-  deps: [ToolRegistry.node, PermissionV2.node, Location.node],
+  deps: [ToolRegistry.node, PermissionV2.node, Location.node, Database.node],
 })

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -15,6 +15,7 @@
     "./autosave-status": "./src/autosave-status.ts",
     "./capture": "./src/capture/capture.ts",
     "./commands": "./src/commands.ts",
+    "./controls": "./src/controls.ts",
     "./decisions": "./src/decisions.ts",
     "./digest": "./src/capture/digest.ts",
     "./effect": "./src/effect/index.ts",

--- a/packages/memory/src/commands.ts
+++ b/packages/memory/src/commands.ts
@@ -7,6 +7,8 @@ export const MEMORY_COMMAND_CATALOG = [
   { usage: "correct <text>", description: "Save a correction to project memory" },
   { usage: "forget <query>", description: "Remove matching project memory" },
   { usage: "auto on|off", description: "Turn automatic memory saves on or off" },
+  { usage: "use on|off", description: "Use saved memories in this session" },
+  { usage: "contribute on|off", description: "Save new memories from this session" },
   { usage: "inspect", description: "Reveal the project memory folder" },
   { usage: "rebuild", description: "Rebuild the memory index from source files" },
   { usage: "purge confirm", description: "Delete all project memory files" },
@@ -25,6 +27,8 @@ export const MEMORY_OPERATIONS = [
   "forget",
   "purge",
   "auto",
+  "use",
+  "contribute",
 ] as const
 export type MemoryOperation = (typeof MEMORY_OPERATIONS)[number]
 
@@ -58,12 +62,17 @@ type Operation =
     }
   | {
       kind: "operation"
+      operation: "use" | "contribute"
+      mode: "on" | "off"
+    }
+  | {
+      kind: "operation"
       operation: "purge"
       confirm: true
     }
   | {
       kind: "operation"
-      operation: Exclude<MemoryOperation, "remember" | "correct" | "forget" | "purge" | "auto">
+      operation: Exclude<MemoryOperation, "remember" | "correct" | "forget" | "purge" | "auto" | "use" | "contribute">
     }
 
 type Usage = {
@@ -106,6 +115,11 @@ function operation(verb: string, text: string): ParsedMemoryCommand | undefined 
     const mode = text.toLowerCase()
     if (mode === "on" || mode === "off") return { kind: "operation", operation: "auto", mode }
     return usage("Missing auto mode. Run /memory auto on or /memory auto off.")
+  }
+  if (verb === "use" || verb === "contribute") {
+    const mode = text.toLowerCase()
+    if (mode === "on" || mode === "off") return { kind: "operation", operation: verb, mode }
+    return usage(`Missing ${verb} mode. Run /memory ${verb} on or /memory ${verb} off.`)
   }
   if (verb === "remember") {
     if (text) return { kind: "operation", operation: "remember", text }

--- a/packages/memory/src/controls.ts
+++ b/packages/memory/src/controls.ts
@@ -1,0 +1,22 @@
+/**
+ * Codex-style per-session memory controls, stored in the host session's metadata record
+ * (the same place as other per-session flags like the sandbox toggle).
+ *
+ * Both controls default to on whenever the memory feature is enabled; only an explicit
+ * `false` opts the session out, so untouched sessions keep full memory behavior.
+ */
+
+export const USE = "memoryUse"
+export const CONTRIBUTE = "memoryContribute"
+
+/** True when the session may use saved memories: index injection and targeted recall. */
+export function use(metadata: Record<string, unknown> | null | undefined) {
+  return metadata?.[USE] !== false
+}
+
+/** True when the session may contribute to future memory generation: turn-close capture and saves. */
+export function contribute(metadata: Record<string, unknown> | null | undefined) {
+  return metadata?.[CONTRIBUTE] !== false
+}
+
+export * as MemoryControls from "./controls"

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -2,6 +2,7 @@ export { digestSchema, mergeOps, parseJson, parseOps, typedSchema } from "./capt
 export { MemoryAutosaveStatus } from "./autosave-status"
 export { MEMORY_COMMAND_CATALOG, MEMORY_USAGE, parseMemoryCommand } from "./commands"
 export type { MemoryOperation, ParsedMemoryCommand } from "./commands"
+export { MemoryControls } from "./controls"
 export { MemoryDecisions } from "./decisions"
 export { MemoryDigest } from "./capture/digest"
 export { MemoryMarkerMeta } from "./marker-meta"

--- a/packages/memory/test/command-cases.json
+++ b/packages/memory/test/command-cases.json
@@ -133,5 +133,45 @@
     "input": "/memory wat",
     "result": "usage",
     "reason": "Unknown memory action"
+  },
+  {
+    "name": "use on operation",
+    "input": "/memory use on",
+    "result": "operation",
+    "operation": "use",
+    "mode": "on"
+  },
+  {
+    "name": "use off operation",
+    "input": "/memory use off",
+    "result": "operation",
+    "operation": "use",
+    "mode": "off"
+  },
+  {
+    "name": "use without mode",
+    "input": "/memory use",
+    "result": "usage",
+    "reason": "Missing use mode. Run /memory use on or /memory use off."
+  },
+  {
+    "name": "contribute on operation",
+    "input": "/memory contribute on",
+    "result": "operation",
+    "operation": "contribute",
+    "mode": "on"
+  },
+  {
+    "name": "contribute off operation",
+    "input": "/memory contribute off",
+    "result": "operation",
+    "operation": "contribute",
+    "mode": "off"
+  },
+  {
+    "name": "contribute without mode",
+    "input": "/memory contribute maybe",
+    "result": "usage",
+    "reason": "Missing contribute mode. Run /memory contribute on or /memory contribute off."
   }
 ]

--- a/packages/memory/test/commands.test.ts
+++ b/packages/memory/test/commands.test.ts
@@ -29,7 +29,7 @@ function expected(item: Case): ParsedMemoryCommand | undefined {
     if (!item.query) throw new Error(`Missing query for fixture: ${item.name}`)
     return { kind: "operation", operation: item.operation, query: item.query }
   }
-  if (item.operation === "auto") {
+  if (item.operation === "auto" || item.operation === "use" || item.operation === "contribute") {
     if (!item.mode) throw new Error(`Missing mode for fixture: ${item.name}`)
     return { kind: "operation", operation: item.operation, mode: item.mode }
   }

--- a/packages/memory/test/controls.test.ts
+++ b/packages/memory/test/controls.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { MemoryControls } from "../src/controls"
+
+describe("memory controls", () => {
+  test("default to on when metadata is missing or untouched", () => {
+    expect(MemoryControls.use(undefined)).toBe(true)
+    expect(MemoryControls.use(null)).toBe(true)
+    expect(MemoryControls.use({})).toBe(true)
+    expect(MemoryControls.contribute(undefined)).toBe(true)
+    expect(MemoryControls.contribute({ sandbox: true })).toBe(true)
+  })
+
+  test("only an explicit false opts the session out", () => {
+    expect(MemoryControls.use({ [MemoryControls.USE]: false })).toBe(false)
+    expect(MemoryControls.use({ [MemoryControls.USE]: true })).toBe(true)
+    expect(MemoryControls.use({ [MemoryControls.USE]: "off" })).toBe(true)
+    expect(MemoryControls.contribute({ [MemoryControls.CONTRIBUTE]: false })).toBe(false)
+    expect(MemoryControls.contribute({ [MemoryControls.CONTRIBUTE]: true })).toBe(true)
+  })
+
+  test("controls are independent", () => {
+    const metadata = { [MemoryControls.USE]: false }
+    expect(MemoryControls.use(metadata)).toBe(false)
+    expect(MemoryControls.contribute(metadata)).toBe(true)
+  })
+})

--- a/packages/opencode/src/memory/host.ts
+++ b/packages/opencode/src/memory/host.ts
@@ -2,6 +2,7 @@ import { generateText, streamText } from "ai"
 import { Effect } from "effect"
 import type { LanguageModelV3 } from "@ai-sdk/provider"
 import { MemoryConfig } from "@opencode-ai/memory/effect/config"
+import { MemoryControls } from "@opencode-ai/memory/controls"
 import { MemoryError } from "@opencode-ai/memory/effect/errors"
 import type { MemoryPorts } from "@opencode-ai/memory/effect/ports"
 import { MemoryPaths } from "@opencode-ai/memory/effect/paths"
@@ -345,6 +346,9 @@ export const close = Effect.fn("MemoryHost.close")(function* (input: {
   summary: SessionSummary.Interface
   provider: Provider.Interface
 }) {
+  const info = yield* input.sessions.get(input.sessionID)
+  // A session that opted out of contribution via the /memory controls never feeds generation.
+  if (!MemoryControls.contribute(info.metadata)) return
   const ctx = yield* InstanceState.context
   const root = MemoryPaths.root({ ctx })
   return yield* MemoryTurn.close({

--- a/packages/tui/src/component/dialog-memory.tsx
+++ b/packages/tui/src/component/dialog-memory.tsx
@@ -117,10 +117,18 @@ export function DialogMemoryHelp(props: { reason?: string; sessionID?: string })
   const toast = useToast()
   const metadata = () => (props.sessionID ? sync.session.get(props.sessionID)?.metadata : undefined)
 
+  // Refetch metadata right before writing: session.update overwrites the full
+  // metadata record, so spreading the cached sync snapshot could revert a
+  // concurrent change made while this dialog stayed open.
   async function toggle(key: string) {
     const id = props.sessionID
     if (!id) return
-    const meta = metadata()
+    const current = await sdk.client.session.get({ sessionID: id })
+    if (current.error) {
+      toast.show({ variant: "error", message: `Memory toggle failed: ${errorMessage(current.error)}` })
+      return
+    }
+    const meta = current.data?.metadata
     const result = await sdk.client.session.update({ sessionID: id, metadata: { ...meta, [key]: meta?.[key] === false } })
     if (!result.error) return
     toast.show({ variant: "error", message: `Memory toggle failed: ${errorMessage(result.error)}` })

--- a/packages/tui/src/component/dialog-memory.tsx
+++ b/packages/tui/src/component/dialog-memory.tsx
@@ -1,10 +1,12 @@
 import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core"
 import { MEMORY_COMMAND_CATALOG } from "@opencode-ai/memory/commands"
+import { MemoryControls } from "@opencode-ai/memory/controls"
 import { MemoryToken } from "@opencode-ai/memory/token"
 import { createMemo, createResource, For, Match, Show, Switch } from "solid-js"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useTuiConfig } from "../config"
 import { useSDK } from "../context/sdk"
+import { useSync } from "../context/sync"
 import { useTheme } from "../context/theme"
 import { useBindings } from "../keymap"
 import { useDialog, type DialogContext } from "../ui/dialog"
@@ -38,9 +40,9 @@ export function showMemoryDialog(dialog: DialogContext) {
   dialog.replace(() => <DialogMemory />)
 }
 
-export function showMemoryHelpDialog(dialog: DialogContext, input?: { reason?: string }) {
+export function showMemoryHelpDialog(dialog: DialogContext, input?: { reason?: string; sessionID?: string }) {
   dialog.setSize("large")
-  dialog.replace(() => <DialogMemoryHelp reason={input?.reason} />)
+  dialog.replace(() => <DialogMemoryHelp reason={input?.reason} sessionID={input?.sessionID} />)
 }
 
 export function showMemoryStatusDialog(dialog: DialogContext) {
@@ -105,25 +107,67 @@ function draft(usage: string) {
   return usage
 }
 
-export function DialogMemoryHelp(props: { reason?: string }) {
+const toggles = ["use", "contribute"] as const
+
+export function DialogMemoryHelp(props: { reason?: string; sessionID?: string }) {
   const sdk = useSDK()
+  const sync = useSync()
   const dialog = useDialog()
   const { theme } = useTheme()
   const toast = useToast()
-  const options: DialogSelectOption<string>[] = MEMORY_COMMAND_CATALOG.map((item) => ({
-    title: item.description,
-    footer: `/memory ${item.usage}`,
-    category: "Memory",
-    value: item.usage,
-  }))
+  const metadata = () => (props.sessionID ? sync.session.get(props.sessionID)?.metadata : undefined)
+
+  async function toggle(key: string) {
+    const id = props.sessionID
+    if (!id) return
+    const meta = metadata()
+    const result = await sdk.client.session.update({ sessionID: id, metadata: { ...meta, [key]: meta?.[key] === false } })
+    if (!result.error) return
+    toast.show({ variant: "error", message: `Memory toggle failed: ${errorMessage(result.error)}` })
+  }
+
+  function mark(on: boolean) {
+    return on ? "[x]" : "[ ]"
+  }
+
+  // Session toggle rows flip in place; catalog rows draft the typed command into the prompt.
+  const options = createMemo<DialogSelectOption<string>[]>(() => [
+    ...(props.sessionID
+      ? [
+          {
+            title: `${mark(MemoryControls.use(metadata()))} Use saved memories in this session`,
+            footer: "/memory use on|off",
+            category: "Session",
+            value: "use",
+            onSelect: () => void toggle(MemoryControls.USE),
+          },
+          {
+            title: `${mark(MemoryControls.contribute(metadata()))} Save new memories from this session`,
+            footer: "/memory contribute on|off",
+            category: "Session",
+            value: "contribute",
+            onSelect: () => void toggle(MemoryControls.CONTRIBUTE),
+          },
+        ]
+      : []),
+    ...MEMORY_COMMAND_CATALOG.filter(
+      (item) => !props.sessionID || !toggles.some((verb) => item.usage.startsWith(`${verb} `)),
+    ).map((item) => ({
+      title: item.description,
+      footer: `/memory ${item.usage}`,
+      category: "Memory",
+      value: item.usage,
+    })),
+  ])
 
   return (
     <DialogSelect
       title="Memory"
-      options={options}
+      options={options()}
       flat
       footer={<Show when={props.reason}>{(reason) => <text fg={theme.error}>{reason()}</text>}</Show>}
       onSelect={async (option) => {
+        if (toggles.some((verb) => option.value === verb)) return
         dialog.clear()
         const result = await sdk.client.tui.appendPrompt({ text: `/memory ${draft(option.value)}` })
         if (!result.error) return

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1028,7 +1028,7 @@ export function Prompt(props: PromptProps) {
         },
         show: () => showMemoryDialog(dialog),
         status: () => showMemoryStatusDialog(dialog),
-        usage: (reason) => showMemoryHelpDialog(dialog, { reason }),
+        usage: (reason) => showMemoryHelpDialog(dialog, { reason, sessionID: props.sessionID }),
       })
       return true
     }

--- a/packages/tui/src/feature-plugins/system/memory.tsx
+++ b/packages/tui/src/feature-plugins/system/memory.tsx
@@ -16,8 +16,11 @@ const tui: TuiPlugin = async (api) => {
         slashName: "memory",
         slashAliases: ["mem"],
         run() {
+          const route = api.route.current
+          const param = route.name === "session" && "params" in route ? route.params?.sessionID : undefined
+          const sessionID = typeof param === "string" ? param : undefined
           api.ui.dialog.setSize("large")
-          api.ui.dialog.replace(() => <DialogMemoryHelp />)
+          api.ui.dialog.replace(() => <DialogMemoryHelp sessionID={sessionID} />)
         },
       },
     ],

--- a/packages/tui/src/util/memory-command.ts
+++ b/packages/tui/src/util/memory-command.ts
@@ -8,6 +8,7 @@
  */
 
 import { MEMORY_USAGE, parseMemoryCommand, type ParsedMemoryCommand } from "@opencode-ai/memory/commands"
+import { MemoryControls } from "@opencode-ai/memory/controls"
 import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 import { errorMessage } from "./error"
 
@@ -78,6 +79,22 @@ export async function runMemoryCommand(input: {
       if (!input.inspect) throw new Error("Memory folder inspection is unavailable")
       input.toast.show({ variant: "info", message: `Memory folder: ${status.root}` })
       await input.inspect(status.root)
+      return true
+    }
+    if (parsed.operation === "use" || parsed.operation === "contribute") {
+      if (!input.sessionID) throw new Error("Open a session first.")
+      const key = parsed.operation === "use" ? MemoryControls.USE : MemoryControls.CONTRIBUTE
+      const session = read(await input.client.session.get({ sessionID: input.sessionID }))
+      read(
+        await input.client.session.update({
+          sessionID: input.sessionID,
+          metadata: { ...session.metadata, [key]: parsed.mode === "on" },
+        }),
+      )
+      input.toast.show({
+        variant: "info",
+        message: `Memory ${parsed.operation === "use" ? "use" : "contribution"} ${parsed.mode} for this session`,
+      })
       return true
     }
     if (parsed.operation === "auto") {


### PR DESCRIPTION
### Issue for this PR

Closes #100

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Codex-style per-session memory controls on top of the existing project memory feature: a session can now opt out of USING saved memories (injection and recall) and/or of CONTRIBUTING to future memory generation. Both default to on whenever memory is enabled.

The controls live in the session's `metadata` record (the same per-session flag store the `/sandbox` toggle uses) under `memoryUse` / `memoryContribute`, with helpers in the new `@opencode-ai/memory/controls` module. Only an explicit `false` opts a session out, so existing sessions keep full memory behavior:

```ts
/** True when the session may use saved memories: index injection and targeted recall. */
export function use(metadata: Record<string, unknown> | null | undefined) {
  return metadata?.[USE] !== false
}

/** True when the session may contribute to future memory generation: turn-close capture and saves. */
export function contribute(metadata: Record<string, unknown> | null | undefined) {
  return metadata?.[CONTRIBUTE] !== false
}
```

Enforcement follows the existing pipeline shape without restructuring it:

- Generation: `MemoryHost.close` (the turn-close capture hook in `packages/opencode/src/memory/host.ts`) returns before `MemoryTurn.close` when the session opted out of contribution, and the `memory_save` tool reports the session as off instead of writing.
- Injection: the V2 runner (`packages/core/src/session/runner/llm.ts`) drops the `core/memory` system-context source (new `SystemContext.omit`) before the context epoch snapshots the baseline, and the `memory_recall` tool reports the session as off instead of recalling. The tools read `SessionTable.metadata` the same way the bash tool reads the sandbox flag.

TUI surface: the `/memory` dialog gains two "Session" toggle rows with checkbox-style state that flip in place (persisted via `session.update` metadata, mirroring the sandbox toggle), and `/memory use on|off` / `/memory contribute on|off` typed commands are added to the shared command catalog and parser.

### How did you verify your code works?

- `bun typecheck` in `packages/memory`, `packages/core`, `packages/opencode`, and `packages/tui` (all clean).
- `bun test` in `packages/memory` (168 pass, including new parser fixtures for `use`/`contribute` and a new `controls.test.ts`).
- `bun test test/system-context` in `packages/core` (29 pass) and `bun test test/memory` in `packages/opencode` (4 pass).

### Screenshots / recordings

_TUI dialog change: two toggle rows ("Use saved memories in this session" / "Save new memories from this session") appear at the top of the `/memory` dialog when a session is active; no recording available from this environment._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-level controls for enabling or disabling memory use and memory contributions.
  * Added `/memory use on|off` and `/memory contribute on|off` commands.
  * Memory settings can be changed from the memory help dialog, with status feedback and error notifications.
* **Bug Fixes**
  * Disabled memory settings now prevent recalling, saving, or generating memory for the selected session.
  * Added validation and usage guidance for incomplete or invalid memory commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->