### PR TITLE
fix(tui): restore spinner and open-state dimming in reasoning header

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1785,10 +1785,15 @@ function ReasoningHeader(props: {
   duration?: string
 }) {
   const { theme } = useTheme()
-  
-  // Create a gradient from accent to primary, matching the theme
-  const gradient = (column: number, length: number) => 
-    tint(theme.accent, theme.primary, length <= 1 ? 1 : column / (length - 1))
+
+  // Create a gradient from accent to primary, matching the theme.
+  // When the reasoning block is expanded, dim the header via thinkingOpacity
+  // so the open state reads differently from the collapsed one.
+  const gradient = (column: number, length: number) => {
+    const color = tint(theme.accent, theme.primary, length <= 1 ? 1 : column / (length - 1))
+    if (props.open) return RGBA.fromValues(color.r, color.g, color.b, theme.thinkingOpacity)
+    return color
+  }
 
   const thinkingText = props.title ? "Thinking: " + props.title : "Thinking"
   
@@ -1804,11 +1809,11 @@ function ReasoningHeader(props: {
     <Switch>
       <Match when={!props.done}>
         <box flexDirection="row">
-          <text>
+          <Spinner color={theme.accent}>
             {Array.from(thinkingText).map((char, column) => (
               <span style={{ fg: gradient(column, thinkingText.length) }}>{char}</span>
             ))}
-          </text>
+          </Spinner>
         </box>
       </Match>
       <Match when={true}>


### PR DESCRIPTION
### Issue for this PR

Closes #152

### Type of change

- [x] Bug fix

### What does this PR do?

Commit 7addbfe added the theme-matched gradient to the reasoning header but removed the animated `Spinner` from the in-progress state (long thinking phases looked frozen) and dropped the `thinkingOpacity` dimming that distinguished the expanded header from the collapsed one. This restores both while keeping the gradient. The in-progress state wraps the gradient spans back in `Spinner` (per-char `fg` on the spans overrides the parent text color, so the gradient survives), and the gradient dims when the block is open:

```tsx
const gradient = (column: number, length: number) => {
  const color = tint(theme.accent, theme.primary, length <= 1 ? 1 : column / (length - 1))
  if (props.open) return RGBA.fromValues(color.r, color.g, color.b, theme.thinkingOpacity)
  return color
}
```

The spinner glyph is colored `theme.accent`, matching the gradient's start, and the `animations_enabled` fallback path in `Spinner` still renders the gradient text.

### How did you verify your code works?

`bun run typecheck` in `packages/tui` passes. Visual behavior follows the existing `Spinner` component contract (children render inside its text node) and the pre-7addbfe dimming semantics.

### Screenshots / recordings

_TUI change; the reasoning header shows an animated spinner while thinking and a dimmed gradient when expanded._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the in-progress thinking indicator with a spinner.
  * Adjusted the label’s gradient appearance when expanded for clearer visual feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->