### PR TITLE
fix(desktop): ad-hoc sign unsigned macOS builds to avoid damaged-app error

### DIFF
--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -37,6 +37,8 @@ async function signWindows(configuration: { path: string }) {
 async function adhoc(context: AfterPackContext) {
   if (context.electronPlatformName !== "darwin") return
   if (process.env.CSC_LINK || process.env.CSC_IDENTITY_AUTO_DISCOVERY !== "false") return
+  if (process.platform !== "darwin")
+    throw new Error("ad-hoc signing the macOS bundle requires codesign, which is only available on macOS hosts")
   const app = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`)
   await execFileAsync("codesign", ["--force", "--deep", "--sign", "-", app])
   console.log(`ad-hoc signed ${app} (no Developer ID identity available)`)

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
 
-import type { AfterPackContext, Configuration } from "electron-builder"
+import type { Configuration } from "electron-builder"
 
 const execFileAsync = promisify(execFile)
 const packageDir = path.dirname(fileURLToPath(import.meta.url))
@@ -30,19 +30,14 @@ async function signWindows(configuration: { path: string }) {
 }
 
 // Without a Developer ID identity electron-builder skips signing entirely and
-// Gatekeeper reports the quarantined download as "damaged". Ad-hoc signing keeps
-// the bundle seal valid so users get the bypassable "unidentified developer"
-// dialog instead. Only runs when CI has explicitly disabled identity discovery
-// because the certificate secret is absent.
-async function adhoc(context: AfterPackContext) {
-  if (context.electronPlatformName !== "darwin") return
-  if (process.env.CSC_LINK || process.env.CSC_IDENTITY_AUTO_DISCOVERY !== "false") return
-  if (process.platform !== "darwin")
-    throw new Error("ad-hoc signing the macOS bundle requires codesign, which is only available on macOS hosts")
-  const app = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`)
-  await execFileAsync("codesign", ["--force", "--deep", "--sign", "-", app])
-  console.log(`ad-hoc signed ${app} (no Developer ID identity available)`)
-}
+// Gatekeeper reports the quarantined download as "damaged". Falling back to
+// electron-builder's native ad-hoc signing (identity "-") keeps the bundle seal
+// valid, applies the entitlements per component, and gives users the bypassable
+// "unidentified developer" dialog instead. Only applies when CI has explicitly
+// disabled identity discovery because the certificate secret is absent; non-mac
+// hosts are guarded inside electron-builder, which skips mac signing entirely.
+const identity =
+  !process.env.CSC_LINK && process.env.CSC_IDENTITY_AUTO_DISCOVERY === "false" ? "-" : undefined
 
 const channel = (() => {
   const raw = process.env.OPENCODE_CHANNEL
@@ -58,7 +53,6 @@ const APP_IDS = {
 
 const getBase = (appId: string): Configuration => ({
   artifactName: "bolt-desktop-${os}-${arch}.${ext}",
-  afterPack: adhoc,
   directories: {
     output: "dist",
     buildResources: "resources",
@@ -91,6 +85,7 @@ const getBase = (appId: string): Configuration => ({
   mac: {
     category: "public.app-category.developer-tools",
     icon: `resources/icons/icon.icns`,
+    identity,
     hardenedRuntime: true,
     gatekeeperAssess: false,
     entitlements: "resources/entitlements.plist",

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
 
-import type { Configuration } from "electron-builder"
+import type { AfterPackContext, Configuration } from "electron-builder"
 
 const execFileAsync = promisify(execFile)
 const packageDir = path.dirname(fileURLToPath(import.meta.url))
@@ -29,6 +29,19 @@ async function signWindows(configuration: { path: string }) {
   )
 }
 
+// Without a Developer ID identity electron-builder skips signing entirely and
+// Gatekeeper reports the quarantined download as "damaged". Ad-hoc signing keeps
+// the bundle seal valid so users get the bypassable "unidentified developer"
+// dialog instead. Only runs when CI has explicitly disabled identity discovery
+// because the certificate secret is absent.
+async function adhoc(context: AfterPackContext) {
+  if (context.electronPlatformName !== "darwin") return
+  if (process.env.CSC_LINK || process.env.CSC_IDENTITY_AUTO_DISCOVERY !== "false") return
+  const app = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`)
+  await execFileAsync("codesign", ["--force", "--deep", "--sign", "-", app])
+  console.log(`ad-hoc signed ${app} (no Developer ID identity available)`)
+}
+
 const channel = (() => {
   const raw = process.env.OPENCODE_CHANNEL
   if (raw === "dev" || raw === "beta" || raw === "prod") return raw
@@ -43,6 +56,7 @@ const APP_IDS = {
 
 const getBase = (appId: string): Configuration => ({
   artifactName: "bolt-desktop-${os}-${arch}.${ext}",
+  afterPack: adhoc,
   directories: {
     output: "dist",
     buildResources: "resources",


### PR DESCRIPTION
### Issue for this PR

Closes #121

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The published macOS desktop app fails to launch with Gatekeeper's "Bolt is damaged and can't be opened" error. The release logs show why: the `APPLE_CERTIFICATE` secret is absent, so `publish.yml` skips the cert import and electron-builder logs `skipped macOS application code signing ... 0 identities found` (run 30684263211). The shipped `.app` is unsigned, and macOS reports quarantined unsigned bundles as "damaged" with no bypass offered.

Fix: fall back to electron-builder's native ad-hoc signing by setting `mac.identity` to `"-"` when, and only when, CI has disabled identity discovery because the certificate secret is missing:

```ts
const identity =
  !process.env.CSC_LINK && process.env.CSC_IDENTITY_AUTO_DISCOVERY === "false" ? "-" : undefined
```

Compared to a manual `codesign` afterPack hook (this PR's first iteration), the native path signs per component via osx-sign, applies `resources/entitlements.plist` (which already carries `com.apple.security.cs.disable-library-validation`, required for ad-hoc + hardened runtime), and is guarded by electron-builder's `isSignAllowed()`, which safely skips mac signing on non-macOS hosts. With a valid ad-hoc seal, Gatekeeper shows the "unidentified developer" dialog, bypassable via right-click Open.

Once the `APPLE_CERTIFICATE` / notarization secrets are provisioned (tracked in #121), `CSC_LINK` is set, the guard yields `undefined`, and proper Developer ID signing + notarization takes over with no further changes.

### How did you verify your code works?

`bun typecheck` and `bun test electron-builder.config.test.ts` (7 pass) from `packages/desktop`. Verified in app-builder-lib 26.15.2 source that `identity: "-"` produces a synthetic ad-hoc identity (`MacTargetHelper.findSigningIdentity`) and that `isSignAllowed()` skips signing on non-darwin hosts. The env guard mirrors the exact state `publish.yml` sets in its no-cert branch.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS application packaging when no Developer ID signing identity is available.
  * Added ad-hoc signing in eligible packaging scenarios to support smoother app creation and distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->