### PR TITLE
feat(opencode): add background process tools

### DIFF
--- a/packages/opencode/src/tool/background-kill.txt
+++ b/packages/opencode/src/tool/background-kill.txt
@@ -1,0 +1,7 @@
+Terminates a background process started with bash_background.
+
+Usage:
+- Pass the process id returned by bash_background.
+- The whole process tree is terminated (graceful kill first, force kill after a short grace period).
+- Safe to call on processes that already finished; reports their final status.
+- Always kill dev servers and watchers you started once you no longer need them.

--- a/packages/opencode/src/tool/background-list.txt
+++ b/packages/opencode/src/tool/background-list.txt
@@ -1,0 +1,6 @@
+Lists all background processes started with bash_background, with their id, status, and command.
+
+Usage:
+- Takes no parameters.
+- Use it to find a process id you lost, or to check for stray processes before starting new ones.
+- Statuses: running, completed, error, cancelled.

--- a/packages/opencode/src/tool/background-output.txt
+++ b/packages/opencode/src/tool/background-output.txt
@@ -1,0 +1,7 @@
+Reads the accumulated output (combined stdout and stderr) and status of a background process started with bash_background.
+
+Usage:
+- Pass the process id returned by bash_background.
+- Returns the output collected so far for running processes, or the final output for finished ones.
+- Pass `wait` (milliseconds) to block until the process finishes or the wait elapses, whichever comes first. Use this to wait for a server to boot instead of polling in a loop.
+- Old output is dropped once the buffer limit is exceeded; only the most recent output is kept.

