### PR TITLE
feat(cli): add bolt commit and bolt review commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Configuration lives in `.bolt/bolt.jsonc` in your project root (created on first
 | `plugin`     | Install and manage plugins                               |
 | `github`     | GitHub Actions agent (install, run)                      |
 | `pr`         | Check out a GitHub PR into a local branch                |
+| `commit`     | Commit staged changes with a generated message           |
+| `review`     | AI review of a diff with pass/fail exit codes            |
 | `stats`      | Show token usage and cost statistics                     |
 | `db`         | Query the local session database                         |
 | `debug`      | Troubleshooting tools (config, lsp, snapshots, and more) |
@@ -181,12 +183,10 @@ The roadmap is about one thing now: making the agent itself smarter, more autono
 </details>
 
 <details>
-<summary><strong>Agents that check their work (5)</strong></summary>
+<summary><strong>Agents that check their work (3)</strong></summary>
 
 - [ ] Test-aware refactor loops: change, run, verify, repeat until green
 - [ ] Confidence scoring: the agent tells you when it is guessing
-- [ ] `bolt review --staged / --branch`: one-shot AI diff review with exit codes
-- [ ] `bolt commit`: commit messages you don't have to rewrite
 - [ ] Self-review pass before any diff is handed to you
 
 </details>
@@ -232,6 +232,8 @@ The roadmap is about one thing now: making the agent itself smarter, more autono
 
 ### Done
 
+- [x] `bolt review --staged / --branch`: one-shot AI diff review with exit codes
+- [x] `bolt commit`: commit messages you don't have to rewrite
 - [x] Best-of-N runs: fire the same task at several models in parallel, rank the results, keep the winner
 - [x] Push-to-talk voice input in the TUI
 - [x] Agent evaluation benchmark harness (`bolt eval`)

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -150,6 +150,8 @@ Configuration lives in `.bolt/bolt.jsonc` in your project root (created on first
 | `plugin`     | Install and manage plugins                               |
 | `github`     | GitHub Actions agent (install, run)                      |
 | `pr`         | Check out a GitHub PR into a local branch                |
+| `commit`     | Commit staged changes with a generated message           |
+| `review`     | AI review of a diff with pass/fail exit codes            |
 | `stats`      | Show token usage and cost statistics                     |
 | `db`         | Query the local session database                         |
 | `debug`      | Troubleshooting tools (config, lsp, snapshots, and more) |
@@ -181,12 +183,10 @@ The roadmap is about one thing now: making the agent itself smarter, more autono
 </details>
 
 <details>
-<summary><strong>Agents that check their work (5)</strong></summary>
+<summary><strong>Agents that check their work (3)</strong></summary>
 
 - [ ] Test-aware refactor loops: change, run, verify, repeat until green
 - [ ] Confidence scoring: the agent tells you when it is guessing
-- [ ] `bolt review --staged / --branch`: one-shot AI diff review with exit codes
-- [ ] `bolt commit`: commit messages you don't have to rewrite
 - [ ] Self-review pass before any diff is handed to you
 
 </details>
@@ -232,6 +232,8 @@ The roadmap is about one thing now: making the agent itself smarter, more autono
 
 ### Done
 
+- [x] `bolt review --staged / --branch`: one-shot AI diff review with exit codes
+- [x] `bolt commit`: commit messages you don't have to rewrite
 - [x] Best-of-N runs: fire the same task at several models in parallel, rank the results, keep the winner
 - [x] Push-to-talk voice input in the TUI
 - [x] Agent evaluation benchmark harness (`bolt eval`)

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -14,6 +14,7 @@ import PROMPT_COMPACTION from "./prompt/compaction.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
+import PROMPT_COMMIT from "./prompt/commit.txt"
 import PROMPT_CODE_REVIEW from "./prompt/code-review.txt"
 import PROMPT_DEBUG from "./prompt/debug.txt"
 import PROMPT_REFACTOR from "./prompt/refactor.txt"
@@ -287,6 +288,22 @@ const layer = Layer.effect(
               user,
             ),
             prompt: PROMPT_TITLE,
+          },
+          commit: {
+            name: "commit",
+            mode: "primary",
+            options: {},
+            native: true,
+            hidden: true,
+            temperature: 0.3,
+            permission: Permission.merge(
+              defaults,
+              Permission.fromConfig({
+                "*": "deny",
+              }),
+              user,
+            ),
+            prompt: PROMPT_COMMIT,
           },
           summary: {
             name: "summary",

--- a/packages/opencode/src/agent/prompt/commit.txt
+++ b/packages/opencode/src/agent/prompt/commit.txt
@@ -1,0 +1,10 @@
+You are a commit message generator. You receive a git diff of staged changes plus recent commit subjects from the same repository.
+
+Rules:
+- Output ONLY the commit message. No commentary, no markdown fences, no surrounding quotes.
+- Match the style of the recent commit subjects when they follow a convention (for example conventional commits like "type(scope): summary").
+- If no convention is apparent, use conventional commits: type(scope): summary with types feat, fix, docs, chore, refactor, or test.
+- Subject line: imperative mood, at most 72 characters, no trailing period.
+- Add a short body (wrapped at 72 columns, separated from the subject by a blank line) only when the change is not self-explanatory from the subject.
+- Describe what changed and why, not how.
+- Never invent ticket numbers, issue references, or co-authors.

--- a/packages/opencode/src/cli/cmd/commit.ts
+++ b/packages/opencode/src/cli/cmd/commit.ts
@@ -1,0 +1,122 @@
+import { Effect } from "effect"
+import { UI } from "../ui"
+import { effectCmd, fail } from "../effect-cmd"
+import { Git } from "@/git"
+import { InstanceRef } from "@/effect/instance-ref"
+import { Session } from "@/session/session"
+import { SessionPrompt } from "@/session/prompt"
+import { MessageID, PartID } from "../../session/schema"
+import { parseModel } from "@/provider/provider"
+import { extractResponseText } from "./github.shared"
+
+const LIMIT = 60_000
+
+/** Strip think blocks and markdown fences from a generated commit message. */
+export function clean(text: string) {
+  const lines = text
+    .replace(/<think>[\s\S]*?<\/think>/g, "")
+    .trim()
+    .split("\n")
+  if (lines[0]?.startsWith("```")) lines.shift()
+  if (lines.at(-1)?.startsWith("```")) lines.pop()
+  return lines.join("\n").trim()
+}
+
+/** Cap a diff for the prompt, keeping the head where the summary lives. */
+export function cap(patch: string, limit = LIMIT) {
+  if (patch.length <= limit) return patch
+  return patch.slice(0, limit) + "\n\n[diff truncated]"
+}
+
+export const CommitCommand = effectCmd({
+  command: "commit",
+  describe: "commit staged changes with a generated message",
+  builder: (yargs) =>
+    yargs
+      .option("all", {
+        alias: "a",
+        type: "boolean",
+        describe: "commit all tracked changes, not just staged ones",
+        default: false,
+      })
+      .option("dry-run", {
+        type: "boolean",
+        describe: "print the generated message without committing",
+        default: false,
+      })
+      .option("model", {
+        alias: "m",
+        type: "string",
+        describe: "model to use in the format of provider/model",
+      }),
+  handler: Effect.fn("Cli.commit")(function* (args) {
+    const ctx = yield* InstanceRef
+    if (!ctx) return yield* fail("Could not load instance context")
+    if (ctx.project.vcs !== "git") {
+      return yield* fail("Could not find git repository. Please run this command from a git repository.")
+    }
+
+    const git = yield* Git.Service
+    const cwd = ctx.worktree
+
+    if (args.all && !(yield* git.hasHead(cwd))) {
+      return yield* fail("--all requires at least one commit. Stage changes and run bolt commit instead.")
+    }
+
+    const diff = yield* git.run(args.all ? ["diff", "HEAD"] : ["diff", "--cached"], { cwd })
+    const patch = diff.text().trim()
+    if (!patch) {
+      return yield* fail(
+        args.all
+          ? "No changes to commit."
+          : "No staged changes to commit. Stage changes with git add, or pass --all to commit every tracked change.",
+      )
+    }
+
+    const log = yield* git.run(["log", "--format=%s", "-10"], { cwd })
+    const subjects = log.exitCode === 0 ? log.text().trim() : ""
+
+    UI.println("Generating commit message...")
+
+    const sessions = yield* Session.Service
+    const prompt = yield* SessionPrompt.Service
+    const session = yield* sessions.create({
+      title: "bolt commit",
+      permission: [{ permission: "question", action: "deny", pattern: "*" }],
+    })
+
+    const text = [
+      "Write a commit message for the following staged changes.",
+      subjects ? `\nRecent commit subjects for style reference:\n${subjects}` : "",
+      `\nDiff:\n${cap(patch)}`,
+    ].join("\n")
+
+    const result = yield* prompt.prompt({
+      sessionID: session.id,
+      messageID: MessageID.ascending(),
+      agent: "commit",
+      model: args.model ? parseModel(args.model) : undefined,
+      parts: [{ id: PartID.ascending(), type: "text", text }],
+    }).pipe(Effect.orDie)
+
+    if (result.info.role === "assistant" && result.info.error) {
+      const err = result.info.error
+      const message = "message" in err.data ? err.data.message : ""
+      return yield* fail(`${err.name}: ${message}`)
+    }
+
+    const message = clean(extractResponseText(result.parts) ?? "")
+    if (!message) return yield* fail("The model returned an empty commit message.")
+
+    if (args["dry-run"]) {
+      UI.empty()
+      UI.println(message)
+      return
+    }
+
+    const commit = yield* git.run(args.all ? ["commit", "-a", "-m", message] : ["commit", "-m", message], { cwd })
+    if (commit.exitCode !== 0) return yield* fail(commit.stderr.toString().trim() || "git commit failed")
+    UI.empty()
+    UI.println(commit.text().trim())
+  }),
+})

--- a/packages/opencode/src/cli/cmd/commit.ts
+++ b/packages/opencode/src/cli/cmd/commit.ts
@@ -64,6 +64,7 @@ export const CommitCommand = effectCmd({
     }
 
     const diff = yield* git.run(args.all ? ["diff", "HEAD"] : ["diff", "--cached"], { cwd })
+    if (diff.exitCode !== 0) return yield* fail(diff.stderr.toString().trim() || "git diff failed")
     const patch = diff.text().trim()
     if (!patch) {
       return yield* fail(

--- a/packages/opencode/src/cli/cmd/commit.ts
+++ b/packages/opencode/src/cli/cmd/commit.ts
@@ -25,7 +25,7 @@ export function clean(text: string) {
 /** Cap a diff for the prompt, keeping the head where the summary lives. */
 export function cap(patch: string, limit = LIMIT) {
   if (patch.length <= limit) return patch
-  return patch.slice(0, limit) + "\n\n[diff truncated]"
+  return `${patch.slice(0, limit)}\n\n[diff truncated]`
 }
 
 export const CommitCommand = effectCmd({

--- a/packages/opencode/src/cli/cmd/review.ts
+++ b/packages/opencode/src/cli/cmd/review.ts
@@ -1,0 +1,122 @@
+import { Effect } from "effect"
+import { UI } from "../ui"
+import { effectCmd, fail } from "../effect-cmd"
+import { Git } from "@/git"
+import { InstanceRef } from "@/effect/instance-ref"
+import { Session } from "@/session/session"
+import { SessionPrompt } from "@/session/prompt"
+import { MessageID, PartID } from "../../session/schema"
+import { parseModel } from "@/provider/provider"
+import { extractResponseText } from "./github.shared"
+
+const LIMIT = 120_000
+
+/** Parse the last pass/fail verdict marker from the review response. */
+export function verdict(text: string) {
+  const matches = [...text.matchAll(/verdict:\s*(pass|fail)/gi)]
+  const last = matches.at(-1)
+  if (!last) return undefined
+  return last[1].toLowerCase() as "pass" | "fail"
+}
+
+const INSTRUCTIONS = [
+  "Review the following code changes. Use the read, grep, and glob tools to inspect surrounding code when the diff alone is not enough.",
+  "Report each issue with a severity (critical, major, minor), the file and line, and a short explanation. Be concise and do not restate the diff. If there are no issues, say so.",
+  'End your final message with exactly one line: "Verdict: PASS" if there are no critical or major issues, otherwise "Verdict: FAIL".',
+].join("\n")
+
+export const ReviewCommand = effectCmd({
+  command: "review",
+  describe: "review code changes with the code-review agent",
+  builder: (yargs) =>
+    yargs
+      .option("staged", {
+        type: "boolean",
+        describe: "review staged changes only",
+        default: false,
+      })
+      .option("branch", {
+        type: "string",
+        describe: "review changes since the merge base with a branch (defaults to the default branch)",
+      })
+      .option("model", {
+        alias: "m",
+        type: "string",
+        describe: "model to use in the format of provider/model",
+      })
+      .conflicts("staged", "branch"),
+  handler: Effect.fn("Cli.review")(function* (args) {
+    const ctx = yield* InstanceRef
+    if (!ctx) return yield* fail("Could not load instance context")
+    if (ctx.project.vcs !== "git") {
+      return yield* fail("Could not find git repository. Please run this command from a git repository.")
+    }
+
+    const git = yield* Git.Service
+    const cwd = ctx.worktree
+
+    const range = yield* Effect.gen(function* () {
+      if (args.staged) return ["diff", "--cached"]
+      if (args.branch === undefined) return ["diff", "HEAD"]
+      const base = yield* Effect.gen(function* () {
+        if (args.branch) return args.branch
+        const branch = yield* git.defaultBranch(cwd)
+        if (!branch) return yield* fail("Could not determine the default branch. Pass one with --branch <name>.")
+        return branch.ref
+      })
+      const merge = yield* git.mergeBase(cwd, base)
+      if (!merge) return yield* fail(`Could not find a merge base with ${base}.`)
+      return ["diff", `${merge}..HEAD`]
+    })
+
+    const diff = yield* git.run(range, { cwd })
+    if (diff.exitCode !== 0) return yield* fail(diff.stderr.toString().trim() || "git diff failed")
+    const patch = diff.text().trim()
+    if (!patch) {
+      UI.println("Nothing to review.")
+      return
+    }
+    if (patch.length > LIMIT) {
+      return yield* fail("The diff is too large to review in one shot. Review a narrower range.")
+    }
+
+    UI.println("Reviewing changes...")
+
+    const sessions = yield* Session.Service
+    const prompt = yield* SessionPrompt.Service
+    const session = yield* sessions.create({
+      title: "bolt review",
+      permission: [{ permission: "question", action: "deny", pattern: "*" }],
+    })
+
+    const result = yield* prompt.prompt({
+      sessionID: session.id,
+      messageID: MessageID.ascending(),
+      agent: "code-review",
+      model: args.model ? parseModel(args.model) : undefined,
+      parts: [{ id: PartID.ascending(), type: "text", text: `${INSTRUCTIONS}\n\nDiff:\n${patch}` }],
+    }).pipe(Effect.orDie)
+
+    if (result.info.role === "assistant" && result.info.error) {
+      const err = result.info.error
+      const message = "message" in err.data ? err.data.message : ""
+      return yield* fail(`${err.name}: ${message}`)
+    }
+
+    const text = extractResponseText(result.parts) ?? ""
+    if (!text) return yield* fail("The model returned an empty review.")
+
+    UI.empty()
+    UI.println(UI.markdown(text))
+    UI.empty()
+
+    const outcome = verdict(text)
+    if (outcome === "pass") return
+    if (outcome === "fail") {
+      process.exitCode = 1
+      return
+    }
+    UI.println("Could not determine a verdict from the review.")
+    process.exitCode = 2
+  }),
+})

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -26,6 +26,8 @@ import { AcpCommand } from "./cli/cmd/acp"
 import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
+import { CommitCommand } from "./cli/cmd/commit"
+import { ReviewCommand } from "./cli/cmd/review"
 import { SessionCommand } from "./cli/cmd/session"
 import { DbCommand } from "./cli/cmd/db"
 import { errorMessage } from "./util/error"
@@ -102,6 +104,8 @@ const cli = yargs(args)
   .command(ImportCommand)
   .command(GithubCommand)
   .command(PrCommand)
+  .command(CommitCommand)
+  .command(ReviewCommand)
   .command(SessionCommand)
   .command(PluginCommand)
   .command(DbCommand)

--- a/packages/opencode/test/cli/commit.test.ts
+++ b/packages/opencode/test/cli/commit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { cap, clean } from "../../src/cli/cmd/commit"
+
+describe("clean", () => {
+  test("passes a plain message through", () => {
+    expect(clean("feat(cli): add commit command")).toBe("feat(cli): add commit command")
+  })
+
+  test("strips think blocks", () => {
+    expect(clean("<think>hmm\nlet me see</think>\nfix(core): handle empty diff")).toBe("fix(core): handle empty diff")
+  })
+
+  test("strips surrounding markdown fences", () => {
+    expect(clean("```\nchore: bump deps\n```")).toBe("chore: bump deps")
+    expect(clean("```text\nchore: bump deps\n```")).toBe("chore: bump deps")
+  })
+
+  test("keeps subject and body", () => {
+    const message = "feat(tui): add fire border\n\nThe border burns while the agent works."
+    expect(clean(message)).toBe(message)
+  })
+
+  test("returns empty string for empty input", () => {
+    expect(clean("")).toBe("")
+    expect(clean("<think>only thoughts</think>")).toBe("")
+  })
+})
+
+describe("cap", () => {
+  test("keeps short diffs intact", () => {
+    expect(cap("small diff")).toBe("small diff")
+  })
+
+  test("truncates long diffs with a marker", () => {
+    const result = cap("a".repeat(100), 10)
+    expect(result).toBe("a".repeat(10) + "\n\n[diff truncated]")
+  })
+})

--- a/packages/opencode/test/cli/commit.test.ts
+++ b/packages/opencode/test/cli/commit.test.ts
@@ -33,6 +33,6 @@ describe("cap", () => {
 
   test("truncates long diffs with a marker", () => {
     const result = cap("a".repeat(100), 10)
-    expect(result).toBe("a".repeat(10) + "\n\n[diff truncated]")
+    expect(result).toBe(`${"a".repeat(10)}\n\n[diff truncated]`)
   })
 })

--- a/packages/opencode/test/cli/review.test.ts
+++ b/packages/opencode/test/cli/review.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { verdict } from "../../src/cli/cmd/review"
+
+describe("verdict", () => {
+  test("parses a pass verdict", () => {
+    expect(verdict("No issues found.\n\nVerdict: PASS")).toBe("pass")
+  })
+
+  test("parses a fail verdict", () => {
+    expect(verdict("- critical: src/a.ts:12 leaks a handle\n\nVerdict: FAIL")).toBe("fail")
+  })
+
+  test("is case insensitive", () => {
+    expect(verdict("verdict: pass")).toBe("pass")
+    expect(verdict("VERDICT: Fail")).toBe("fail")
+  })
+
+  test("uses the last verdict when several appear", () => {
+    expect(verdict('End with "Verdict: PASS" or "Verdict: FAIL".\n\nVerdict: FAIL')).toBe("fail")
+  })
+
+  test("returns undefined when no verdict is present", () => {
+    expect(verdict("Looks fine to me.")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #132

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Ships two roadmap items from "Agents that check their work":

`bolt commit` generates a commit message from the staged diff and commits. It feeds the model the diff plus the last 10 commit subjects so the message matches the repo's existing style (conventional commits as fallback). `--dry-run` prints the message without committing, `--all` covers all tracked changes, `-m provider/model` overrides the model. A new hidden native `commit` agent (all tools denied, temperature 0.3, prompt in `src/agent/prompt/commit.txt`) does the generation, mirroring the existing `title` agent.

`bolt review` runs a one-shot AI review using the existing read-only `code-review` agent: `--staged` for the index, `--branch [base]` for the merge-base diff against a branch (default branch when omitted), and uncommitted tracked changes by default. The agent can use read/grep/glob to inspect surrounding code, and is instructed to end with a verdict line that maps to exit codes so it can gate CI or a pre-push hook:

```ts
const outcome = verdict(text) // last /verdict:\s*(pass|fail)/i match
if (outcome === "pass") return // exit 0
if (outcome === "fail") { process.exitCode = 1; return }
UI.println("Could not determine a verdict from the review.")
process.exitCode = 2
```

Both commands create a real session (question permission denied so headless runs never hang), so every run is inspectable via `bolt db` and the session list. Sessions are prompted through `SessionPrompt.Service` like the GitHub Actions handler, and README roadmap checkboxes plus the commands table are updated.

### How did you verify your code works?

`bun typecheck` clean; `bun test ./test/cli/commit.test.ts ./test/cli/review.test.ts` (12 tests) for the message-cleaning, diff-capping, and verdict-parsing helpers. Smoke-tested the CLI in a scratch git repo: `--help` output for both commands, `review` with a clean tree prints "Nothing to review." and exits 0, `commit` with nothing staged fails with an actionable message and exit 1. The full LLM path follows the same `SessionPrompt.prompt` flow used by `bolt github` and was not exercised against a live provider in the sandbox.

### Screenshots / recordings

_CLI change; help output and empty-diff behavior shown above._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bolt commit` to generate commit messages from Git changes, with dry-run, model selection, and staging options.
  * Added `bolt review` to analyze staged or branch-based changes and report PASS/FAIL results.
* **Documentation**
  * Updated command references and roadmap documentation to reflect the completed features.
* **Tests**
  * Added coverage for commit-message cleanup, diff truncation, and review verdict parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->