### PR TITLE
feat(desktop): terminal installer for macOS without gatekeeper warning

### DIFF
--- a/install-desktop
+++ b/install-desktop
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+APP=Bolt
+
+MUTED='\033[0;2m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+usage() {
+    cat <<EOF
+Bolt Desktop Installer (macOS)
+
+Installs Bolt.app into /Applications from the terminal. Terminal downloads
+carry no quarantine attribute, so macOS shows no Gatekeeper warning.
+
+Usage: install-desktop [options]
+
+Options:
+    -h, --help              Display this help message
+    -v, --version <version> Install a specific version (e.g., 1.20.2)
+
+Examples:
+    curl -fsSL https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install-desktop | bash
+    curl -fsSL https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install-desktop | bash -s -- --version 1.20.2
+EOF
+}
+
+error() {
+    printf "${RED}error${NC}: %s\n" "$1" >&2
+    exit 1
+}
+
+VERSION=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        -v|--version) VERSION="${2:-}"; shift 2 ;;
+        *) error "unknown option: $1" ;;
+    esac
+done
+
+[[ "$(uname -s)" == "Darwin" ]] || error "this installer is for macOS; grab a Linux or Windows build from https://github.com/bolt-builder/bolt-cli/releases/latest"
+
+case "$(uname -m)" in
+    arm64) ARCH=arm64 ;;
+    x86_64) ARCH=x64 ;;
+    *) error "unsupported architecture: $(uname -m)" ;;
+esac
+
+ASSET="bolt-desktop-mac-$ARCH.app.tar.gz"
+if [[ -n "$VERSION" ]]; then
+    URL="https://github.com/bolt-builder/bolt-cli/releases/download/v${VERSION#v}/$ASSET"
+else
+    URL="https://github.com/bolt-builder/bolt-cli/releases/latest/download/$ASSET"
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+printf "${MUTED}downloading${NC} %s\n" "$URL"
+curl -#fL "$URL" -o "$TMP/$ASSET" || error "download failed; check the version exists at https://github.com/bolt-builder/bolt-cli/releases"
+
+printf "${MUTED}installing${NC} /Applications/$APP.app\n"
+tar -xzf "$TMP/$ASSET" -C "$TMP"
+[[ -d "$TMP/$APP.app" ]] || error "unexpected archive layout: $APP.app not found"
+
+# A running copy can't be replaced cleanly.
+if pgrep -xq "$APP" 2>/dev/null; then
+    error "$APP is running; quit it and re-run this installer"
+fi
+
+rm -rf "/Applications/$APP.app"
+mv "$TMP/$APP.app" "/Applications/$APP.app"
+
+# Terminal downloads carry no quarantine attribute; strip defensively anyway.
+xattr -rd com.apple.quarantine "/Applications/$APP.app" 2>/dev/null || true
+
+printf "\n${MUTED}done${NC} — installed to /Applications/$APP.app\n"
+printf "open it from Launchpad, or: open -a $APP\n"


### PR DESCRIPTION
### Issue for this PR

Closes #128

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Browser-downloaded builds of the desktop app show "Apple could not verify Bolt is free of malware" because they are ad-hoc signed, not notarized, and notarization requires a paid Apple Developer ID. The Gatekeeper dialog is driven by the `com.apple.quarantine` xattr that browsers attach to downloads; `curl` attaches nothing, so a terminal install shows no dialog at all.

This adds an `install-desktop` script at the repo root (sibling of the CLI `install` script, same conventions) so macOS users can run:

```bash
curl -fsSL https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install-desktop | bash
```

It detects Apple Silicon vs Intel, downloads `bolt-desktop-mac-{arm64,x64}.app.tar.gz` from the latest release (or `--version x.y.z`), refuses to replace a running app, installs to `/Applications/Bolt.app`, and strips any quarantine attribute defensively:

```bash
rm -rf "/Applications/$APP.app"
mv "$TMP/$APP.app" "/Applications/$APP.app"
xattr -rd com.apple.quarantine "/Applications/$APP.app" 2>/dev/null || true
```

### How did you verify your code works?

`bash -n` passes; the `releases/latest/download/bolt-desktop-mac-arm64.app.tar.gz` URL resolves 200; downloaded the real v1.20.2 asset and confirmed the archive contains `Bolt.app/` at its root, matching the script's expectation. Full end-to-end install needs a macOS machine, which this sandbox is not; the download and extraction logic mirrors the asset layout exactly.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->