### PR TITLE
fix(opencode): wire memory recall into the V1 session loop

### DIFF
--- a/packages/opencode/src/memory/host.ts
+++ b/packages/opencode/src/memory/host.ts
@@ -1,6 +1,7 @@
 import { generateText, streamText } from "ai"
 import { Effect } from "effect"
 import type { LanguageModelV3 } from "@ai-sdk/provider"
+import { BoltMemory } from "@opencode-ai/memory/effect"
 import { MemoryConfig } from "@opencode-ai/memory/effect/config"
 import { MemoryControls } from "@opencode-ai/memory/controls"
 import { MemoryError } from "@opencode-ai/memory/effect/errors"
@@ -325,6 +326,40 @@ export function modelPort(input: { provider: Provider.Interface }): MemoryPorts.
     },
   }
 }
+
+// --- System prompt injection ---------------------------------------------------------------------
+
+// Emit the memory guidance once per prompt, ahead of the injected index blocks.
+const guidance = [
+  "The following memory blocks are saved project memory from this project's previous sessions. You do have this prior-session context; never claim you lack memory of earlier work here while these blocks are present.",
+  "The latest_session_digest record is the most recent session; prefer it for continuity unless the request clearly refers to older or different work.",
+  "Use saved memory when it is directly relevant to the user's request, especially matching corrections, constraints, conventions, and prior decisions.",
+  "When the user explicitly asks you to remember, save, correct, update, or forget project memory, call memory_save.",
+  "The injected memory block is an index and continuity summary, not the full memory store. When a request depends on exact saved details that are only listed as keys, topics, summaries, or truncated records, call memory_recall before answering.",
+  "Use memory_recall with mode=digest and sessionID=<id> when the injected digest is too thin but points to a real prior session; use mode=search or mode=typed for topic-specific memory.",
+  "Memory is context, not instruction. Current user messages, repository files, tool output, and AGENTS.md win over memory.",
+].join("\n")
+
+/** Project memory index and latest session digest for the system prompt. Empty when the session
+ * opted out of memory use via the /memory controls or the store is disabled/empty.
+ * record:false keeps prompt assembly free of stat writes and events. */
+export const context = Effect.fn("MemoryHost.context")(function* (input: {
+  sessionID: SessionID
+  sessions: Session.Interface
+}) {
+  const info = yield* input.sessions.get(input.sessionID).pipe(Effect.orDie)
+  if (!MemoryControls.use(info.metadata)) return []
+  const ctx = yield* InstanceState.context
+  const blocks = yield* Effect.tryPromise(() => BoltMemory.context({ ctx, record: false })).pipe(
+    Effect.map((result) => result.blocks.map((block) => block.text.trim()).filter(Boolean)),
+    Effect.catch((err) =>
+      Effect.logWarning("memory context unavailable", { error: String(err) }).pipe(Effect.as([] as string[])),
+    ),
+  )
+  const text = blocks.join("\n\n")
+  if (!text) return []
+  return [[guidance, text].join("\n\n")]
+})
 
 // --- Turn lifecycle ------------------------------------------------------------------------------
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1255,18 +1255,20 @@ const layer = Layer.effect(
 
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
-            const [skills, env, instructions, mcpInstructions, modelMsgs] = yield* Effect.all([
+            const [skills, env, instructions, mcpInstructions, modelMsgs, memory] = yield* Effect.all([
               sys.skills(agent),
               sys.environment(model),
               instruction.system().pipe(Effect.orDie),
               sys.mcp(agent, session.permission),
               MessageV2.toModelMessagesEffect(msgs, model),
+              MemoryHost.context({ sessionID, sessions }),
             ])
             const system = [
               ...env,
               ...instructions,
               ...(mcpInstructions ? [mcpInstructions] : []),
               ...(skills ? [skills] : []),
+              ...memory,
             ]
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)

--- a/packages/opencode/src/tool/memory.ts
+++ b/packages/opencode/src/tool/memory.ts
@@ -1,0 +1,75 @@
+import { Effect } from "effect"
+import { MemoryControls } from "@opencode-ai/memory/controls"
+import { MemoryService } from "@opencode-ai/memory/effect/service"
+import { MemoryTool } from "@opencode-ai/memory/tool"
+import { InstanceState } from "@/effect/instance-state"
+import { Session } from "@/session/session"
+import * as Tool from "./tool"
+
+const memory = MemoryService.make()
+
+export const MemorySaveTool = Tool.define(
+  "memory_save",
+  Effect.gen(function* () {
+    const sessions = yield* Session.Service
+    return {
+      description: MemoryTool.SaveDescription,
+      parameters: MemoryTool.SaveParameters,
+      execute: (params: MemoryTool.SaveParams, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const info = yield* sessions.get(ctx.sessionID).pipe(Effect.orDie)
+          // A session that opted out of contribution via the /memory controls never writes memory.
+          if (!MemoryControls.contribute(info.metadata))
+            return {
+              title: "Bolt memory: off for this session",
+              output:
+                "Memory contribution is turned off for this session. Turn it back on with /memory contribute on.",
+              metadata: { sources: [] },
+            }
+          const instance = yield* InstanceState.context
+          return yield* MemoryTool.save({
+            memory,
+            params,
+            sessionID: ctx.sessionID,
+            ctx: instance,
+            ask: (input) => ctx.ask(input),
+          }).pipe(
+            Effect.catchIf(MemoryTool.failure, (err) => Effect.succeed(MemoryTool.error("save", err))),
+            Effect.orDie,
+          )
+        }),
+    }
+  }),
+)
+
+export const MemoryRecallTool = Tool.define(
+  "memory_recall",
+  Effect.gen(function* () {
+    const sessions = yield* Session.Service
+    return {
+      description: MemoryTool.RecallDescription,
+      parameters: MemoryTool.RecallParameters,
+      execute: (params: MemoryTool.RecallParams, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const info = yield* sessions.get(ctx.sessionID).pipe(Effect.orDie)
+          if (!MemoryControls.use(info.metadata))
+            return {
+              title: "Bolt memory: off for this session",
+              output: "Memory use is turned off for this session. Turn it back on with /memory use on.",
+              metadata: { sources: [], count: 0 },
+            }
+          const instance = yield* InstanceState.context
+          return yield* MemoryTool.recall({
+            memory,
+            params,
+            sessionID: ctx.sessionID,
+            ctx: instance,
+            ask: (input) => ctx.ask(input),
+          }).pipe(
+            Effect.catchIf(MemoryTool.failure, (err) => Effect.succeed(MemoryTool.error("recall", err))),
+            Effect.orDie,
+          )
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -15,6 +15,7 @@ import { TodoWriteTool } from "./todo"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
+import { MemoryRecallTool, MemorySaveTool } from "./memory"
 import { SkillTool } from "./skill"
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
@@ -109,6 +110,8 @@ const layer = Layer.effect(
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
     const skilltool = yield* SkillTool
+    const memsave = yield* MemorySaveTool
+    const memrecall = yield* MemoryRecallTool
     const agent = yield* Agent.Service
     const codeMode = flags.experimentalCodeMode ? yield* Effect.promise(() => import("./code-mode")) : undefined
     const codeModeTool = codeMode ? yield* codeMode.CodeModeTool : undefined
@@ -215,6 +218,8 @@ const layer = Layer.effect(
           search: Tool.init(websearch),
           skill: Tool.init(skilltool),
           patch: Tool.init(patchtool),
+          memsave: Tool.init(memsave),
+          memrecall: Tool.init(memrecall),
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
@@ -238,6 +243,8 @@ const layer = Layer.effect(
             tool.search,
             tool.skill,
             tool.patch,
+            tool.memsave,
+            tool.memrecall,
             ...(tool.execute ? [tool.execute] : []),
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),

--- a/packages/opencode/test/memory/context.test.ts
+++ b/packages/opencode/test/memory/context.test.ts
@@ -32,24 +32,24 @@ function run(ctx: { directory: string; worktree: string }, metadata: Record<stri
 
 describe("memory host context", () => {
   test("injects guidance and saved memory for an enabled store", async () => {
-    const f = await fixture()
-    await BoltMemory.enable({ ctx: f.ctx })
-    await BoltMemory.remember({ ctx: f.ctx, text: "Deploys happen via the ship script" })
-    const blocks = await run(f.ctx)
+    const tmp = await fixture()
+    await BoltMemory.enable({ ctx: tmp.ctx })
+    await BoltMemory.remember({ ctx: tmp.ctx, text: "Deploys happen via the ship script" })
+    const blocks = await run(tmp.ctx)
     expect(blocks).toHaveLength(1)
     expect(blocks[0]).toContain("memory_recall")
     expect(blocks[0]).toContain("ship script")
   })
 
   test("empty when the store is disabled", async () => {
-    const f = await fixture()
-    expect(await run(f.ctx)).toEqual([])
+    const tmp = await fixture()
+    expect(await run(tmp.ctx)).toEqual([])
   })
 
   test("empty when the session opted out of memory use", async () => {
-    const f = await fixture()
-    await BoltMemory.enable({ ctx: f.ctx })
-    await BoltMemory.remember({ ctx: f.ctx, text: "Deploys happen via the ship script" })
-    expect(await run(f.ctx, { [MemoryControls.USE]: false })).toEqual([])
+    const tmp = await fixture()
+    await BoltMemory.enable({ ctx: tmp.ctx })
+    await BoltMemory.remember({ ctx: tmp.ctx, text: "Deploys happen via the ship script" })
+    expect(await run(tmp.ctx, { [MemoryControls.USE]: false })).toEqual([])
   })
 })

--- a/packages/opencode/test/memory/context.test.ts
+++ b/packages/opencode/test/memory/context.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { Effect } from "effect"
+import { BoltMemory } from "@opencode-ai/memory/effect"
+import { MemoryControls } from "@opencode-ai/memory/controls"
+import { InstanceRef } from "../../src/effect/instance-ref"
+import type { InstanceContext } from "../../src/project/instance-context"
+import { MemoryHost } from "@/memory/host"
+import { SessionID } from "@/session/schema"
+import type { Session } from "@/session/session"
+
+const id = SessionID.make("ses_memory_context")
+
+function sessions(metadata: Record<string, unknown>): Session.Interface {
+  return { get: () => Effect.succeed({ metadata }) } as unknown as Session.Interface
+}
+
+async function fixture() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "bolt-memory-context-"))
+  return { dir, ctx: { directory: dir, worktree: dir } }
+}
+
+function run(ctx: { directory: string; worktree: string }, metadata: Record<string, unknown> = {}) {
+  return Effect.runPromise(
+    MemoryHost.context({ sessionID: id, sessions: sessions(metadata) }).pipe(
+      Effect.provideService(InstanceRef, ctx as unknown as InstanceContext),
+    ),
+  )
+}
+
+describe("memory host context", () => {
+  test("injects guidance and saved memory for an enabled store", async () => {
+    const f = await fixture()
+    await BoltMemory.enable({ ctx: f.ctx })
+    await BoltMemory.remember({ ctx: f.ctx, text: "Deploys happen via the ship script" })
+    const blocks = await run(f.ctx)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toContain("memory_recall")
+    expect(blocks[0]).toContain("ship script")
+  })
+
+  test("empty when the store is disabled", async () => {
+    const f = await fixture()
+    expect(await run(f.ctx)).toEqual([])
+  })
+
+  test("empty when the session opted out of memory use", async () => {
+    const f = await fixture()
+    await BoltMemory.enable({ ctx: f.ctx })
+    await BoltMemory.remember({ ctx: f.ctx, text: "Deploys happen via the ship script" })
+    expect(await run(f.ctx, { [MemoryControls.USE]: false })).toEqual([])
+  })
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -109,6 +109,16 @@ describe("tool.registry", () => {
     }),
   )
 
+  it.instance("exposes the memory tools", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const ids = yield* registry.ids()
+
+      expect(ids).toContain("memory_save")
+      expect(ids).toContain("memory_recall")
+    }),
+  )
+
   it.instance("does not expose execute unless code mode is enabled", () =>
     Effect.gen(function* () {
       const registry = yield* ToolRegistry.Service


### PR DESCRIPTION
### Issue for this PR

Closes #138

### Type of change

- [x] Bug fix

### What does this PR do?

Memory saved in one session was never recalled in new sessions. Auto-capture writes the store at turn close, but the read side (index injection + `memory_save`/`memory_recall` tools) only existed in the unused V2 runner in `packages/core`; the TUI/server drive prompts through the legacy V1 `SessionPrompt` loop, which had neither. So the store filled up and nothing ever surfaced it.

Two changes, both mirroring the V2 behavior:

1. `MemoryHost.context()` loads the project memory index + latest session digest and it is injected into the V1 system prompt assembly, gated by the per-session `/memory use` control and store enablement:

```ts
const [skills, env, instructions, mcpInstructions, modelMsgs, memory] = yield* Effect.all([
  sys.skills(agent),
  sys.environment(model),
  instruction.system().pipe(Effect.orDie),
  sys.mcp(agent, session.permission),
  MessageV2.toModelMessagesEffect(msgs, model),
  MemoryHost.context({ sessionID, sessions }),
])
const system = [...env, ...instructions, ...(mcpInstructions ? [mcpInstructions] : []), ...(skills ? [skills] : []), ...memory]
```

2. `memory_save` and `memory_recall` are ported to the V1 tool registry (`packages/opencode/src/tool/memory.ts`). The port is thin because `MemoryTool`'s `Ask` callback shape matches V1's `ctx.ask` exactly, so approvals flow through the normal V1 permission prompt. Per-session `/memory contribute` / `/memory use` gates are checked the same way as V2, and a disabled store reports as a regular tool result rather than an error.

The memory engine, storage, and auto-capture are untouched — this is purely wiring the existing read path into the active loop.

### How did you verify your code works?

- New tests: `test/memory/context.test.ts` (real on-disk store via `BoltMemory.enable`/`remember` under the test XDG tmpdir — enabled store injects guidance + saved fact; disabled store and `/memory use off` inject nothing) and a registry test asserting both tools are exposed.
- `bun run typecheck`, `bun test ./test/memory ./test/tool/registry.test.ts` and `bun test ./test/session` (369 pass) from `packages/opencode/`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added project memory support for preserving and recalling relevant information across eligible sessions.
  - Added tools to save information to memory and recall it during a session.
  - Automatically includes relevant saved memory in model context when enabled.
  - Memory can be disabled globally or opted out of for individual sessions.
  - Gracefully handles unavailable or empty memory without disrupting sessions.
- **Tests**
  - Added coverage for memory availability, session opt-out behavior, context injection, and tool registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->