### PR TITLE
fix(core): use ripgrep search backend when a .boltignore governs the repo

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -232,7 +232,16 @@ export const fffLayer = Layer.effect(
   }),
 )
 
-const layer = Layer.unwrap(Effect.sync(() => (Flag.OPENCODE_DISABLE_FFF || !Fff.available() ? ripgrepLayer : fffLayer)))
+// fff has no ignore-file support, so repos governed by a .boltignore must use
+// the ripgrep backend to keep hidden files out of glob/find/grep results.
+const layer = Layer.unwrap(
+  Effect.gen(function* () {
+    if (Flag.OPENCODE_DISABLE_FFF || !Fff.available()) return ripgrepLayer
+    const location = yield* Location.Service
+    if (Ripgrep.ignored(location.directory)) return ripgrepLayer
+    return fffLayer
+  }),
+)
 
 export const locationLayer = layer
 

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -31,7 +31,7 @@ const MAX_SUBMATCHES = 100
 function boltignore(cwd: string) {
   const base = root(cwd)
   const file = path.join(base, ".boltignore")
-  if (!fs.existsSync(file)) return { cwd, args: [], search: ".", prefix: "" }
+  if (!fs.statSync(file, { throwIfNoEntry: false })?.isFile()) return { cwd, args: [], search: ".", prefix: "" }
   const search = path.relative(base, cwd)
   return {
     cwd: base,
@@ -54,7 +54,7 @@ function root(cwd: string) {
 // Whether a .boltignore governs this directory. Search backends without
 // ignore-file support (fff) must fall back to ripgrep when this is true.
 export function ignored(cwd: string) {
-  return fs.existsSync(path.join(root(cwd), ".boltignore"))
+  return fs.statSync(path.join(root(cwd), ".boltignore"), { throwIfNoEntry: false })?.isFile() === true
 }
 
 // -g globs follow .gitignore rules relative to the ripgrep working directory:

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -29,24 +29,32 @@ const MAX_SUBMATCHES = 100
 // directory) to keep root-anchored rules like `/src/generated/` correctly
 // scoped. User globs and output paths are translated between the two bases.
 function boltignore(cwd: string) {
-  const root = (() => {
-    let dir = cwd
-    while (true) {
-      if (fs.existsSync(path.join(dir, ".git"))) return dir
-      const parent = path.dirname(dir)
-      if (parent === dir) return cwd
-      dir = parent
-    }
-  })()
-  const file = path.join(root, ".boltignore")
+  const base = root(cwd)
+  const file = path.join(base, ".boltignore")
   if (!fs.existsSync(file)) return { cwd, args: [], search: ".", prefix: "" }
-  const search = path.relative(root, cwd)
+  const search = path.relative(base, cwd)
   return {
-    cwd: root,
+    cwd: base,
     args: [`--ignore-file=${file}`],
     search: search || ".",
     prefix: search ? `${search.replaceAll("\\", "/")}/` : "",
   }
+}
+
+function root(cwd: string) {
+  let dir = cwd
+  while (true) {
+    if (fs.existsSync(path.join(dir, ".git"))) return dir
+    const parent = path.dirname(dir)
+    if (parent === dir) return cwd
+    dir = parent
+  }
+}
+
+// Whether a .boltignore governs this directory. Search backends without
+// ignore-file support (fff) must fall back to ripgrep when this is true.
+export function ignored(cwd: string) {
+  return fs.existsSync(path.join(root(cwd), ".boltignore"))
 }
 
 // -g globs follow .gitignore rules relative to the ripgrep working directory:

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -69,6 +69,24 @@ describe("Ripgrep", () => {
     ),
   )
 
+  it.live("ignored reports whether a .boltignore governs a directory", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => fs.mkdir(path.join(tmp.path, "src"), { recursive: true }))
+          yield* Effect.promise(() => Bun.$`git init -q ${tmp.path}`)
+          expect(Ripgrep.ignored(tmp.path)).toBe(false)
+          expect(Ripgrep.ignored(path.join(tmp.path, "src"))).toBe(false)
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, ".boltignore"), "hidden.txt\n"))
+          expect(Ripgrep.ignored(tmp.path)).toBe(true)
+          // Subdirectories resolve the .boltignore at the repository root.
+          expect(Ripgrep.ignored(path.join(tmp.path, "src"))).toBe(true)
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("never includes git metadata", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),


### PR DESCRIPTION
### Issue for this PR

Closes #106

### Type of change

- [x] Bug fix

### What does this PR do?

`.boltignore` was silently bypassed on most installs: the search layer picks the fff backend whenever it is available, and fff builds its own index with no ignore-file support (its `InitOptions` has no exclude mechanism), so files hidden via `.boltignore` still showed up in glob/find/grep and @-mention autocomplete. Only the ripgrep fallback applied the rules.

The fix makes the backend chooser fall back to ripgrep when a `.boltignore` governs the location:

```ts
const layer = Layer.unwrap(
  Effect.gen(function* () {
    if (Flag.OPENCODE_DISABLE_FFF || !Fff.available()) return ripgrepLayer
    const location = yield* Location.Service
    if (Ripgrep.ignored(location.directory)) return ripgrepLayer
    return fffLayer
  }),
)
```

`Ripgrep.ignored(cwd)` is a new exported predicate that reuses the existing git-root walk (extracted into a shared `root` helper) to check for a `.boltignore` at the repository root. Repos without a `.boltignore` keep the fff backend and its performance; repos that opted in trade fff for correct hiding.

### How did you verify your code works?

- Added `Ripgrep.ignored` test covering root and subdirectory resolution: `bun test ./test/ripgrep.test.ts` (4 pass)
- `bun test ./test/filesystem/search.test.ts` (2 pass)
- `bun typecheck` in `packages/core` clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-search backend selection for repositories using `.boltignore`.
  * Automatically uses ripgrep when ignore rules cannot be supported by the default search backend.
  * Preserved existing search availability and disablement behavior.

* **Tests**
  * Added coverage for detecting `.boltignore` files from repository roots and subdirectories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->