### PR TITLE
docs: refresh roadmap with shipped memory work and tool expansion plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,23 @@ The roadmap is about one thing now: making the agent itself smarter, more autono
 ### Next
 
 <details>
-<summary><strong>Agents that remember (4)</strong></summary>
+<summary><strong>Agents that remember (2)</strong></summary>
 
 - [ ] Repo convention learning: the agent picks up your codebase's style and sticks to it
-- [ ] Compounding memory: every session teaches the next one
 - [ ] Memory introspection: ask the agent why it believes something and where it learned it
-- [ ] Cross-session recall: "do it like we did in that auth refactor last month"
+
+</details>
+
+<details>
+<summary><strong>Agents with better hands (7)</strong></summary>
+
+- [ ] `multiedit`: batch several edits to one file in a single tool call
+- [ ] Background process tools: start a dev server, poll its output, kill it, all without blocking the loop
+- [ ] `test_run`: run tests and hand the agent structured failures (file, line, message)
+- [ ] `view_image`: let the agent look at screenshots and design mocks
+- [ ] Browser tool: navigate and screenshot the running app to verify UI changes visually
+- [ ] LSP power tools: rename symbol and find references, promoted out of experimental
+- [ ] Semantic codebase search: find code by meaning, not regex
 
 </details>
 
@@ -232,6 +243,8 @@ The roadmap is about one thing now: making the agent itself smarter, more autono
 
 ### Done
 
+- [x] Compounding memory: every session teaches the next one, automatically
+- [x] Cross-session recall: new sessions start with project memory and `memory_save` / `memory_recall` in every agent's toolbox
 - [x] `bolt review --staged / --branch`: one-shot AI diff review with exit codes
 - [x] `bolt commit`: commit messages you don't have to rewrite
 - [x] Best-of-N runs: fire the same task at several models in parallel, rank the results, keep the winner

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -173,12 +173,23 @@ The roadmap is about one thing now: making the agent itself smarter, more autono
 ### Next
 
 <details>
-<summary><strong>Agents that remember (4)</strong></summary>
+<summary><strong>Agents that remember (2)</strong></summary>
 
 - [ ] Repo convention learning: the agent picks up your codebase's style and sticks to it
-- [ ] Compounding memory: every session teaches the next one
 - [ ] Memory introspection: ask the agent why it believes something and where it learned it
-- [ ] Cross-session recall: "do it like we did in that auth refactor last month"
+
+</details>
+
+<details>
+<summary><strong>Agents with better hands (7)</strong></summary>
+
+- [ ] `multiedit`: batch several edits to one file in a single tool call
+- [ ] Background process tools: start a dev server, poll its output, kill it, all without blocking the loop
+- [ ] `test_run`: run tests and hand the agent structured failures (file, line, message)
+- [ ] `view_image`: let the agent look at screenshots and design mocks
+- [ ] Browser tool: navigate and screenshot the running app to verify UI changes visually
+- [ ] LSP power tools: rename symbol and find references, promoted out of experimental
+- [ ] Semantic codebase search: find code by meaning, not regex
 
 </details>
 
@@ -232,6 +243,8 @@ The roadmap is about one thing now: making the agent itself smarter, more autono
 
 ### Done
 
+- [x] Compounding memory: every session teaches the next one, automatically
+- [x] Cross-session recall: new sessions start with project memory and `memory_save` / `memory_recall` in every agent's toolbox
 - [x] `bolt review --staged / --branch`: one-shot AI diff review with exit codes
 - [x] `bolt commit`: commit messages you don't have to rewrite
 - [x] Best-of-N runs: fire the same task at several models in parallel, rank the results, keep the winner


### PR DESCRIPTION
### Issue for this PR

Closes #141

### Type of change

- [x] Documentation

### What does this PR do?

Refreshes the README roadmap to match reality after #139 merged:

- Moves "Compounding memory" and "Cross-session recall" from the "Agents that remember" group to Done, since automatic capture + memory index injection + `memory_save`/`memory_recall` now all run in the live session loop.
- Adds a new "Agents with better hands (7)" group covering the planned tool expansion: `multiedit`, background process tools, `test_run`, `view_image`, browser tool, LSP promotion (rename/find references), and semantic codebase search.

`README.md` and `packages/opencode/README.md` are kept byte-identical (verified with `cmp`).

### How did you verify your code works?

Docs-only change; verified the two READMEs are byte-identical with `cmp`.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to mark compounding memory and cross-session recall as completed.
  * Refined upcoming memory improvements and added planned enhancements for more capable agent tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->