### PR TITLE
fix(desktop): skip notarization for ad-hoc signed macOS builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -391,6 +391,11 @@ jobs:
             unset CSC_KEY_PASSWORD
             export CSC_IDENTITY_AUTO_DISCOVERY=false
           fi
+          # APPLE_API_KEY is a path and always non-empty; a partial notary env
+          # makes electron-builder fail hard instead of skipping notarization.
+          if [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER" ]; then
+            unset APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER
+          fi
           # macOS dmgbuild flakes with "hdiutil: couldn't eject - Resource busy" when
           # Spotlight/XProtect briefly holds the mounted DMG volume; retry up to 3 times.
           for attempt in 1 2 3; do

--- a/packages/desktop/electron-builder.config.test.ts
+++ b/packages/desktop/electron-builder.config.test.ts
@@ -89,3 +89,39 @@ for (const channel of ["beta", "prod"] as const) {
     })
   })
 }
+
+test("skips notarization for ad-hoc signed builds", async () => {
+  const link = process.env.CSC_LINK
+  const discovery = process.env.CSC_IDENTITY_AUTO_DISCOVERY
+  delete process.env.CSC_LINK
+  process.env.CSC_IDENTITY_AUTO_DISCOVERY = "false"
+
+  const module = await import("./electron-builder.config.ts?notarize=adhoc")
+  const config = module.default as Configuration
+
+  if (link === undefined) delete process.env.CSC_LINK
+  else process.env.CSC_LINK = link
+  if (discovery === undefined) delete process.env.CSC_IDENTITY_AUTO_DISCOVERY
+  else process.env.CSC_IDENTITY_AUTO_DISCOVERY = discovery
+
+  expect(config.mac?.identity).toBe("-")
+  expect(config.mac?.notarize).toBe(false)
+})
+
+test("notarizes when a signing certificate is available", async () => {
+  const link = process.env.CSC_LINK
+  const discovery = process.env.CSC_IDENTITY_AUTO_DISCOVERY
+  process.env.CSC_LINK = "base64-cert"
+  delete process.env.CSC_IDENTITY_AUTO_DISCOVERY
+
+  const module = await import("./electron-builder.config.ts?notarize=cert")
+  const config = module.default as Configuration
+
+  if (link === undefined) delete process.env.CSC_LINK
+  else process.env.CSC_LINK = link
+  if (discovery === undefined) delete process.env.CSC_IDENTITY_AUTO_DISCOVERY
+  else process.env.CSC_IDENTITY_AUTO_DISCOVERY = discovery
+
+  expect(config.mac?.identity).toBeUndefined()
+  expect(config.mac?.notarize).toBe(true)
+})

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -89,7 +89,9 @@ const getBase = (appId: string): Configuration => ({
     gatekeeperAssess: false,
     entitlements: "resources/entitlements.plist",
     entitlementsInherit: "resources/entitlements.plist",
-    notarize: true,
+    // Apple only notarizes Developer ID signed apps; ad-hoc builds must skip
+    // notarization or electron-builder fails looking for notary credentials.
+    notarize: identity !== "-",
     target: ["dmg", "zip"],
   },
   dmg: {


### PR DESCRIPTION
### Issue for this PR

Closes #126

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The v1.20.2 release run failed on both macOS jobs (`macos-26` arm64 failed all 3 packaging attempts, cancelling the rest of the matrix) with `⨯ Env vars APPLE_API_KEY, APPLE_API_KEY_ID and APPLE_API_ISSUER need to be set`. Before #122 the mac build skipped signing entirely, so notarization never ran; now that ad-hoc signing succeeds, electron-builder proceeds to the notarize step and hits a partial notary env: `publish.yml` always exports `APPLE_API_KEY` as a runner-temp path (non-empty even without the secret) while `APPLE_API_KEY_ID`/`APPLE_API_ISSUER` are empty, and electron-builder treats "some but not all set" as a hard error instead of skipping.

Two guards:

```ts
// electron-builder.config.ts: Apple only notarizes Developer ID signed apps
notarize: identity !== "-",
```

and in `publish.yml`, the Package step unsets the notary env when the secrets are absent so a partial env can never trip the hard error:

```bash
if [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER" ]; then
  unset APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER
fi
```

Ad-hoc signed apps can never be notarized (Apple requires a Developer ID), so `notarize: false` is the correct behavior for that path, not a workaround. Once the real signing secrets are added, `CSC_LINK` is present, identity discovery finds the Developer ID cert, and notarization runs with the full env exactly as before.

### How did you verify your code works?

`bun test electron-builder.config.test.ts` from `packages/desktop` (9 pass, including two new tests: ad-hoc path yields `identity: "-"` + `notarize: false`, cert path yields `identity: undefined` + `notarize: true`) and `bun run typecheck` (clean). The failing run for reference: 30708679008.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS app packaging by preventing notarization attempts for ad-hoc signed builds.
  * Prevented incomplete notarization credentials from being used during packaging.

* **Tests**
  * Added coverage for notarization behavior across ad-hoc and certificate-based macOS builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->