### PR TITLE
feat(opencode): add multiedit tool for atomic batched file edits

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -34,7 +34,8 @@ function convertToLineEnding(text: string, ending: "\n" | "\r\n"): string {
 
 const locks = new Map<string, Semaphore.Semaphore>()
 
-function lock(filePath: string) {
+// Shared with multiedit so concurrent edits to the same file are serialized across both tools.
+export function lock(filePath: string) {
   const resolvedFilePath = FSUtil.resolve(filePath)
   const hit = locks.get(resolvedFilePath)
   if (hit) return hit

--- a/packages/opencode/src/tool/multiedit.ts
+++ b/packages/opencode/src/tool/multiedit.ts
@@ -1,5 +1,5 @@
 import * as path from "path"
-import { Effect, Schema, Semaphore } from "effect"
+import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { LSP } from "@/lsp/lsp"
 import { createTwoFilesPatch, diffLines } from "diff"
@@ -13,7 +13,7 @@ import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import * as Bom from "@/util/bom"
-import { replace, trimDiff } from "./edit"
+import { lock, replace, trimDiff } from "./edit"
 
 function normalize(text: string): string {
   return text.replaceAll("\r\n", "\n")
@@ -26,18 +26,6 @@ function ending(text: string): "\n" | "\r\n" {
 function convert(text: string, eol: "\n" | "\r\n"): string {
   if (eol === "\n") return text
   return text.replaceAll("\n", "\r\n")
-}
-
-const locks = new Map<string, Semaphore.Semaphore>()
-
-function lock(filePath: string) {
-  const resolved = FSUtil.resolve(filePath)
-  const hit = locks.get(resolved)
-  if (hit) return hit
-
-  const next = Semaphore.makeUnsafe(1)
-  locks.set(resolved, next)
-  return next
 }
 
 export const Parameters = Schema.Struct({

--- a/packages/opencode/src/tool/multiedit.ts
+++ b/packages/opencode/src/tool/multiedit.ts
@@ -1,0 +1,183 @@
+import * as path from "path"
+import { Effect, Schema, Semaphore } from "effect"
+import * as Tool from "./tool"
+import { LSP } from "@/lsp/lsp"
+import { createTwoFilesPatch, diffLines } from "diff"
+import DESCRIPTION from "./multiedit.txt"
+import { FileSystem } from "@opencode-ai/core/filesystem"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Format } from "../format"
+import { InstanceState } from "@/effect/instance-state"
+import { Snapshot } from "@/snapshot"
+import { assertExternalDirectoryEffect } from "./external-directory"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import * as Bom from "@/util/bom"
+import { replace, trimDiff } from "./edit"
+
+function normalize(text: string): string {
+  return text.replaceAll("\r\n", "\n")
+}
+
+function ending(text: string): "\n" | "\r\n" {
+  return text.includes("\r\n") ? "\r\n" : "\n"
+}
+
+function convert(text: string, eol: "\n" | "\r\n"): string {
+  if (eol === "\n") return text
+  return text.replaceAll("\n", "\r\n")
+}
+
+const locks = new Map<string, Semaphore.Semaphore>()
+
+function lock(filePath: string) {
+  const resolved = FSUtil.resolve(filePath)
+  const hit = locks.get(resolved)
+  if (hit) return hit
+
+  const next = Semaphore.makeUnsafe(1)
+  locks.set(resolved, next)
+  return next
+}
+
+export const Parameters = Schema.Struct({
+  filePath: Schema.String.annotate({ description: "The absolute path to the file to modify" }),
+  edits: Schema.Array(
+    Schema.Struct({
+      oldString: Schema.String.annotate({ description: "The text to replace" }),
+      newString: Schema.String.annotate({
+        description: "The text to replace it with (must be different from oldString)",
+      }),
+      replaceAll: Schema.optional(Schema.Boolean).annotate({
+        description: "Replace all occurrences of oldString (default false)",
+      }),
+    }),
+  ).annotate({
+    description: "Edits to apply in order. Each edit operates on the result of the previous one.",
+  }),
+})
+
+export const MultiEditTool = Tool.define(
+  "multiedit",
+  Effect.gen(function* () {
+    const lsp = yield* LSP.Service
+    const afs = yield* FSUtil.Service
+    const format = yield* Format.Service
+    const events = yield* EventV2Bridge.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          if (!params.filePath) {
+            throw new Error("filePath is required")
+          }
+          if (params.edits.length === 0) {
+            throw new Error("edits must contain at least one edit")
+          }
+
+          const instance = yield* InstanceState.context
+          const filePath = path.isAbsolute(params.filePath)
+            ? params.filePath
+            : path.join(instance.directory, params.filePath)
+          yield* assertExternalDirectoryEffect(ctx, filePath)
+
+          let diff = ""
+          let contentOld = ""
+          let contentNew = ""
+          yield* lock(filePath).withPermits(1)(
+            Effect.gen(function* () {
+              const info = yield* afs.stat(filePath).pipe(Effect.catch(() => Effect.succeed(undefined)))
+              if (!info) throw new Error(`File ${filePath} not found`)
+              if (info.type === "Directory") throw new Error(`Path is a directory, not a file: ${filePath}`)
+              const source = yield* Bom.readFile(afs, filePath)
+              contentOld = source.text
+
+              const eol = ending(contentOld)
+              // Apply every edit in memory first so a failing edit leaves the file untouched.
+              let content = contentOld
+              for (let i = 0; i < params.edits.length; i++) {
+                const edit = params.edits[i]
+                try {
+                  content = replace(
+                    content,
+                    convert(normalize(edit.oldString), eol),
+                    convert(normalize(edit.newString), eol),
+                    edit.replaceAll,
+                  )
+                } catch (err) {
+                  const message = err instanceof Error ? err.message : String(err)
+                  throw new Error(`Edit ${i + 1} of ${params.edits.length} failed, no changes applied: ${message}`)
+                }
+              }
+
+              const next = Bom.split(content)
+              const desiredBom = source.bom || next.bom
+              contentNew = next.text
+
+              diff = trimDiff(createTwoFilesPatch(filePath, filePath, normalize(contentOld), normalize(contentNew)))
+              yield* ctx.ask({
+                permission: "edit",
+                patterns: [path.relative(instance.worktree, filePath)],
+                always: ["*"],
+                metadata: {
+                  filepath: filePath,
+                  diff,
+                },
+              })
+
+              yield* afs.writeWithDirs(filePath, Bom.join(contentNew, desiredBom))
+              if (yield* format.file(filePath)) {
+                contentNew = yield* Bom.syncFile(afs, filePath, desiredBom)
+              }
+              yield* events.publish(FileSystem.Event.Edited, { file: filePath })
+              yield* events.publish(Watcher.Event.Updated, {
+                file: filePath,
+                event: "change",
+              })
+              diff = trimDiff(createTwoFilesPatch(filePath, filePath, normalize(contentOld), normalize(contentNew)))
+            }).pipe(Effect.orDie),
+          )
+
+          let additions = 0
+          let deletions = 0
+          for (const change of diffLines(contentOld, contentNew)) {
+            if (change.added) additions += change.count || 0
+            if (change.removed) deletions += change.count || 0
+          }
+          const filediff: Snapshot.FileDiff = {
+            file: filePath,
+            patch: diff,
+            additions,
+            deletions,
+          }
+
+          yield* ctx.metadata({
+            metadata: {
+              diff,
+              filediff,
+              diagnostics: {},
+            },
+          })
+
+          let output = `Applied ${params.edits.length} edit${params.edits.length === 1 ? "" : "s"} successfully.`
+          yield* lsp.touchFile(filePath, "document")
+          const diagnostics = yield* lsp.diagnostics()
+          const normalizedFilePath = FSUtil.normalizePath(filePath)
+          const block = LSP.Diagnostic.report(filePath, diagnostics[normalizedFilePath] ?? [])
+          if (block) output += `\n\nLSP errors detected in this file, please fix:\n${block}`
+
+          return {
+            metadata: {
+              diagnostics,
+              diff,
+              filediff,
+            },
+            title: `${path.relative(instance.worktree, filePath)}`,
+            output,
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/multiedit.txt
+++ b/packages/opencode/src/tool/multiedit.txt
@@ -1,0 +1,11 @@
+Performs multiple find-and-replace edits on one file in a single atomic operation.
+
+Prefer this over several sequential `edit` calls when you need to make more than one change to the same file.
+
+Usage:
+- You must use your `read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file.
+- Provide `filePath` (absolute path) and an `edits` array. Each edit has `oldString`, `newString`, and an optional `replaceAll`.
+- Edits are applied in order. Each edit operates on the result of the previous edit, so a later `oldString` must match the file content as it exists after the earlier edits.
+- All edits must succeed or none are applied. If any edit fails (oldString not found, or found multiple times without `replaceAll`), the file is left untouched.
+- Matching semantics are identical to the `edit` tool: `oldString` must match exactly, including indentation, and must be unique in the file unless `replaceAll` is set.
+- This tool cannot create new files. Use `write` for new files and `edit` for single changes.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -16,6 +16,7 @@ import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
 import { MemoryRecallTool, MemorySaveTool } from "./memory"
+import { MultiEditTool } from "./multiedit"
 import { SkillTool } from "./skill"
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
@@ -112,6 +113,7 @@ const layer = Layer.effect(
     const skilltool = yield* SkillTool
     const memsave = yield* MemorySaveTool
     const memrecall = yield* MemoryRecallTool
+    const multiedit = yield* MultiEditTool
     const agent = yield* Agent.Service
     const codeMode = flags.experimentalCodeMode ? yield* Effect.promise(() => import("./code-mode")) : undefined
     const codeModeTool = codeMode ? yield* codeMode.CodeModeTool : undefined
@@ -211,6 +213,7 @@ const layer = Layer.effect(
           glob: Tool.init(globtool),
           grep: Tool.init(greptool),
           edit: Tool.init(edit),
+          multiedit: Tool.init(multiedit),
           write: Tool.init(writetool),
           task: Tool.init(task),
           fetch: Tool.init(webfetch),
@@ -236,6 +239,7 @@ const layer = Layer.effect(
             tool.glob,
             tool.grep,
             tool.edit,
+            tool.multiedit,
             tool.write,
             tool.task,
             tool.fetch,
@@ -299,7 +303,7 @@ const layer = Layer.effect(
         const usePatch =
           input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4")
         if (tool.id === ApplyPatchTool.id) return usePatch
-        if (tool.id === EditTool.id || tool.id === WriteTool.id) return !usePatch
+        if (tool.id === EditTool.id || tool.id === WriteTool.id || tool.id === MultiEditTool.id) return !usePatch
 
         return true
       })

--- a/packages/opencode/test/tool/multiedit.test.ts
+++ b/packages/opencode/test/tool/multiedit.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect } from "bun:test"
+import path from "path"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Cause, Effect, Exit } from "effect"
+import { MultiEditTool } from "../../src/tool/multiedit"
+import { disposeAllInstances } from "../fixture/fixture"
+import { LSP } from "@/lsp/lsp"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Format } from "../../src/format"
+import { Agent } from "../../src/agent/agent"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { Truncate } from "@/tool/truncate"
+import { SessionID, MessageID } from "../../src/session/schema"
+import * as Tool from "../../src/tool/tool"
+import { testEffect } from "../lib/effect"
+import { InstanceState } from "@/effect/instance-state"
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-multiedit-session"),
+  messageID: MessageID.make("msg_test"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const layer = LayerNode.compile(
+  LayerNode.group([LSP.node, FSUtil.node, Format.node, EventV2Bridge.node, Truncate.node, Agent.node]),
+)
+
+const it = testEffect(layer)
+
+const run = Effect.fn("MultiEditToolTest.run")(function* (args: Tool.InferParameters<typeof MultiEditTool>) {
+  const info = yield* MultiEditTool
+  const tool = yield* info.init()
+  return yield* tool.execute(args, ctx)
+})
+
+const fail = Effect.fn("MultiEditToolTest.fail")(function* (args: Tool.InferParameters<typeof MultiEditTool>) {
+  const exit = yield* run(args).pipe(Effect.exit)
+  if (Exit.isFailure(exit)) {
+    const err = Cause.squash(exit.cause)
+    return err instanceof Error ? err : new Error(String(err))
+  }
+  throw new Error("expected multiedit to fail")
+})
+
+const put = Effect.fn("MultiEditToolTest.put")(function* (p: string, content: string) {
+  const fs = yield* FSUtil.Service
+  yield* fs.writeWithDirs(p, content)
+})
+
+const load = Effect.fn("MultiEditToolTest.load")(function* (p: string) {
+  const fs = yield* FSUtil.Service
+  return yield* fs.readFileString(p)
+})
+
+const file = Effect.fn("MultiEditToolTest.file")(function* (name: string) {
+  const dir = yield* InstanceState.directory
+  return path.join(dir, name)
+})
+
+describe("tool.multiedit", () => {
+  it.instance("applies several edits in order", () =>
+    Effect.gen(function* () {
+      const p = yield* file("multi.txt")
+      yield* put(p, "alpha\nbeta\ngamma\n")
+      const result = yield* run({
+        filePath: p,
+        edits: [
+          { oldString: "alpha", newString: "one" },
+          { oldString: "beta", newString: "two" },
+          { oldString: "gamma", newString: "three" },
+        ],
+      })
+      expect(yield* load(p)).toBe("one\ntwo\nthree\n")
+      expect(result.output).toContain("Applied 3 edits")
+    }),
+  )
+
+  it.instance("later edits see the result of earlier edits", () =>
+    Effect.gen(function* () {
+      const p = yield* file("chain.txt")
+      yield* put(p, "value = 1\n")
+      yield* run({
+        filePath: p,
+        edits: [
+          { oldString: "value = 1", newString: "count = 1" },
+          { oldString: "count = 1", newString: "count = 2" },
+        ],
+      })
+      expect(yield* load(p)).toBe("count = 2\n")
+    }),
+  )
+
+  it.instance("supports replaceAll per edit", () =>
+    Effect.gen(function* () {
+      const p = yield* file("all.txt")
+      yield* put(p, "foo foo foo\nbar\n")
+      yield* run({
+        filePath: p,
+        edits: [
+          { oldString: "foo", newString: "baz", replaceAll: true },
+          { oldString: "bar", newString: "qux" },
+        ],
+      })
+      expect(yield* load(p)).toBe("baz baz baz\nqux\n")
+    }),
+  )
+
+  it.instance("is atomic: a failing edit leaves the file untouched", () =>
+    Effect.gen(function* () {
+      const p = yield* file("atomic.txt")
+      yield* put(p, "alpha\nbeta\n")
+      const err = yield* fail({
+        filePath: p,
+        edits: [
+          { oldString: "alpha", newString: "one" },
+          { oldString: "does-not-exist", newString: "two" },
+        ],
+      })
+      expect(err.message).toContain("Edit 2 of 2 failed")
+      expect(yield* load(p)).toBe("alpha\nbeta\n")
+    }),
+  )
+
+  it.instance("rejects an empty edits array", () =>
+    Effect.gen(function* () {
+      const p = yield* file("empty.txt")
+      yield* put(p, "alpha\n")
+      const err = yield* fail({ filePath: p, edits: [] })
+      expect(err.message).toContain("at least one edit")
+    }),
+  )
+
+  it.instance("rejects missing files", () =>
+    Effect.gen(function* () {
+      const p = yield* file("missing.txt")
+      const err = yield* fail({ filePath: p, edits: [{ oldString: "a", newString: "b" }] })
+      expect(err.message).toContain("not found")
+    }),
+  )
+
+  it.instance("preserves CRLF line endings", () =>
+    Effect.gen(function* () {
+      const p = yield* file("crlf.txt")
+      yield* put(p, "alpha\r\nbeta\r\n")
+      yield* run({
+        filePath: p,
+        edits: [{ oldString: "alpha\nbeta", newString: "one\ntwo" }],
+      })
+      expect(yield* load(p)).toBe("one\r\ntwo\r\n")
+    }),
+  )
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -116,6 +116,7 @@ describe("tool.registry", () => {
 
       expect(ids).toContain("memory_save")
       expect(ids).toContain("memory_recall")
+      expect(ids).toContain("multiedit")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #143

### Type of change

- [x] New feature

### What does this PR do?

Adds a `multiedit` tool (first item of the new "Agents with better hands" roadmap group): several find-and-replace edits to one file in a single tool call, instead of N `edit` roundtrips with N permission prompts and N formatter runs.

Shape matches what agents already know from Claude Code: `filePath` plus an ordered `edits` array. All edits are applied in memory first using the exact same `replace()` matching engine as the `edit` tool, so a failing edit leaves the file untouched and produces one clear error:

```ts
let content = contentOld
for (let i = 0; i < params.edits.length; i++) {
  const edit = params.edits[i]
  try {
    content = replace(content, convert(normalize(edit.oldString), eol), convert(normalize(edit.newString), eol), edit.replaceAll)
  } catch (err) {
    throw new Error(`Edit ${i + 1} of ${params.edits.length} failed, no changes applied: ${...}`)
  }
}
```

One combined diff drives a single permission ask, then one write, one format pass, one filesystem event, and one LSP diagnostics report — identical post-write behavior to `edit`. Registered in the tool registry and hidden for GPT-family models that use `apply_patch`, same as `edit`/`write`. BOM and CRLF handling mirror the edit tool.

### How did you verify your code works?

New `test/tool/multiedit.test.ts` on the same harness as the edit tool tests: ordered application, chained edits (later edits see earlier results), per-edit `replaceAll`, atomicity on failure, empty-edits and missing-file rejection, CRLF preservation. Plus a registry exposure assertion. `bun run typecheck` and `bun test ./test/tool/multiedit.test.ts ./test/tool/registry.test.ts ./test/tool/edit.test.ts` (52 pass) from `packages/opencode/`.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-edit tool for applying multiple ordered find-and-replace changes to one file.
  * Supports replacing all matches while preserving line endings and file encoding details.
  * Reports patch information and refreshed diagnostics after successful edits.

* **Bug Fixes**
  * Failed edit sequences leave files unchanged and identify the failing edit.
  * Added validation for missing files and empty edit requests.

* **Documentation**
  * Documented usage, matching rules, requirements, and limitations for multi-edit operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->