### PR TITLE
feat(opencode): add test_run tool with structured failure parsing

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -18,6 +18,7 @@ import { InvalidTool } from "./invalid"
 import { BackgroundKillTool, BackgroundListTool, BackgroundOutputTool, BackgroundStartTool } from "./background"
 import { MemoryRecallTool, MemorySaveTool } from "./memory"
 import { MultiEditTool } from "./multiedit"
+import { TestRunTool } from "./testrun"
 import { SkillTool } from "./skill"
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
@@ -119,6 +120,7 @@ const layer = Layer.effect(
     const bgoutput = yield* BackgroundOutputTool
     const bgkill = yield* BackgroundKillTool
     const bglist = yield* BackgroundListTool
+    const testrun = yield* TestRunTool
     const agent = yield* Agent.Service
     const codeMode = flags.experimentalCodeMode ? yield* Effect.promise(() => import("./code-mode")) : undefined
     const codeModeTool = codeMode ? yield* codeMode.CodeModeTool : undefined
@@ -232,6 +234,7 @@ const layer = Layer.effect(
           bgoutput: Tool.init(bgoutput),
           bgkill: Tool.init(bgkill),
           bglist: Tool.init(bglist),
+          testrun: Tool.init(testrun),
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
@@ -262,6 +265,7 @@ const layer = Layer.effect(
             tool.bgoutput,
             tool.bgkill,
             tool.bglist,
+            tool.testrun,
             ...(tool.execute ? [tool.execute] : []),
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),

--- a/packages/opencode/src/tool/testrun.ts
+++ b/packages/opencode/src/tool/testrun.ts
@@ -1,0 +1,236 @@
+import { Effect, Schema, Stream } from "effect"
+import path from "path"
+import * as Tool from "./tool"
+import { Config } from "@/config/config"
+import { InstanceState } from "@/effect/instance-state"
+import { Plugin } from "@/plugin"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Shell } from "@opencode-ai/core/shell"
+import { ShellID } from "./shell/id"
+import { BashArity } from "@/permission/arity"
+import * as Truncate from "./truncate"
+import { ChildProcess } from "effect/unstable/process"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import DESCRIPTION from "./testrun.txt"
+
+const DEFAULT_TIMEOUT = 10 * 60 * 1000
+
+export type Failure = {
+  name: string
+  file?: string
+  message?: string
+}
+
+type Matcher = {
+  pattern: RegExp
+  failure: (match: RegExpExecArray) => Failure
+}
+
+// One matcher per test-runner output dialect. Each yields the failing test's name and,
+// when the dialect carries it, the file and message.
+const matchers: Matcher[] = [
+  // pytest: FAILED tests/test_x.py::test_name - AssertionError: boom
+  {
+    pattern: /^FAILED (\S+?)::(\S+?)(?: - (.*))?$/gm,
+    failure: (m) => ({ name: m[2], file: m[1], ...(m[3] ? { message: m[3] } : {}) }),
+  },
+  // go: --- FAIL: TestName (0.00s)
+  { pattern: /^--- FAIL: (\S+)/gm, failure: (m) => ({ name: m[1] }) },
+  // cargo: test module::case ... FAILED
+  { pattern: /^test (\S+) \.\.\. FAILED$/gm, failure: (m) => ({ name: m[1] }) },
+  // bun test: (fail) suite > case
+  { pattern: /^\(fail\) (.+?)(?: \[[\d.]+m?s\])?$/gm, failure: (m) => ({ name: m[1] }) },
+  // jest/vitest/mocha glyphs: ✕ case, ✗ case, × case
+  { pattern: /^\s*[✕✗×] (.+?)(?: \(\d+ ?m?s\))?$/gm, failure: (m) => ({ name: m[1] }) },
+  // TAP: not ok 3 - case name
+  { pattern: /^not ok \d+ (?:- )?(.+)$/gm, failure: (m) => ({ name: m[1] }) },
+]
+
+const counters = [
+  // bun/vitest style: "3 pass" / "1 fail", pytest style: "1 failed, 3 passed"
+  /(?<fail>\d+) fail(?:ed)?(?:,| |$)/m,
+  /(?<pass>\d+) pass(?:ed)?(?:,| |$)/m,
+]
+
+/** Extract structured failures and pass/fail counts from raw test-runner output. */
+export function parse(text: string) {
+  const seen = new Set<string>()
+  const failures: Failure[] = []
+  for (const matcher of matchers) {
+    matcher.pattern.lastIndex = 0
+    for (const match of text.matchAll(matcher.pattern)) {
+      const failure = matcher.failure(match as unknown as RegExpExecArray)
+      const key = `${failure.file ?? ""}::${failure.name}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      failures.push(failure)
+    }
+  }
+  const counts: { pass?: number; fail?: number } = {}
+  for (const counter of counters) {
+    const match = text.match(counter)
+    if (!match?.groups) continue
+    if (match.groups.fail !== undefined) counts.fail = Number(match.groups.fail)
+    if (match.groups.pass !== undefined) counts.pass = Number(match.groups.pass)
+  }
+  return { failures, counts }
+}
+
+/** Detect the project's test command from lockfiles and manifests. */
+export const detect = Effect.fn("TestRunTool.detect")(function* (fs: FSUtil.Interface, dir: string) {
+  const manifest = path.join(dir, "package.json")
+  if (yield* fs.existsSafe(manifest)) {
+    const pkg = yield* Effect.tryPromise(() => Bun.file(manifest).json()).pipe(
+      Effect.catch(() => Effect.succeed(undefined)),
+    )
+    if (pkg?.scripts?.test) {
+      if (yield* fs.existsSafe(path.join(dir, "bun.lock"))) return "bun run test"
+      if (yield* fs.existsSafe(path.join(dir, "bun.lockb"))) return "bun run test"
+      if (yield* fs.existsSafe(path.join(dir, "pnpm-lock.yaml"))) return "pnpm test"
+      if (yield* fs.existsSafe(path.join(dir, "yarn.lock"))) return "yarn test"
+      return "npm test"
+    }
+  }
+  if (yield* fs.existsSafe(path.join(dir, "Cargo.toml"))) return "cargo test"
+  if (yield* fs.existsSafe(path.join(dir, "go.mod"))) return "go test ./..."
+  if (yield* fs.existsSafe(path.join(dir, "pytest.ini"))) return "pytest"
+  if (yield* fs.existsSafe(path.join(dir, "pyproject.toml"))) return "pytest"
+  return undefined
+})
+
+export const Parameters = Schema.Struct({
+  command: Schema.optional(Schema.String).annotate({
+    description:
+      "Test command to run. When omitted, the project's test command is detected from package.json, Cargo.toml, go.mod, or pytest config.",
+  }),
+  workdir: Schema.optional(Schema.String).annotate({
+    description: "Working directory to run tests in. Defaults to the project directory.",
+  }),
+  timeout: Schema.optional(Schema.Number).annotate({
+    description: "Optional timeout in milliseconds (default 600000)",
+  }),
+})
+
+export const TestRunTool = Tool.define(
+  "test_run",
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner
+    const config = yield* Config.Service
+    const plugin = yield* Plugin.Service
+    const fs = yield* FSUtil.Service
+    const trunc = yield* Truncate.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const instance = yield* InstanceState.context
+          const cwd = params.workdir ? path.resolve(instance.directory, params.workdir) : instance.directory
+          const command = params.command ?? (yield* detect(fs, cwd))
+          if (!command) {
+            throw new Error(
+              "Could not detect a test command for this project. Pass the command parameter explicitly.",
+            )
+          }
+
+          const tokens = command.trim().split(/\s+/)
+          yield* ctx.ask({
+            permission: ShellID.ToolID,
+            patterns: [command],
+            always: [BashArity.prefix(tokens).join(" ") + " *"],
+            metadata: { command, test: true },
+          })
+
+          const cfg = yield* config.get()
+          const shell = Shell.acceptable(cfg.shell)
+          const extra = yield* plugin.trigger(
+            "shell.env",
+            { cwd, sessionID: ctx.sessionID, callID: ctx.callID },
+            { env: {} },
+          )
+          const env = { ...process.env, ...extra.env }
+          const timeout = params.timeout ?? DEFAULT_TIMEOUT
+          const limits = yield* trunc.limits()
+
+          let raw = ""
+          let expired = false
+          const code = yield* Effect.scoped(
+            Effect.gen(function* () {
+              const handle = yield* spawner.spawn(
+                process.platform === "win32" && Shell.ps(shell)
+                  ? ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+                      cwd,
+                      env,
+                      stdin: "ignore",
+                      detached: false,
+                    })
+                  : ChildProcess.make(command, [], {
+                      shell,
+                      cwd,
+                      env,
+                      stdin: "ignore",
+                      detached: process.platform !== "win32",
+                    }),
+              )
+              yield* Effect.forkScoped(
+                Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
+                  Effect.sync(() => {
+                    raw += chunk
+                    // Cap memory while keeping the tail, where summaries and failures live.
+                    const keep = limits.maxBytes * 4
+                    if (raw.length > keep) raw = raw.slice(raw.length - keep)
+                  }),
+                ),
+              )
+              const exit = yield* Effect.raceAll([
+                handle.exitCode.pipe(Effect.map((code) => ({ kind: "exit" as const, code }))),
+                Effect.sleep(`${timeout} millis`).pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
+              ])
+              if (exit.kind === "timeout") {
+                expired = true
+                yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.catch(() => Effect.void))
+              }
+              return exit.code
+            }),
+          ).pipe(Effect.orDie)
+
+          const result = parse(raw)
+          const passed = code === 0 && !expired
+          const lines: string[] = []
+          lines.push(`status=${expired ? "timeout" : passed ? "pass" : "fail"}`)
+          lines.push(`command=${command}`)
+          if (code !== null) lines.push(`exit=${code}`)
+          if (result.counts.pass !== undefined || result.counts.fail !== undefined) {
+            lines.push(`passed=${result.counts.pass ?? "?"} failed=${result.counts.fail ?? "?"}`)
+          }
+          if (!passed && result.failures.length > 0) {
+            lines.push("", "Failures:")
+            for (const failure of result.failures.slice(0, 50)) {
+              const loc = failure.file ? ` (${failure.file})` : ""
+              const msg = failure.message ? `: ${failure.message}` : ""
+              lines.push(`- ${failure.name}${loc}${msg}`)
+            }
+            if (result.failures.length > 50) lines.push(`...and ${result.failures.length - 50} more`)
+          }
+          if (!passed) {
+            const tail = raw.length > limits.maxBytes ? raw.slice(raw.length - limits.maxBytes) : raw
+            lines.push("", "Output tail:", tail.trimEnd() || "(no output)")
+          }
+
+          return {
+            title: `${command} [${expired ? "timeout" : passed ? "pass" : "fail"}]`,
+            output: lines.join("\n"),
+            metadata: {
+              command,
+              exit: code,
+              passed,
+              failureCount: result.failures.length,
+              ...(result.counts.pass !== undefined ? { passCount: result.counts.pass } : {}),
+              ...(result.counts.fail !== undefined ? { failCount: result.counts.fail } : {}),
+            },
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/testrun.txt
+++ b/packages/opencode/src/tool/testrun.txt
@@ -1,0 +1,9 @@
+Runs the project's tests and returns structured results: pass/fail status, counts, and a list of failing tests with file and message where available.
+
+Prefer this over running test commands with the bash tool: it detects the right test command, parses failures out of the noise, and keeps the output compact.
+
+Usage:
+- With no parameters, the project's test command is detected (package.json test script with the right package manager, cargo test, go test ./..., or pytest).
+- Pass `command` to run a specific test command instead, e.g. a single test file: `bun test ./test/foo.test.ts`.
+- Supported failure formats: pytest, go test, cargo test, bun test, jest/vitest/mocha, and TAP. Unrecognized output still returns status, exit code, and the output tail.
+- On failure the raw output tail is included after the structured list; use it when a failure needs more context.

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -121,6 +121,7 @@ describe("tool.registry", () => {
       expect(ids).toContain("process_output")
       expect(ids).toContain("kill_process")
       expect(ids).toContain("list_processes")
+      expect(ids).toContain("test_run")
     }),
   )
 

--- a/packages/opencode/test/tool/testrun.test.ts
+++ b/packages/opencode/test/tool/testrun.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect, Layer } from "effect"
+import { TestRunTool, parse } from "../../src/tool/testrun"
+import { Config } from "@/config/config"
+import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
+import { Agent } from "../../src/agent/agent"
+import { Truncate } from "@/tool/truncate"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Plugin } from "../../src/plugin"
+import { testEffect } from "../lib/effect"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+
+describe("testrun.parse", () => {
+  test("parses pytest failures with file and message", () => {
+    const out = [
+      "collected 3 items",
+      "FAILED tests/test_auth.py::test_login - AssertionError: expected 200",
+      "FAILED tests/test_auth.py::test_logout",
+      "1 failed, 2 passed in 0.5s",
+    ].join("\n")
+    const result = parse(out)
+    expect(result.failures).toEqual([
+      { name: "test_login", file: "tests/test_auth.py", message: "AssertionError: expected 200" },
+      { name: "test_logout", file: "tests/test_auth.py" },
+    ])
+    expect(result.counts).toEqual({ fail: 1, pass: 2 })
+  })
+
+  test("parses go test failures", () => {
+    const out = ["--- FAIL: TestDispatch (0.03s)", "    dispatch_test.go:42: budget exceeded", "FAIL"].join("\n")
+    expect(parse(out).failures).toEqual([{ name: "TestDispatch" }])
+  })
+
+  test("parses cargo test failures", () => {
+    const out = ["test retry::tests::exhausts_budget ... FAILED", "test result: FAILED. 1 passed; 1 failed"].join("\n")
+    expect(parse(out).failures).toEqual([{ name: "retry::tests::exhausts_budget" }])
+  })
+
+  test("parses bun test failures and counts", () => {
+    const out = ["(pass) tool.edit > replaces text [1.2ms]", "(fail) tool.edit > preserves BOM", "1 pass", "1 fail"].join(
+      "\n",
+    )
+    const result = parse(out)
+    expect(result.failures).toEqual([{ name: "tool.edit > preserves BOM" }])
+    expect(result.counts).toEqual({ pass: 1, fail: 1 })
+  })
+
+  test("parses jest/vitest glyph failures and TAP", () => {
+    const out = ["  ✕ renders the header (12 ms)", "not ok 2 - handles empty input"].join("\n")
+    const names = parse(out).failures.map((failure) => failure.name)
+    expect(names).toContain("renders the header")
+    expect(names).toContain("handles empty input")
+  })
+
+  test("deduplicates repeated failures", () => {
+    const out = ["--- FAIL: TestX", "--- FAIL: TestX"].join("\n")
+    expect(parse(out).failures).toHaveLength(1)
+  })
+
+  test("returns empty for passing output", () => {
+    const result = parse("all 12 tests passed\n12 pass\n0 fail")
+    expect(result.failures).toEqual([])
+    expect(result.counts.fail).toBe(0)
+  })
+})
+
+const layer = Layer.mergeAll(
+  LayerNode.compile(
+    LayerNode.group([
+      CrossSpawnSpawner.node,
+      FSUtil.node,
+      Plugin.node,
+      Truncate.node,
+      Config.node,
+      Agent.node,
+      RuntimeFlags.node,
+    ]),
+  ),
+  testInstanceStoreLayer,
+)
+const it = testEffect(layer)
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-testrun"),
+  messageID: MessageID.make("msg_test"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+const node = process.execPath.replaceAll("\\", "/")
+
+describe("tool.testrun", () => {
+  it.live("reports structured failures from a failing command", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.gen(function* () {
+        const info = yield* TestRunTool
+        const tool = yield* info.init()
+        const script = "console.log('--- FAIL: TestBroken'); console.log('1 fail'); process.exit(1)"
+        const result = yield* tool.execute({ command: `"${node}" -e "${script}"` }, ctx)
+        expect(result.output).toContain("status=fail")
+        expect(result.output).toContain("- TestBroken")
+        expect(result.metadata.passed).toBe(false)
+        expect(result.metadata.failureCount).toBe(1)
+      }).pipe(provideInstance(dir))
+    }),
+  )
+
+  it.live("reports pass for a succeeding command", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.gen(function* () {
+        const info = yield* TestRunTool
+        const tool = yield* info.init()
+        const result = yield* tool.execute({ command: `"${node}" -e "console.log('5 pass')"` }, ctx)
+        expect(result.output).toContain("status=pass")
+        expect(result.metadata.passed).toBe(true)
+      }).pipe(provideInstance(dir))
+    }),
+  )
+
+  it.live("errors when no test command can be detected", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.gen(function* () {
+        const info = yield* TestRunTool
+        const tool = yield* info.init()
+        const exit = yield* tool.execute({}, ctx).pipe(Effect.exit)
+        expect(exit._tag).toBe("Failure")
+      }).pipe(provideInstance(dir))
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #147

### Type of change

- [x] New feature

### What does this PR do?

Adds a `test_run` tool (the `test_run` roadmap item): runs the project's tests and hands the agent structured results instead of a wall of raw output. With no parameters it detects the test command (package.json `test` script routed through the right package manager via lockfile, `cargo test`, `go test ./...`, or `pytest`); an explicit `command` overrides detection for single-file runs.

Failures are extracted by a set of per-dialect matchers covering pytest, go test, cargo test, bun test, jest/vitest/mocha glyphs, and TAP:

```ts
const matchers: Matcher[] = [
  // pytest: FAILED tests/test_x.py::test_name - AssertionError: boom
  {
    pattern: /^FAILED (\S+?)::(\S+?)(?: - (.*))?$/gm,
    failure: (m) => ({ name: m[2], file: m[1], ...(m[3] ? { message: m[3] } : {}) }),
  },
  // go: --- FAIL: TestName (0.00s)
  { pattern: /^--- FAIL: (\S+)/gm, failure: (m) => ({ name: m[1] }) },
  // ...cargo, bun, jest/vitest glyphs, TAP
]
```

The tool returns `status=pass|fail|timeout`, exit code, pass/fail counts when the runner prints them, a deduplicated failure list (name, file, message), and the raw output tail only on failure. Unrecognized runners still get status + exit + tail, so it degrades safely. Permission uses the same `bash` action as the shell tool, so existing allow/deny rules apply. Memory is bounded by keeping only the output tail (summaries and failures print last in every supported runner).

Stacked on the `background` branch (#146); GitHub will retarget as the stack merges.

### How did you verify your code works?

`parse` is exported and unit-tested against real output shapes from all six dialects (file/message extraction, counts, dedup, passing output). Integration tests execute real Node processes through the tool: failing command produces `status=fail` + structured failure + `failureCount`, passing command produces `status=pass`, and detection failure errors cleanly. `bun run typecheck` and `bun test ./test/tool/testrun.test.ts ./test/tool/registry.test.ts` (26 pass) from `packages/opencode/`.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR