### PR TITLE
feat(tui): glowing outline on the user message while the agent works

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -17,7 +17,7 @@ import { fileURLToPath } from "url"
 import { useLocal } from "../../context/local"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { tint, useTheme } from "../../context/theme"
-import { EmptyBorder, SplitBorder } from "../../ui/border"
+
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { useClipboard } from "../../context/clipboard"
 import { Spinner } from "../spinner"
@@ -1466,19 +1466,10 @@ export function Prompt(props: PromptProps) {
         <FireStrip rows={flames()} />
       </Show>
       <box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
-        <box
-          width="100%"
-          border={["left"]}
-          borderColor={borderHighlight()}
-          customBorderChars={{
-            ...SplitBorder.customBorderChars,
-            bottomLeft: "╹",
-          }}
-        >
+        <box width="100%" border borderStyle="rounded" borderColor={borderHighlight()}>
           <box
             paddingLeft={2}
             paddingRight={2}
-            paddingTop={1}
             flexShrink={0}
             backgroundColor={theme.backgroundElement}
             flexGrow={1}
@@ -1568,6 +1559,7 @@ export function Prompt(props: PromptProps) {
                 <Show when={local.agent.current()} fallback={<box height={1} />}>
                   {(agent) => (
                     <>
+                      <text fg={fadeColor(local.agent.color(agent().name), agentMetaAlpha())}>◆</text>
                       <text fg={fadeColor(highlight(), agentMetaAlpha())}>
                         {store.mode === "shell"
                           ? "Shell"
@@ -1619,32 +1611,6 @@ export function Prompt(props: PromptProps) {
               </Show>
             </box>
           </box>
-        </box>
-        <box
-          height={1}
-          border={["left"]}
-          borderColor={borderHighlight()}
-          customBorderChars={{
-            ...EmptyBorder,
-            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
-          }}
-        >
-          <box
-            height={1}
-            border={["bottom"]}
-            borderColor={theme.backgroundElement}
-            customBorderChars={
-              theme.backgroundElement.a !== 0
-                ? {
-                    ...EmptyBorder,
-                    horizontal: "▀",
-                  }
-                : {
-                    ...EmptyBorder,
-                    horizontal: " ",
-                  }
-            }
-          />
         </box>
         <box width="100%" flexDirection="row" justifyContent="space-between">
           <Switch>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -5,7 +5,6 @@ import {
   MouseEvent,
   PasteEvent,
   decodePasteBytes,
-  rgbToHex,
   type KeyEvent,
   type Renderable,
 } from "@opentui/core"
@@ -22,7 +21,7 @@ import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { useClipboard } from "../../context/clipboard"
 import { Spinner } from "../spinner"
 import { voice } from "../../voice"
-import { createFire, FireStrip } from "../fire-frame"
+
 import { useSDK } from "../../context/sdk"
 import { useRoute } from "../../context/route"
 import { useProject } from "../../context/project"
@@ -1412,12 +1411,6 @@ export function Prompt(props: PromptProps) {
     animationsEnabled,
   )
   const borderHighlight = createMemo(() => tint(theme.border, highlight(), agentMetaAlpha()))
-  const fire = createMemo(() => animationsEnabled() && status().type !== "idle")
-  const flames = createFire(
-    () => dimensions().width,
-    fire,
-    () => rgbToHex(theme.primary),
-  )
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined
     if (store.mode === "shell") {
@@ -1458,13 +1451,6 @@ export function Prompt(props: PromptProps) {
 
   return (
     <>
-      {/* Outside the anchor box on purpose: the autocomplete palette renders
-          above the anchor, so keeping the fire out of it lets the palette sit
-          flush against the input and cover the flames instead of floating
-          above the whole strip. */}
-      <Show when={props.visible !== false && fire()}>
-        <FireStrip rows={flames()} />
-      </Show>
       <box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
         <box
           width="100%"

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -17,7 +17,7 @@ import { fileURLToPath } from "url"
 import { useLocal } from "../../context/local"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { tint, useTheme } from "../../context/theme"
-
+import { EmptyBorder, SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { useClipboard } from "../../context/clipboard"
 import { Spinner } from "../spinner"
@@ -1466,10 +1466,19 @@ export function Prompt(props: PromptProps) {
         <FireStrip rows={flames()} />
       </Show>
       <box ref={(r: BoxRenderable) => (anchor = r)} visible={props.visible !== false} width="100%">
-        <box width="100%" border borderStyle="rounded" borderColor={borderHighlight()}>
+        <box
+          width="100%"
+          border={["left"]}
+          borderColor={borderHighlight()}
+          customBorderChars={{
+            ...SplitBorder.customBorderChars,
+            bottomLeft: "╹",
+          }}
+        >
           <box
             paddingLeft={2}
             paddingRight={2}
+            paddingTop={1}
             flexShrink={0}
             backgroundColor={theme.backgroundElement}
             flexGrow={1}
@@ -1559,7 +1568,6 @@ export function Prompt(props: PromptProps) {
                 <Show when={local.agent.current()} fallback={<box height={1} />}>
                   {(agent) => (
                     <>
-                      <text fg={fadeColor(local.agent.color(agent().name), agentMetaAlpha())}>◆</text>
                       <text fg={fadeColor(highlight(), agentMetaAlpha())}>
                         {store.mode === "shell"
                           ? "Shell"
@@ -1611,6 +1619,32 @@ export function Prompt(props: PromptProps) {
               </Show>
             </box>
           </box>
+        </box>
+        <box
+          height={1}
+          border={["left"]}
+          borderColor={borderHighlight()}
+          customBorderChars={{
+            ...EmptyBorder,
+            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
+          }}
+        >
+          <box
+            height={1}
+            border={["bottom"]}
+            borderColor={theme.backgroundElement}
+            customBorderChars={
+              theme.backgroundElement.a !== 0
+                ? {
+                    ...EmptyBorder,
+                    horizontal: "▀",
+                  }
+                : {
+                    ...EmptyBorder,
+                    horizontal: " ",
+                  }
+            }
+          />
         </box>
         <box width="100%" flexDirection="row" justifyContent="space-between">
           <Switch>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1544,7 +1544,7 @@ function UserMessage(props: {
           id={props.message.id}
           ref={(el: BoxRenderable) => alwaysSeparate.add(el)}
           border={working() ? true : ["left"]}
-          borderStyle={working() ? "rounded" : undefined}
+          borderStyle={working() ? "heavy" : undefined}
           borderColor={working() ? outline() : color()}
           customBorderChars={working() ? undefined : SplitBorder.customBorderChars}
           marginTop={props.index === 0 ? 0 : 1}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1525,12 +1525,13 @@ function UserMessage(props: {
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
   const color = createMemo(() => local.agent.color(props.message.agent))
-  // Glow: breathe the rail of the message the agent is currently working on.
+  // Continue-style glow: while the agent works on this message, swap the left
+  // rail for a full outline that sweeps between the theme primary and accent.
   const working = createMemo(
     () => !!props.last && (ctx.sync.data.session_status[ctx.sessionID]?.type ?? "idle") !== "idle",
   )
   const glow = createPulse(working, () => kv.get("animations_enabled", true))
-  const rail = createMemo(() => (working() ? tint(theme.backgroundPanel, color(), 0.3 + 0.7 * glow()) : color()))
+  const outline = createMemo(() => tint(theme.primary, theme.accent, glow()))
   const queuedFg = createMemo(() => selectedForeground(theme, color()))
   const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
 
@@ -1542,9 +1543,10 @@ function UserMessage(props: {
         <box
           id={props.message.id}
           ref={(el: BoxRenderable) => alwaysSeparate.add(el)}
-          border={["left"]}
-          borderColor={rail()}
-          customBorderChars={SplitBorder.customBorderChars}
+          border={working() ? true : ["left"]}
+          borderStyle={working() ? "rounded" : undefined}
+          borderColor={working() ? outline() : color()}
+          customBorderChars={working() ? undefined : SplitBorder.customBorderChars}
           marginTop={props.index === 0 ? 0 : 1}
         >
           <box

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -24,7 +24,8 @@ import { useEvent } from "../../context/event"
 import { SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { Spinner } from "../../component/spinner"
-import { createSyntaxStyleMemo, generateSubtleSyntax, selectedForeground, useTheme } from "../../context/theme"
+import { createSyntaxStyleMemo, generateSubtleSyntax, selectedForeground, tint, useTheme } from "../../context/theme"
+import { createPulse } from "../../util/signal"
 import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, RGBA } from "@opentui/core"
 import { Prompt, type PromptRef } from "../../component/prompt"
 import type {
@@ -247,6 +248,10 @@ export function Session() {
 
   const lastAssistant = createMemo(() => {
     return messages().findLast((x) => x.role === "assistant")
+  })
+
+  const lastUser = createMemo(() => {
+    return messages().findLast((x) => x.role === "user")
   })
 
   const dimensions = useTerminalDimensions()
@@ -1366,6 +1371,7 @@ export function Session() {
                           message={message as UserMessage}
                           parts={sync.data.part[message.id] ?? []}
                           pending={pending()}
+                          last={lastUser()?.id === message.id}
                         />
                       </Match>
                       <Match when={message.role === "assistant"}>
@@ -1498,9 +1504,11 @@ function UserMessage(props: {
   onMouseUp: () => void
   index: number
   pending?: string
+  last?: boolean
 }) {
   const ctx = use()
   const local = useLocal()
+  const kv = useKV()
   const text = createMemo(() => {
     const texts = props.parts
       .map((x) => {
@@ -1517,6 +1525,12 @@ function UserMessage(props: {
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
   const color = createMemo(() => local.agent.color(props.message.agent))
+  // Glow: breathe the rail of the message the agent is currently working on.
+  const working = createMemo(
+    () => !!props.last && (ctx.sync.data.session_status[ctx.sessionID]?.type ?? "idle") !== "idle",
+  )
+  const glow = createPulse(working, () => kv.get("animations_enabled", true))
+  const rail = createMemo(() => (working() ? tint(theme.backgroundPanel, color(), 0.3 + 0.7 * glow()) : color()))
   const queuedFg = createMemo(() => selectedForeground(theme, color()))
   const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
 
@@ -1529,7 +1543,7 @@ function UserMessage(props: {
           id={props.message.id}
           ref={(el: BoxRenderable) => alwaysSeparate.add(el)}
           border={["left"]}
-          borderColor={color()}
+          borderColor={rail()}
           customBorderChars={SplitBorder.customBorderChars}
           marginTop={props.index === 0 ? 0 : 1}
         >

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -21,7 +21,7 @@ import { useRoute, useRouteData } from "../../context/route"
 import { useProject } from "../../context/project"
 import { useSync } from "../../context/sync"
 import { useEvent } from "../../context/event"
-import { SplitBorder } from "../../ui/border"
+import { GlowBorder, SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { Spinner } from "../../component/spinner"
 import { createSyntaxStyleMemo, generateSubtleSyntax, selectedForeground, tint, useTheme } from "../../context/theme"
@@ -1544,9 +1544,8 @@ function UserMessage(props: {
           id={props.message.id}
           ref={(el: BoxRenderable) => alwaysSeparate.add(el)}
           border={working() ? true : ["left"]}
-          borderStyle={working() ? "heavy" : undefined}
           borderColor={working() ? outline() : color()}
-          customBorderChars={working() ? undefined : SplitBorder.customBorderChars}
+          customBorderChars={working() ? GlowBorder : SplitBorder.customBorderChars}
           marginTop={props.index === 0 ? 0 : 1}
         >
           <box

--- a/packages/tui/src/ui/border.ts
+++ b/packages/tui/src/ui/border.ts
@@ -12,6 +12,21 @@ export const EmptyBorder = {
   rightT: "",
 }
 
+// Chunky full-block frame with quarter-block corners that read as rounded.
+export const GlowBorder = {
+  topLeft: "▗",
+  topRight: "▖",
+  bottomLeft: "▝",
+  bottomRight: "▘",
+  horizontal: "█",
+  vertical: "█",
+  topT: "█",
+  bottomT: "█",
+  leftT: "█",
+  rightT: "█",
+  cross: "█",
+}
+
 export const SplitBorder = {
   border: ["left" as const, "right" as const],
   customBorderChars: {

--- a/packages/tui/src/util/signal.ts
+++ b/packages/tui/src/util/signal.ts
@@ -27,6 +27,9 @@ export function createPulse(active: Accessor<boolean>, enabled: Accessor<boolean
         return
       }
 
+      // Reset so re-enabling animations mid-activity starts the wave at 0
+      // instead of holding the steady value 1 until the first tick.
+      setValue(0)
       const start = performance.now()
       const timer = setInterval(() => {
         const phase = ((performance.now() - start) % period) / period

--- a/packages/tui/src/util/signal.ts
+++ b/packages/tui/src/util/signal.ts
@@ -16,6 +16,30 @@ export function createDebouncedSignal<T>(value: T, ms: number): [Accessor<T>, (v
   return [get, debounced]
 }
 
+/** Breathing 0..1 wave while active; holds 1 when active with animations off. */
+export function createPulse(active: Accessor<boolean>, enabled: Accessor<boolean>, period = 1600) {
+  const [value, setValue] = createSignal(0)
+
+  createEffect(
+    on([active, enabled], ([run, animate]) => {
+      if (!run || !animate) {
+        setValue(run ? 1 : 0)
+        return
+      }
+
+      const start = performance.now()
+      const timer = setInterval(() => {
+        const phase = ((performance.now() - start) % period) / period
+        setValue(0.5 - Math.cos(phase * Math.PI * 2) / 2)
+      }, 50)
+
+      onCleanup(() => clearInterval(timer))
+    }),
+  )
+
+  return value
+}
+
 export function createFadeIn(show: Accessor<boolean>, enabled: Accessor<boolean>) {
   const [alpha, setAlpha] = createSignal(show() ? 1 : 0)
   let revealed = show()


### PR DESCRIPTION
### Issue for this PR

Closes #134

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Continue.dev-style send feedback in the transcript: while the agent is working on your prompt, that user message swaps its left rail for a full chunky block-frame outline (quarter-block corners that read as rounded) whose color sweeps between the theme primary and accent. When the session goes idle it returns to the normal agent-colored rail, so idle transcripts render exactly as before.

```tsx
const working = createMemo(
  () => !!props.last && (ctx.sync.data.session_status[ctx.sessionID]?.type ?? "idle") !== "idle",
)
const glow = createPulse(working, () => kv.get("animations_enabled", true))
const outline = createMemo(() => tint(theme.primary, theme.accent, glow()))
// ...
border={working() ? true : ["left"]}
customBorderChars={working() ? GlowBorder : SplitBorder.customBorderChars}
borderColor={working() ? outline() : color()}
```

`createPulse` (new in `util/signal.ts`) is a 0..1 cosine wave on a 50ms timer; with animations disabled it holds a steady full-primary outline instead of sweeping. `last` comes from a new `lastUser` memo mirroring the existing `lastAssistant` pattern, and the busy signal is the same `session_status` wiring the fire strip used, so everything follows the active theme automatically.

The doom-fire strip above the prompt input is removed (the glow outline is now the busy indicator); the `fire-frame`/`ui/fire` modules stay in the tree so it can come back later. An earlier rounded-border experiment on the prompt input box is reverted in this branch: the input renders exactly as on dev.

### How did you verify your code works?

`bun typecheck` and `bun test` (203 tests) pass in `packages/tui` after each commit, including the revert. Ran the TUI in tmux to confirm the home screen and prompt input render unchanged with the fire wiring removed. The glow path needs a live provider to observe end to end; it mirrors the proven `session_status` signal.

### Screenshots / recordings

_The outline only appears while a prompt is running against a live provider; idle rendering is unchanged from dev._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