--- a/packages/opencode/src/tool/background.ts
+++ b/packages/opencode/src/tool/background.ts
@@ -1,0 +1,257 @@
+import { Effect, Schema, Stream } from "effect"
+import path from "path"
+import * as Tool from "./tool"
+import { BackgroundJob } from "@/background/job"
+import { InstanceState } from "@/effect/instance-state"
+import { Config } from "@/config/config"
+import { Plugin } from "@/plugin"
+import { Identifier } from "@opencode-ai/core/id/id"
+import { Shell } from "@opencode-ai/core/shell"
+import { ShellID } from "./shell/id"
+import { BashArity } from "@/permission/arity"
+import * as Truncate from "./truncate"
+import { ChildProcess } from "effect/unstable/process"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import START_DESCRIPTION from "./background.txt"
+import OUTPUT_DESCRIPTION from "./background-output.txt"
+import KILL_DESCRIPTION from "./background-kill.txt"
+import LIST_DESCRIPTION from "./background-list.txt"
+
+const TYPE = "shell"
+
+/** Live output per running job. BackgroundJob only exposes output after completion, so the
+ * stream consumer inside each job's run effect appends here and process_output reads it. */
+const live = new Map<string, { text: string; cut: boolean }>()
+
+function append(id: string, chunk: string, keep: number) {
+  const entry = live.get(id) ?? { text: "", cut: false }
+  entry.text += chunk
+  if (entry.text.length > keep) {
+    entry.text = entry.text.slice(entry.text.length - keep)
+    entry.cut = true
+  }
+  live.set(id, entry)
+}
+
+function command(shell: string, text: string, cwd: string, env: NodeJS.ProcessEnv) {
+  if (process.platform === "win32" && Shell.ps(shell)) {
+    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", text], {
+      cwd,
+      env,
+      stdin: "ignore",
+      detached: false,
+    })
+  }
+  return ChildProcess.make(text, [], {
+    shell,
+    cwd,
+    env,
+    stdin: "ignore",
+    detached: process.platform !== "win32",
+  })
+}
+
+function render(info: BackgroundJob.Info) {
+  const meta = info.metadata ?? {}
+  const cmd = typeof meta.command === "string" ? meta.command : (info.title ?? "")
+  return `${info.id} [${info.status}] ${cmd}`
+}
+
+export const StartParameters = Schema.Struct({
+  command: Schema.String.annotate({ description: "The shell command to run in the background" }),
+  workdir: Schema.optional(Schema.String).annotate({
+    description: "Working directory for the command. Defaults to the project directory.",
+  }),
+  title: Schema.optional(Schema.String).annotate({
+    description: "Short human-readable label for the process (e.g. 'dev server')",
+  }),
+})
+
+export const BackgroundStartTool = Tool.define(
+  "bash_background",
+  Effect.gen(function* () {
+    const jobs = yield* BackgroundJob.Service
+    const spawner = yield* ChildProcessSpawner
+    const config = yield* Config.Service
+    const plugin = yield* Plugin.Service
+    const trunc = yield* Truncate.Service
+
+    return {
+      description: START_DESCRIPTION,
+      parameters: StartParameters,
+      execute: (params: Schema.Schema.Type<typeof StartParameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          if (!params.command.trim()) throw new Error("command is required")
+          const instance = yield* InstanceState.context
+          const cwd = params.workdir ? path.resolve(instance.directory, params.workdir) : instance.directory
+
+          // Same permission action as the foreground shell tool so existing bash
+          // allow/deny rules apply to background commands too.
+          const tokens = params.command.trim().split(/\s+/)
+          yield* ctx.ask({
+            permission: ShellID.ToolID,
+            patterns: [params.command],
+            always: [BashArity.prefix(tokens).join(" ") + " *"],
+            metadata: {
+              command: params.command,
+              background: true,
+            },
+          })
+
+          const cfg = yield* config.get()
+          const shell = Shell.acceptable(cfg.shell)
+          const extra = yield* plugin.trigger(
+            "shell.env",
+            { cwd, sessionID: ctx.sessionID, callID: ctx.callID },
+            { env: {} },
+          )
+          const env = { ...process.env, ...extra.env }
+          const limits = yield* trunc.limits()
+          const keep = limits.maxBytes * 2
+
+          // Generate the id up front so the run effect can key its live output buffer.
+          const id = Identifier.ascending("job")
+          const info = yield* jobs.start({
+            id,
+            type: TYPE,
+            title: params.title ?? params.command,
+            metadata: {
+              sessionId: ctx.sessionID,
+              parentSessionId: ctx.sessionID,
+              background: true,
+              command: params.command,
+              cwd,
+            },
+            run: Effect.scoped(
+              Effect.gen(function* () {
+                const handle = yield* spawner.spawn(command(shell, params.command, cwd, env))
+                yield* Effect.forkScoped(
+                  Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
+                    Effect.sync(() => append(id, chunk, keep)),
+                  ),
+                )
+                const code = yield* handle.exitCode.pipe(
+                  Effect.onInterrupt(() =>
+                    handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.catch(() => Effect.void)),
+                  ),
+                )
+                const entry = live.get(id)
+                live.delete(id)
+                const text = entry?.text ?? ""
+                return `exit=${code}\n${text}`
+              }),
+            ),
+          })
+
+          return {
+            title: params.title ?? params.command,
+            output: [
+              `Started background process ${info.id}: ${params.command}`,
+              `Use process_output with id=${info.id} to read its output, and kill_process to stop it.`,
+            ].join("\n"),
+            metadata: { id: info.id, status: info.status },
+          }
+        }),
+    }
+  }),
+)
+
+export const OutputParameters = Schema.Struct({
+  id: Schema.String.annotate({ description: "The background process id returned by bash_background" }),
+  wait: Schema.optional(Schema.Number).annotate({
+    description: "Optional milliseconds to wait for the process to finish before returning",
+  }),
+})
+
+export const BackgroundOutputTool = Tool.define(
+  "process_output",
+  Effect.gen(function* () {
+    const jobs = yield* BackgroundJob.Service
+    const trunc = yield* Truncate.Service
+
+    return {
+      description: OUTPUT_DESCRIPTION,
+      parameters: OutputParameters,
+      execute: (params: Schema.Schema.Type<typeof OutputParameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          if (params.wait !== undefined && params.wait > 0) {
+            yield* jobs.wait({ id: params.id, timeout: params.wait })
+          }
+          const info = yield* jobs.get(params.id)
+          if (!info || info.type !== TYPE) {
+            throw new Error(`No background process found with id ${params.id}. Use list_processes to see known ids.`)
+          }
+          const entry = live.get(params.id)
+          const text = info.status === "running" ? (entry?.text ?? "") : (info.output ?? info.error ?? "")
+          const limits = yield* trunc.limits()
+          const cut = (entry?.cut ?? false) || text.length > limits.maxBytes
+          const body = text.length > limits.maxBytes ? text.slice(text.length - limits.maxBytes) : text
+          return {
+            title: `${params.id} [${info.status}]`,
+            output: [`status=${info.status}`, body || "(no output yet)"].join("\n"),
+            metadata: { id: info.id, status: info.status, truncated: cut },
+          }
+        }),
+    }
+  }),
+)
+
+export const KillParameters = Schema.Struct({
+  id: Schema.String.annotate({ description: "The background process id to terminate" }),
+})
+
+export const BackgroundKillTool = Tool.define(
+  "kill_process",
+  Effect.gen(function* () {
+    const jobs = yield* BackgroundJob.Service
+
+    return {
+      description: KILL_DESCRIPTION,
+      parameters: KillParameters,
+      execute: (params: Schema.Schema.Type<typeof KillParameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const found = yield* jobs.get(params.id)
+          if (!found || found.type !== TYPE) {
+            throw new Error(`No background process found with id ${params.id}. Use list_processes to see known ids.`)
+          }
+          const info = (yield* jobs.cancel(params.id)) ?? found
+          live.delete(params.id)
+          return {
+            title: `${params.id} [${info.status}]`,
+            output: `Process ${params.id} is now ${info.status}.`,
+            metadata: { id: info.id, status: info.status },
+          }
+        }),
+    }
+  }),
+)
+
+export const ListParameters = Schema.Struct({})
+
+export const BackgroundListTool = Tool.define(
+  "list_processes",
+  Effect.gen(function* () {
+    const jobs = yield* BackgroundJob.Service
+
+    return {
+      description: LIST_DESCRIPTION,
+      parameters: ListParameters,
+      execute: (_params: Schema.Schema.Type<typeof ListParameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const list = (yield* jobs.list()).filter((info) => info.type === TYPE)
+          if (list.length === 0) {
+            return {
+              title: "No background processes",
+              output: "No background processes have been started in this session.",
+              metadata: { count: 0 },
+            }
+          }
+          return {
+            title: `${list.length} background process${list.length === 1 ? "" : "es"}`,
+            output: list.map(render).join("\n"),
+            metadata: { count: list.length },
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/background.txt
+++ b/packages/opencode/src/tool/background.txt
@@ -1,0 +1,9 @@
+Starts a shell command as a background process and returns immediately with a process id.
+
+Use this for long-running commands that should keep running while you continue working: dev servers, watchers, tails, long builds. Do NOT use shell-level backgrounding (`&`, `nohup`, `setsid`) with the bash tool; output is lost and the process cannot be managed.
+
+Usage:
+- Returns a process id. Use `process_output` with that id to read accumulated output, `kill_process` to stop it, and `list_processes` to see all background processes.
+- The process is killed automatically when the session ends.
+- Same permission rules as the bash tool apply.
+- For quick commands that finish on their own, use the bash tool instead.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -15,6 +15,7 @@ import { TodoWriteTool } from "./todo"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
+import { BackgroundKillTool, BackgroundListTool, BackgroundOutputTool, BackgroundStartTool } from "./background"
 import { MemoryRecallTool, MemorySaveTool } from "./memory"
 import { MultiEditTool } from "./multiedit"
 import { SkillTool } from "./skill"
@@ -114,6 +115,10 @@ const layer = Layer.effect(
     const memsave = yield* MemorySaveTool
     const memrecall = yield* MemoryRecallTool
     const multiedit = yield* MultiEditTool
+    const bgstart = yield* BackgroundStartTool
+    const bgoutput = yield* BackgroundOutputTool
+    const bgkill = yield* BackgroundKillTool
+    const bglist = yield* BackgroundListTool
     const agent = yield* Agent.Service
     const codeMode = flags.experimentalCodeMode ? yield* Effect.promise(() => import("./code-mode")) : undefined
     const codeModeTool = codeMode ? yield* codeMode.CodeModeTool : undefined
@@ -223,6 +228,10 @@ const layer = Layer.effect(
           patch: Tool.init(patchtool),
           memsave: Tool.init(memsave),
           memrecall: Tool.init(memrecall),
+          bgstart: Tool.init(bgstart),
+          bgoutput: Tool.init(bgoutput),
+          bgkill: Tool.init(bgkill),
+          bglist: Tool.init(bglist),
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
@@ -249,6 +258,10 @@ const layer = Layer.effect(
             tool.patch,
             tool.memsave,
             tool.memrecall,
+            tool.bgstart,
+            tool.bgoutput,
+            tool.bgkill,
+            tool.bglist,
             ...(tool.execute ? [tool.execute] : []),
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),

--- a/packages/opencode/test/tool/background.test.ts
+++ b/packages/opencode/test/tool/background.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Cause, Effect, Exit, Layer } from "effect"
+import { BackgroundJob } from "@/background/job"
+import {
+  BackgroundKillTool,
+  BackgroundListTool,
+  BackgroundOutputTool,
+  BackgroundStartTool,
+} from "../../src/tool/background"
+import { Config } from "@/config/config"
+import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
+import { Agent } from "../../src/agent/agent"
+import { Truncate } from "@/tool/truncate"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Plugin } from "../../src/plugin"
+import { testEffect } from "../lib/effect"
+import { Tool } from "@/tool/tool"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+
+const layer = Layer.mergeAll(
+  LayerNode.compile(
+    LayerNode.group([
+      CrossSpawnSpawner.node,
+      FSUtil.node,
+      Plugin.node,
+      Truncate.node,
+      Config.node,
+      Agent.node,
+      RuntimeFlags.node,
+      BackgroundJob.node,
+    ]),
+  ),
+  testInstanceStoreLayer,
+)
+const it = testEffect(layer)
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-background"),
+  messageID: MessageID.make("msg_test"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+const tools = Effect.fn("BackgroundToolTest.tools")(function* () {
+  const start = yield* (yield* BackgroundStartTool).init()
+  const output = yield* (yield* BackgroundOutputTool).init()
+  const kill = yield* (yield* BackgroundKillTool).init()
+  const list = yield* (yield* BackgroundListTool).init()
+  return { start, output, kill, list }
+})
+
+const runIn = <A, E, R>(directory: string, self: Effect.Effect<A, E, R>) => self.pipe(provideInstance(directory))
+
+const node = process.execPath.replaceAll("\\", "/")
+
+describe("tool.background", () => {
+  it.live("runs a command to completion and exposes its output", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* runIn(
+        dir,
+        Effect.gen(function* () {
+          const t = yield* tools()
+          const started = yield* t.start.execute({ command: `"${node}" -e "console.log('hello-bg')"` }, ctx)
+          const id = started.metadata.id as string
+          expect(started.output).toContain(id)
+
+          const done = yield* t.output.execute({ id, wait: 15000 }, ctx)
+          expect(done.output).toContain("hello-bg")
+          expect(done.output).toMatch(/status=(completed|error)/)
+        }),
+      )
+    }),
+  )
+
+  it.live("streams live output from a running process and kills it", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* runIn(
+        dir,
+        Effect.gen(function* () {
+          const t = yield* tools()
+          const started = yield* t.start.execute(
+            {
+              command: `"${node}" -e "console.log('boot-marker'); setInterval(() => {}, 1000)"`,
+              title: "fake server",
+            },
+            ctx,
+          )
+          const id = started.metadata.id as string
+
+          // Poll until the boot marker shows up in the live buffer.
+          const seen = yield* Effect.gen(function* () {
+            const result = yield* t.output.execute({ id }, ctx)
+            if (!result.output.includes("boot-marker")) return yield* Effect.fail(new Error("not yet"))
+            return result
+          }).pipe(Effect.retry({ times: 50, schedule: undefined }), Effect.orDie)
+          expect(seen.output).toContain("status=running")
+
+          const killed = yield* t.kill.execute({ id }, ctx)
+          expect(killed.output).toContain("cancelled")
+
+          const after = yield* t.output.execute({ id }, ctx)
+          expect(after.output).toContain("status=cancelled")
+        }),
+      )
+    }),
+  )
+
+  it.live("lists background processes and rejects unknown ids", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* runIn(
+        dir,
+        Effect.gen(function* () {
+          const t = yield* tools()
+          const empty = yield* t.list.execute({}, ctx)
+          expect(empty.output).toContain("No background processes")
+
+          const started = yield* t.start.execute({ command: `"${node}" -e "console.log('x')"` }, ctx)
+          const id = started.metadata.id as string
+          const listed = yield* t.list.execute({}, ctx)
+          expect(listed.output).toContain(id)
+
+          const exit = yield* t.output.execute({ id: "job_does_not_exist" }, ctx).pipe(Effect.exit)
+          if (!Exit.isFailure(exit)) throw new Error("expected unknown id to fail")
+          const err = Cause.squash(exit.cause)
+          expect(String(err)).toContain("No background process found")
+        }),
+      )
+    }),
+  )
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -117,6 +117,10 @@ describe("tool.registry", () => {
       expect(ids).toContain("memory_save")
       expect(ids).toContain("memory_recall")
       expect(ids).toContain("multiedit")
+      expect(ids).toContain("bash_background")
+      expect(ids).toContain("process_output")
+      expect(ids).toContain("kill_process")
+      expect(ids).toContain("list_processes")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #145

### Type of change

- [x] New feature

### What does this PR do?

Adds four tools so the agent can manage long-running processes instead of blocking on the bash timeout or losing orphans to `&`/`nohup`: `bash_background` (start, returns a process id immediately), `process_output` (poll accumulated output, optional `wait` ms to block until exit), `kill_process` (terminate the tree, graceful then force), and `list_processes`. This unlocks the start-dev-server -> verify -> kill loop and is the "Background process tools" roadmap item.

Everything rides on the existing `BackgroundJob` registry, which already gives us per-directory scoping and transitive cancellation when the session is cancelled or removed (jobs carry `sessionId`/`parentSessionId` metadata). The one gap in `BackgroundJob` is that it only exposes output after completion, so each job's run effect feeds a live ring buffer that `process_output` reads while the process is still running:

```ts
run: Effect.scoped(
  Effect.gen(function* () {
    const handle = yield* spawner.spawn(command(shell, params.command, cwd, env))
    yield* Effect.forkScoped(
      Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
        Effect.sync(() => append(id, chunk, keep)),
      ),
    )
    const code = yield* handle.exitCode.pipe(
      Effect.onInterrupt(() => handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.catch(() => Effect.void))),
    )
    // ...
  }),
),
```

Killing works through scope closure: `kill_process` -> `jobs.cancel` -> job scope closes -> the spawn handle's finalizer plus the `onInterrupt` force-kill terminate the process tree. `bash_background` asks under the same `bash` permission action as the foreground shell tool, so existing allow/deny rules apply; it skips the tree-sitter path scan since background commands run inside the project.

Based on the `multiedit` branch (stacks on #144); GitHub will retarget to `dev` once that merges.

### How did you verify your code works?

New `test/tool/background.test.ts` with real spawned Node processes: run-to-completion output, live polling of a running server plus kill (status transitions to cancelled), listing, and unknown-id rejection. Registry exposure assertions added. `bun run typecheck` and `bun test ./test/tool/background.test.ts ./test/tool/registry.test.ts` (19 pass) from `packages/opencode/`.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR