### PR TITLE
fix(release): generate real release notes instead of "Initial release"

### DIFF
--- a/.github/TEAM_MEMBERS
+++ b/.github/TEAM_MEMBERS
@@ -1,3 +1,4 @@
-Devflex-ai
+DevFlex-AI
 bolt-cli-bot[bot]
+bolt-cli[bot]
 bolt-cli

--- a/script/changelog.ts
+++ b/script/changelog.ts
@@ -1,9 +1,36 @@
 #!/usr/bin/env bun
 import path from "path"
+import { parseArgs } from "util"
+
+import { $ } from "bun"
 
 const root = path.resolve(import.meta.dir, "..")
 const file = path.join(root, "UPCOMING_CHANGELOG.md")
 
-await Bun.write(file, "Initial release\n")
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    from: { type: "string", short: "f" },
+    to: { type: "string", short: "t", default: "HEAD" },
+  },
+})
+
+const args = ["script/raw-changelog.ts", "--to", values.to!]
+if (values.from) args.push("--from", values.from)
+
+const raw = await $`bun ${args}`.cwd(root).nothrow().text()
+
+// raw-changelog prefixes machine metadata; keep a human "changes since" line instead
+const lines = raw.split("\n")
+const since = lines.find((line) => line.startsWith("Last release: "))?.slice("Last release: ".length)
+const body = lines
+  .filter((line) => !line.startsWith("Last release: ") && !line.startsWith("Target ref: "))
+  .join("\n")
+  .trim()
+
+const empty = !body || body === "No notable changes."
+const notes = empty ? "No notable changes" : since ? `Changes since ${since}\n\n${body}` : body
+
+await Bun.write(file, notes + "\n")
 
 process.exit(0)

--- a/script/raw-changelog.ts
+++ b/script/raw-changelog.ts
@@ -23,14 +23,27 @@ type Diff = {
 }
 
 const repo = process.env.GH_REPO ?? "bolt-builder/bolt-cli"
-const bot = ["actions-user", "github-actions[bot]", "opencode", "opencode-agent[bot]"]
+const bot = [
+  "actions-user",
+  "github-actions[bot]",
+  "opencode",
+  "opencode-agent[bot]",
+  "deepsource-autofix[bot]",
+  "dependabot[bot]",
+]
 const team = [
   ...(await Bun.file(new URL("../.github/TEAM_MEMBERS", import.meta.url))
     .text()
     .then((x) => x.split(/\r?\n/).map((x) => x.trim()))
     .then((x) => x.filter((x) => x && !x.startsWith("#")))),
   ...bot,
-]
+].map((x) => x.toLowerCase())
+
+function internal(login: string | null) {
+  return !!login && team.includes(login.toLowerCase())
+}
+
+const skip = /^(ignore|test|chore|ci|release)(\([^)]*\))?:|^sync release versions/i
 const order = ["Core", "TUI", "Desktop", "SDK", "Extensions"] as const
 const sections = {
   core: "Core",
@@ -126,7 +139,7 @@ async function commits(from: string, to: string) {
   for (const hash of log.split("\n").filter(Boolean)) {
     const item = data.get(hash)
     if (!item) continue
-    if (/^(ignore:|test:|chore:|ci:|release:)/i.test(item.message)) continue
+    if (skip.test(item.message)) continue
 
     const diff = await $`git diff-tree --no-commit-id --name-only -r ${hash}`.text()
     const areas = new Set<string>()
@@ -160,8 +173,9 @@ async function contributors(from: string, to: string) {
   const users: User = new Map()
   for (const item of await diff(base, head)) {
     const title = item.message.split("\n")[0] ?? ""
-    if (!item.login || team.includes(item.login)) continue
-    if (/^(ignore:|test:|chore:|ci:|release:)/i.test(title)) continue
+    if (internal(item.login)) continue
+    if (!item.login) continue
+    if (skip.test(title)) continue
     if (!users.has(item.login)) users.set(item.login, new Set())
     users.get(item.login)!.add(title)
   }
@@ -208,7 +222,7 @@ function format(from: string, to: string, list: Commit[], thanks: string[]) {
   }
 
   for (const commit of list) {
-    const attr = commit.author && !team.includes(commit.author) ? ` (@${commit.author})` : ""
+    const attr = commit.author && !internal(commit.author) ? ` (@${commit.author})` : ""
     grouped.get(section(commit.areas))!.get(type(commit.message))!.push(`- \`${commit.hash}\` ${commit.message}${attr}`)
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #117

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Every release body said "Initial release" because `script/changelog.ts` was a stub that hardcoded that string into `UPCOMING_CHANGELOG.md`, the file `script/version.ts` passes to `gh release create --notes-file`. The real generator (`script/raw-changelog.ts`) existed but was never invoked.

`changelog.ts` now runs the raw generator and reshapes its machine header into a human line:

```ts
const raw = await $`bun ${args}`.cwd(root).nothrow().text()
const since = lines.find((line) => line.startsWith("Last release: "))?.slice("Last release: ".length)
const notes = empty ? "No notable changes" : since ? `Changes since ${since}

${body}` : body
await Bun.write(file, notes + "
")
```

Also fixes note quality in `raw-changelog.ts`: the type filter now matches scoped prefixes (`chore(scope):`, `test(scope):`) plus the `sync release versions` commit, team matching is case-insensitive (TEAM_MEMBERS had `Devflex-ai` vs the real login `DevFlex-AI`, so the maintainer was thanked as a community contributor), and `deepsource-autofix[bot]` / `dependabot[bot]` are treated as bots.

### How did you verify your code works?

Ran `bun script/changelog.ts --from 1.19.0 --to v1.20.0` against the live repo: produces grouped Core/TUI/Desktop/SDK/Extensions sections with real commits, no chore/test/sync noise, and only genuine community contributors in the thanks section. `bun script/changelog.ts --to HEAD` (only docs/image commits since v1.20.0) correctly falls back to "No notable changes".

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->