### PR TITLE
fix(release): exclude upstream commits from community contributors

### DIFF
--- a/script/raw-changelog.ts
+++ b/script/raw-changelog.ts
@@ -20,6 +20,7 @@ type Diff = {
   sha: string
   login: string | null
   message: string
+  parents: number
 }
 
 const repo = process.env.GH_REPO ?? "bolt-builder/bolt-cli"
@@ -74,7 +75,7 @@ async function diff(base: string, head: string) {
   const list: Diff[] = []
   for (let page = 1; ; page++) {
     const text =
-      await $`gh api "/repos/${repo}/compare/${base}...${head}?per_page=100&page=${page}" --jq '.commits[] | {sha: .sha, login: .author.login, message: .commit.message}'`.text()
+      await $`gh api "/repos/${repo}/compare/${base}...${head}?per_page=100&page=${page}" --jq '.commits[] | {sha: .sha, login: .author.login, message: .commit.message, parents: (.parents | length)}'`.text()
     const batch = text
       .split("\n")
       .filter(Boolean)
@@ -166,6 +167,18 @@ async function commits(from: string, to: string) {
   return reverted(list)
 }
 
+// A commit only counts as a community contribution when a PR in this repo was
+// authored by the commit author. Upstream commits arrive through sync merges
+// whose PR is authored by a bot or team member, so they fail this check.
+async function authored(sha: string, login: string) {
+  const data = await $`gh api "/repos/${repo}/commits/${sha}/pulls"`.json()
+  return (data as { user: { login: string }; base: { repo: { full_name: string } } }[]).some(
+    (pr) =>
+      pr.base.repo.full_name.toLowerCase() === repo.toLowerCase() &&
+      pr.user.login.toLowerCase() === login.toLowerCase(),
+  )
+}
+
 async function contributors(from: string, to: string) {
   const base = ref(from)
   const head = ref(to)
@@ -176,6 +189,8 @@ async function contributors(from: string, to: string) {
     if (internal(item.login)) continue
     if (!item.login) continue
     if (skip.test(title)) continue
+    if (item.parents > 1) continue
+    if (!(await authored(item.sha, item.login))) continue
     if (!users.has(item.login)) users.set(item.login, new Set())
     users.get(item.login)!.add(title)
   }

--- a/script/raw-changelog.ts
+++ b/script/raw-changelog.ts
@@ -171,12 +171,14 @@ async function commits(from: string, to: string) {
 // authored by the commit author. Upstream commits arrive through sync merges
 // whose PR is authored by a bot or team member, so they fail this check.
 async function authored(sha: string, login: string) {
-  const data = await $`gh api "/repos/${repo}/commits/${sha}/pulls"`.json()
-  return (data as { user: { login: string }; base: { repo: { full_name: string } } }[]).some(
-    (pr) =>
-      pr.base.repo.full_name.toLowerCase() === repo.toLowerCase() &&
-      pr.user.login.toLowerCase() === login.toLowerCase(),
-  )
+  const data = await $`gh api --paginate --slurp "/repos/${repo}/commits/${sha}/pulls?per_page=100"`.json()
+  return (data as { user: { login: string }; base: { repo: { full_name: string } } }[][])
+    .flat()
+    .some(
+      (pr) =>
+        pr.base.repo.full_name.toLowerCase() === repo.toLowerCase() &&
+        pr.user.login.toLowerCase() === login.toLowerCase(),
+    )
 }
 
 async function contributors(from: string, to: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #124

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The v1.20.2 draft notes thanked upstream OpenCode authors (@fwang, @OpeOginni) as bolt-cli community contributors, including a raw `Merge branch 'dev' of github.com:anomalyco/opencode into dev` line. Those commits entered through the upstream sync merge (PR #120 by pull[bot]), not through contributions to this repo: `contributors()` in `script/raw-changelog.ts` walks every commit in the compare range with no filtering on merge commits or where the commit came from.

The fix skips merge commits (compare API parent count) and only credits a commit when a PR in this repo was authored by the commit author:

```ts
async function authored(sha: string, login: string) {
  const data = await $`gh api "/repos/${repo}/commits/${sha}/pulls"`.json()
  return (data as { user: { login: string }; base: { repo: { full_name: string } } }[]).some(
    (pr) =>
      pr.base.repo.full_name.toLowerCase() === repo.toLowerCase() &&
      pr.user.login.toLowerCase() === login.toLowerCase(),
  )
}
```

Upstream commits only associate with the sync PR (authored by pull[bot] or a team member), so they fail the check; a genuine community PR into this repo passes because its PR author is the contributor. Verified against real API data: upstream `f67e80c` associates with anomalyco/opencode#39842 (OpeOginni) and bolt-cli#120 (pull[bot]) so it is excluded, while in-repo commits associate with their own PR.

### How did you verify your code works?

Ran `bun script/raw-changelog.ts --from 1.20.1 --to HEAD` before and after: before reproduces the v1.20.2 draft's bogus "Thank you to 2 community contributors" section; after, the section is gone while the Desktop and SDK entries are unchanged.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog contributor attribution by excluding merge commits.
  * Contributor recognition now requires verified pull-request authorship in the configured repository.
  * Changelog entries now include commit parent information for more accurate history tracking.
  * These improvements provide more reliable contributor information and commit-history details in generated changelogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->