### PR TITLE
fix(release): compute versions from our own package and fix the release tag push

### DIFF
--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -34,7 +34,7 @@ const IS_PREVIEW = CHANNEL !== "latest"
 const VERSION = await (async () => {
   if (env.OPENCODE_VERSION) return env.OPENCODE_VERSION
   if (IS_PREVIEW) return `0.0.0-${CHANNEL}-${new Date().toISOString().slice(0, 16).replace(/[-:T]/g, "")}`
-  const version = await fetch("https://registry.npmjs.org/opencode-ai/latest")
+  const version = await fetch("https://registry.npmjs.org/@bolt-builder/bolt-cli/latest")
     .then((res) => {
       if (!res.ok) throw new Error(res.statusText)
       return res.json()

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -65,9 +65,16 @@ if (Script.release && !Script.preview) {
   // partially failed publish), prepareReleaseFiles leaves the tree clean and
   // an unconditional `git commit` would fail with "nothing to commit".
   if (await $`git status --porcelain --untracked-files=no`.text()) await $`git commit -am "release: ${tag}"`
+  // Bare --force-with-lease can never move an existing tag: tags have no
+  // remote-tracking refs, so git rejects the push with "stale info". Pin the
+  // lease to the tag value fetched at the start of this run instead. New tags
+  // get an empty expectation (remote ref must not exist), and re-dispatching a
+  // failed publish moves its own tag, while a tag moved concurrently by
+  // another run still fails the lease.
+  const prior = (await $`git rev-parse --verify refs/tags/${tag}`.nothrow().quiet().text()).trim()
   await $`git tag -d ${tag}`.nothrow()
   await $`git tag ${tag}`
-  await $`git push origin refs/tags/${tag} --force-with-lease --no-verify`
+  await $`git push origin refs/tags/${tag} --force-with-lease=refs/tags/${tag}:${prior} --no-verify`
   await new Promise((resolve) => setTimeout(resolve, 5_000))
   await $`git fetch origin`
   await $`git checkout -B dev origin/dev`


### PR DESCRIPTION
### Issue for this PR

Closes #112

### Type of change

- [x] Bug fix

### What does this PR do?

Dispatched publish runs (`release minor`, run 30674373201) fail deterministically at the tag push with `! [rejected] v1.19.0 (stale info)`. Two compounding rebrand-era bugs:

1. **Version bumps read the upstream package.** `packages/script/src/index.ts` fetched `registry.npmjs.org/opencode-ai/latest` (upstream OpenCode, 1.18.x) instead of our published `@bolt-builder/bolt-cli` (1.19.0). A minor bump therefore computed 1.19.0 — a version we already shipped — and the run had to move the existing `v1.19.0` tag. Now it reads our own package, so the next minor correctly becomes 1.20.0.

2. **Bare `--force-with-lease` can never move a tag.** Tags have no remote-tracking refs, so git rejects any existing-tag move with `stale info` regardless of concurrency — which also broke the intended recovery flow of re-dispatching a failed publish with the same version. The push now pins the lease to the tag value fetched at the start of the run:

```ts
const prior = (await $`git rev-parse --verify refs/tags/${tag}`.nothrow().quiet().text()).trim()
await $`git tag -d ${tag}`.nothrow()
await $`git tag ${tag}`
await $`git push origin refs/tags/${tag} --force-with-lease=refs/tags/${tag}:${prior} --no-verify`
```

New tags get an empty expectation (remote ref must not exist), a re-dispatch can move its own tag, and a tag moved concurrently by another run still fails the lease.

Push-triggered runs were never affected: they are previews and skip the tag push, which is why only dispatched bump runs failed.

### How did you verify your code works?

Reproduced the lease semantics against a local bare repo covering all three cases: new tag push succeeds, intentional move after fetch succeeds, and a concurrent move by another writer is rejected with `stale info`. Also confirmed via the npm registry that `opencode-ai@latest` is 1.18.x while `@bolt-builder/bolt-cli@latest` is 1.19.0, matching the observed collision.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * Preview releases now correctly use the latest version of the Bolt CLI package when determining version information.
  * Re-running a release can safely update an existing tag while protecting against unexpected concurrent changes.
  * Version parsing and increment behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->