### PR TITLE
fix(opencode): restore background and test_run tools lost in upstream merge

### DIFF
--- a/packages/opencode/src/tool/background-kill.txt
+++ b/packages/opencode/src/tool/background-kill.txt
@@ -1,0 +1,7 @@
+Terminates a background process started with bash_background.
+
+Usage:
+- Pass the process id returned by bash_background.
+- The whole process tree is terminated (graceful kill first, force kill after a short grace period).
+- Safe to call on processes that already finished; reports their final status.
+- Always kill dev servers and watchers you started once you no longer need them.

--- a/packages/opencode/src/tool/background-list.txt
+++ b/packages/opencode/src/tool/background-list.txt
@@ -1,0 +1,6 @@
+Lists all background processes started with bash_background, with their id, status, and command.
+
+Usage:
+- Takes no parameters.
+- Use it to find a process id you lost, or to check for stray processes before starting new ones.
+- Statuses: running, completed, error, cancelled.

--- a/packages/opencode/src/tool/background-output.txt
+++ b/packages/opencode/src/tool/background-output.txt
@@ -1,0 +1,7 @@
+Reads the accumulated output (combined stdout and stderr) and status of a background process started with bash_background.
+
+Usage:
+- Pass the process id returned by bash_background.
+- Returns the output collected so far for running processes, or the final output for finished ones.
+- Pass `wait` (milliseconds) to block until the process finishes or the wait elapses, whichever comes first. Use this to wait for a server to boot instead of polling in a loop.
+- Old output is dropped once the buffer limit is exceeded; only the most recent output is kept.

--- a/packages/opencode/src/tool/background.ts
+++ b/packages/opencode/src/tool/background.ts
@@ -1,0 +1,257 @@
+import { Effect, Schema, Stream } from "effect"
+import path from "path"
+import * as Tool from "./tool"
+import { BackgroundJob } from "@/background/job"
+import { InstanceState } from "@/effect/instance-state"
+import { Config } from "@/config/config"
+import { Plugin } from "@/plugin"
+import { Identifier } from "@opencode-ai/core/id/id"
+import { Shell } from "@opencode-ai/core/shell"
+import { ShellID } from "./shell/id"
+import { BashArity } from "@/permission/arity"
+import * as Truncate from "./truncate"
+import { ChildProcess } from "effect/unstable/process"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import START_DESCRIPTION from "./background.txt"
+import OUTPUT_DESCRIPTION from "./background-output.txt"
+import KILL_DESCRIPTION from "./background-kill.txt"
+import LIST_DESCRIPTION from "./background-list.txt"
+
+const TYPE = "shell"
+
+/** Live output per running job. BackgroundJob only exposes output after completion, so the
+ * stream consumer inside each job's run effect appends here and process_output reads it. */
+const live = new Map<string, { text: string; cut: boolean }>()
+
+function append(id: string, chunk: string, keep: number) {
+  const entry = live.get(id) ?? { text: "", cut: false }
+  entry.text += chunk
+  if (entry.text.length > keep) {
+    entry.text = entry.text.slice(entry.text.length - keep)
+    entry.cut = true
+  }
+  live.set(id, entry)
+}
+
+function command(shell: string, text: string, cwd: string, env: NodeJS.ProcessEnv) {
+  if (process.platform === "win32" && Shell.ps(shell)) {
+    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", text], {
+      cwd,
+      env,
+      stdin: "ignore",
+      detached: false,
+    })
+  }
+  return ChildProcess.make(text, [], {
+    shell,
+    cwd,
+    env,
+    stdin: "ignore",
+    detached: process.platform !== "win32",
+  })
+}
+
+function render(info: BackgroundJob.Info) {
+  const meta = info.metadata ?? {}
+  const cmd = typeof meta.command === "string" ? meta.command : (info.title ?? "")
+  return `${info.id} [${info.status}] ${cmd}`
+}
+
+export const StartParameters = Schema.Struct({
+  command: Schema.String.annotate({ description: "The shell command to run in the background" }),
+  workdir: Schema.optional(Schema.String).annotate({
+    description: "Working directory for the command. Defaults to the project directory.",
+  }),
+  title: Schema.optional(Schema.String).annotate({
+    description: "Short human-readable label for the process (e.g. 'dev server')",
+  }),
+})
+
+export const BackgroundStartTool = Tool.define(
+  "bash_background",
+  Effect.gen(function* () {
+    const jobs = yield* BackgroundJob.Service
+    const spawner = yield* ChildProcessSpawner
+    const config = yield* Config.Service
+    const plugin = yield* Plugin.Service
+    const trunc = yield* Truncate.Service
+
+    return {
+      description: START_DESCRIPTION,
+      parameters: StartParameters,
+      execute: (params: Schema.Schema.Type<typeof StartParameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          if (!params.command.trim()) throw new Error("command is required")
+          const instance = yield* InstanceState.context
+          const cwd = params.workdir ? path.resolve(instance.directory, params.workdir) : instance.directory
+
+          // Same permission action as the foreground shell tool so existing bash
+          // allow/deny rules apply to background commands too.
+          const tokens = params.command.trim().split(/\s+/)
+          yield* ctx.ask({
+            permission: ShellID.ToolID,
+            patterns: [params.command],
+            always: [BashArity.prefix(tokens).join(" ") + " *"],
+            metadata: {
+              command: params.command,
+              background: true,
+            },
+          })
+
+          const cfg = yield* config.get()
+          const shell = Shell.acceptable(cfg.shell)
+          const extra = yield* plugin.trigger(
+            "shell.env",
+            { cwd, sessionID: ctx.sessionID, callID: ctx.callID },
+            { env: {} },
+          )
+          const env = { ...process.env, ...extra.env }
+          const limits = yield* trunc.limits()
+          const keep = limits.maxBytes * 2
+
+          // Generate the id up front so the run effect can key its live output buffer.
+          const id = Identifier.ascending("job")
+          const info = yield* jobs.start({
+            id,
+            type: TYPE,
+            title: params.title ?? params.command,
+            metadata: {
+              sessionId: ctx.sessionID,
+              parentSessionId: ctx.sessionID,
+              background: true,
+              command: params.command,
+              cwd,
+            },
+            run: Effect.scoped(
+              Effect.gen(function* () {
+                const handle = yield* spawner.spawn(command(shell, params.command, cwd, env))
+                yield* Effect.forkScoped(
+                  Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
+                    Effect.sync(() => append(id, chunk, keep)),
+                  ),
+                )
+                const code = yield* handle.exitCode.pipe(
+                  Effect.onInterrupt(() =>
+                    handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.catch(() => Effect.void)),
+                  ),
+                )
+                const entry = live.get(id)
+                live.delete(id)
+                const text = entry?.text ?? ""
+                return `exit=${code}\n${text}`
+              }),
+            ),
+          })
+
+          return {
+            title: params.title ?? params.command,
+            output: [
+              `Started background process ${info.id}: ${params.command}`,
+              `Use process_output with id=${info.id} to read its output, and kill_process to stop it.`,
+            ].join("\n"),
+            metadata: { id: info.id, status: info.status },
+          }
+        }),
+    }
+  }),
+)
+
+export const OutputParameters = Schema.Struct({
+  id: Schema.String.annotate({ description: "The background process id returned by bash_background" }),
+  wait: Schema.optional(Schema.Number).annotate({
+    description: "Optional milliseconds to wait for the process to finish before returning",
+  }),
+})
+
+export const BackgroundOutputTool = Tool.define(
+  "process_output",
+  Effect.gen(function* () {
+    const jobs = yield* BackgroundJob.Service
+    const trunc = yield* Truncate.Service
+
+    return {
+      description: OUTPUT_DESCRIPTION,
+      parameters: OutputParameters,
+      execute: (params: Schema.Schema.Type<typeof OutputParameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          if (params.wait !== undefined && params.wait > 0) {
+            yield* jobs.wait({ id: params.id, timeout: params.wait })
+          }
+          const info = yield* jobs.get(params.id)
+          if (!info || info.type !== TYPE) {
+            throw new Error(`No background process found with id ${params.id}. Use list_processes to see known ids.`)
+          }
+          const entry = live.get(params.id)
+          const text = info.status === "running" ? (entry?.text ?? "") : (info.output ?? info.error ?? "")
+          const limits = yield* trunc.limits()
+          const cut = (entry?.cut ?? false) || text.length > limits.maxBytes
+          const body = text.length > limits.maxBytes ? text.slice(text.length - limits.maxBytes) : text
+          return {
+            title: `${params.id} [${info.status}]`,
+            output: [`status=${info.status}`, body || "(no output yet)"].join("\n"),
+            metadata: { id: info.id, status: info.status, truncated: cut },
+          }
+        }),
+    }
+  }),
+)
+
+export const KillParameters = Schema.Struct({
+  id: Schema.String.annotate({ description: "The background process id to terminate" }),
+})
+
+export const BackgroundKillTool = Tool.define(
+  "kill_process",
+  Effect.gen(function* () {
+    const jobs = yield* BackgroundJob.Service
+
+    return {
+      description: KILL_DESCRIPTION,
+      parameters: KillParameters,
+      execute: (params: Schema.Schema.Type<typeof KillParameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const found = yield* jobs.get(params.id)
+          if (!found || found.type !== TYPE) {
+            throw new Error(`No background process found with id ${params.id}. Use list_processes to see known ids.`)
+          }
+          const info = (yield* jobs.cancel(params.id)) ?? found
+          live.delete(params.id)
+          return {
+            title: `${params.id} [${info.status}]`,
+            output: `Process ${params.id} is now ${info.status}.`,
+            metadata: { id: info.id, status: info.status },
+          }
+        }),
+    }
+  }),
+)
+
+export const ListParameters = Schema.Struct({})
+
+export const BackgroundListTool = Tool.define(
+  "list_processes",
+  Effect.gen(function* () {
+    const jobs = yield* BackgroundJob.Service
+
+    return {
+      description: LIST_DESCRIPTION,
+      parameters: ListParameters,
+      execute: (_params: Schema.Schema.Type<typeof ListParameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const list = (yield* jobs.list()).filter((info) => info.type === TYPE)
+          if (list.length === 0) {
+            return {
+              title: "No background processes",
+              output: "No background processes have been started in this session.",
+              metadata: { count: 0 },
+            }
+          }
+          return {
+            title: `${list.length} background process${list.length === 1 ? "" : "es"}`,
+            output: list.map(render).join("\n"),
+            metadata: { count: list.length },
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/background.txt
+++ b/packages/opencode/src/tool/background.txt
@@ -1,0 +1,9 @@
+Starts a shell command as a background process and returns immediately with a process id.
+
+Use this for long-running commands that should keep running while you continue working: dev servers, watchers, tails, long builds. Do NOT use shell-level backgrounding (`&`, `nohup`, `setsid`) with the bash tool; output is lost and the process cannot be managed.
+
+Usage:
+- Returns a process id. Use `process_output` with that id to read accumulated output, `kill_process` to stop it, and `list_processes` to see all background processes.
+- The process is killed automatically when the session ends.
+- Same permission rules as the bash tool apply.
+- For quick commands that finish on their own, use the bash tool instead.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -18,6 +18,7 @@ import { InvalidTool } from "./invalid"
 import { BackgroundKillTool, BackgroundListTool, BackgroundOutputTool, BackgroundStartTool } from "./background"
 import { MemoryRecallTool, MemorySaveTool } from "./memory"
 import { MultiEditTool } from "./multiedit"
+import { TestRunTool } from "./testrun"
 import { SkillTool } from "./skill"
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
@@ -119,6 +120,7 @@ const layer = Layer.effect(
     const bgoutput = yield* BackgroundOutputTool
     const bgkill = yield* BackgroundKillTool
     const bglist = yield* BackgroundListTool
+    const testrun = yield* TestRunTool
     const agent = yield* Agent.Service
     const codeMode = flags.experimentalCodeMode ? yield* Effect.promise(() => import("./code-mode")) : undefined
     const codeModeTool = codeMode ? yield* codeMode.CodeModeTool : undefined
@@ -232,6 +234,7 @@ const layer = Layer.effect(
           bgoutput: Tool.init(bgoutput),
           bgkill: Tool.init(bgkill),
           bglist: Tool.init(bglist),
+          testrun: Tool.init(testrun),
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
@@ -262,6 +265,7 @@ const layer = Layer.effect(
             tool.bgoutput,
             tool.bgkill,
             tool.bglist,
+            tool.testrun,
             ...(tool.execute ? [tool.execute] : []),
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -15,6 +15,7 @@ import { TodoWriteTool } from "./todo"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
+import { BackgroundKillTool, BackgroundListTool, BackgroundOutputTool, BackgroundStartTool } from "./background"
 import { MemoryRecallTool, MemorySaveTool } from "./memory"
 import { MultiEditTool } from "./multiedit"
 import { SkillTool } from "./skill"
@@ -114,6 +115,10 @@ const layer = Layer.effect(
     const memsave = yield* MemorySaveTool
     const memrecall = yield* MemoryRecallTool
     const multiedit = yield* MultiEditTool
+    const bgstart = yield* BackgroundStartTool
+    const bgoutput = yield* BackgroundOutputTool
+    const bgkill = yield* BackgroundKillTool
+    const bglist = yield* BackgroundListTool
     const agent = yield* Agent.Service
     const codeMode = flags.experimentalCodeMode ? yield* Effect.promise(() => import("./code-mode")) : undefined
     const codeModeTool = codeMode ? yield* codeMode.CodeModeTool : undefined
@@ -223,6 +228,10 @@ const layer = Layer.effect(
           patch: Tool.init(patchtool),
           memsave: Tool.init(memsave),
           memrecall: Tool.init(memrecall),
+          bgstart: Tool.init(bgstart),
+          bgoutput: Tool.init(bgoutput),
+          bgkill: Tool.init(bgkill),
+          bglist: Tool.init(bglist),
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
@@ -249,6 +258,10 @@ const layer = Layer.effect(
             tool.patch,
             tool.memsave,
             tool.memrecall,
+            tool.bgstart,
+            tool.bgoutput,
+            tool.bgkill,
+            tool.bglist,
             ...(tool.execute ? [tool.execute] : []),
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),

--- a/packages/opencode/src/tool/testrun.ts
+++ b/packages/opencode/src/tool/testrun.ts
@@ -1,0 +1,236 @@
+import { Effect, Schema, Stream } from "effect"
+import path from "path"
+import * as Tool from "./tool"
+import { Config } from "@/config/config"
+import { InstanceState } from "@/effect/instance-state"
+import { Plugin } from "@/plugin"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Shell } from "@opencode-ai/core/shell"
+import { ShellID } from "./shell/id"
+import { BashArity } from "@/permission/arity"
+import * as Truncate from "./truncate"
+import { ChildProcess } from "effect/unstable/process"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import DESCRIPTION from "./testrun.txt"
+
+const DEFAULT_TIMEOUT = 10 * 60 * 1000
+
+export type Failure = {
+  name: string
+  file?: string
+  message?: string
+}
+
+type Matcher = {
+  pattern: RegExp
+  failure: (match: RegExpExecArray) => Failure
+}
+
+// One matcher per test-runner output dialect. Each yields the failing test's name and,
+// when the dialect carries it, the file and message.
+const matchers: Matcher[] = [
+  // pytest: FAILED tests/test_x.py::test_name - AssertionError: boom
+  {
+    pattern: /^FAILED (\S+?)::(\S+?)(?: - (.*))?$/gm,
+    failure: (m) => ({ name: m[2], file: m[1], ...(m[3] ? { message: m[3] } : {}) }),
+  },
+  // go: --- FAIL: TestName (0.00s)
+  { pattern: /^--- FAIL: (\S+)/gm, failure: (m) => ({ name: m[1] }) },
+  // cargo: test module::case ... FAILED
+  { pattern: /^test (\S+) \.\.\. FAILED$/gm, failure: (m) => ({ name: m[1] }) },
+  // bun test: (fail) suite > case
+  { pattern: /^\(fail\) (.+?)(?: \[[\d.]+m?s\])?$/gm, failure: (m) => ({ name: m[1] }) },
+  // jest/vitest/mocha glyphs: ✕ case, ✗ case, × case
+  { pattern: /^\s*[✕✗×] (.+?)(?: \(\d+ ?m?s\))?$/gm, failure: (m) => ({ name: m[1] }) },
+  // TAP: not ok 3 - case name
+  { pattern: /^not ok \d+ (?:- )?(.+)$/gm, failure: (m) => ({ name: m[1] }) },
+]
+
+const counters = [
+  // bun/vitest style: "3 pass" / "1 fail", pytest style: "1 failed, 3 passed"
+  /(?<fail>\d+) fail(?:ed)?(?:,| |$)/m,
+  /(?<pass>\d+) pass(?:ed)?(?:,| |$)/m,
+]
+
+/** Extract structured failures and pass/fail counts from raw test-runner output. */
+export function parse(text: string) {
+  const seen = new Set<string>()
+  const failures: Failure[] = []
+  for (const matcher of matchers) {
+    matcher.pattern.lastIndex = 0
+    for (const match of text.matchAll(matcher.pattern)) {
+      const failure = matcher.failure(match as unknown as RegExpExecArray)
+      const key = `${failure.file ?? ""}::${failure.name}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      failures.push(failure)
+    }
+  }
+  const counts: { pass?: number; fail?: number } = {}
+  for (const counter of counters) {
+    const match = text.match(counter)
+    if (!match?.groups) continue
+    if (match.groups.fail !== undefined) counts.fail = Number(match.groups.fail)
+    if (match.groups.pass !== undefined) counts.pass = Number(match.groups.pass)
+  }
+  return { failures, counts }
+}
+
+/** Detect the project's test command from lockfiles and manifests. */
+export const detect = Effect.fn("TestRunTool.detect")(function* (fs: FSUtil.Interface, dir: string) {
+  const manifest = path.join(dir, "package.json")
+  if (yield* fs.existsSafe(manifest)) {
+    const pkg = yield* Effect.tryPromise(() => Bun.file(manifest).json()).pipe(
+      Effect.catch(() => Effect.succeed(undefined)),
+    )
+    if (pkg?.scripts?.test) {
+      if (yield* fs.existsSafe(path.join(dir, "bun.lock"))) return "bun run test"
+      if (yield* fs.existsSafe(path.join(dir, "bun.lockb"))) return "bun run test"
+      if (yield* fs.existsSafe(path.join(dir, "pnpm-lock.yaml"))) return "pnpm test"
+      if (yield* fs.existsSafe(path.join(dir, "yarn.lock"))) return "yarn test"
+      return "npm test"
+    }
+  }
+  if (yield* fs.existsSafe(path.join(dir, "Cargo.toml"))) return "cargo test"
+  if (yield* fs.existsSafe(path.join(dir, "go.mod"))) return "go test ./..."
+  if (yield* fs.existsSafe(path.join(dir, "pytest.ini"))) return "pytest"
+  if (yield* fs.existsSafe(path.join(dir, "pyproject.toml"))) return "pytest"
+  return undefined
+})
+
+export const Parameters = Schema.Struct({
+  command: Schema.optional(Schema.String).annotate({
+    description:
+      "Test command to run. When omitted, the project's test command is detected from package.json, Cargo.toml, go.mod, or pytest config.",
+  }),
+  workdir: Schema.optional(Schema.String).annotate({
+    description: "Working directory to run tests in. Defaults to the project directory.",
+  }),
+  timeout: Schema.optional(Schema.Number).annotate({
+    description: "Optional timeout in milliseconds (default 600000)",
+  }),
+})
+
+export const TestRunTool = Tool.define(
+  "test_run",
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner
+    const config = yield* Config.Service
+    const plugin = yield* Plugin.Service
+    const fs = yield* FSUtil.Service
+    const trunc = yield* Truncate.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const instance = yield* InstanceState.context
+          const cwd = params.workdir ? path.resolve(instance.directory, params.workdir) : instance.directory
+          const command = params.command ?? (yield* detect(fs, cwd))
+          if (!command) {
+            throw new Error(
+              "Could not detect a test command for this project. Pass the command parameter explicitly.",
+            )
+          }
+
+          const tokens = command.trim().split(/\s+/)
+          yield* ctx.ask({
+            permission: ShellID.ToolID,
+            patterns: [command],
+            always: [BashArity.prefix(tokens).join(" ") + " *"],
+            metadata: { command, test: true },
+          })
+
+          const cfg = yield* config.get()
+          const shell = Shell.acceptable(cfg.shell)
+          const extra = yield* plugin.trigger(
+            "shell.env",
+            { cwd, sessionID: ctx.sessionID, callID: ctx.callID },
+            { env: {} },
+          )
+          const env = { ...process.env, ...extra.env }
+          const timeout = params.timeout ?? DEFAULT_TIMEOUT
+          const limits = yield* trunc.limits()
+
+          let raw = ""
+          let expired = false
+          const code = yield* Effect.scoped(
+            Effect.gen(function* () {
+              const handle = yield* spawner.spawn(
+                process.platform === "win32" && Shell.ps(shell)
+                  ? ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+                      cwd,
+                      env,
+                      stdin: "ignore",
+                      detached: false,
+                    })
+                  : ChildProcess.make(command, [], {
+                      shell,
+                      cwd,
+                      env,
+                      stdin: "ignore",
+                      detached: process.platform !== "win32",
+                    }),
+              )
+              yield* Effect.forkScoped(
+                Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
+                  Effect.sync(() => {
+                    raw += chunk
+                    // Cap memory while keeping the tail, where summaries and failures live.
+                    const keep = limits.maxBytes * 4
+                    if (raw.length > keep) raw = raw.slice(raw.length - keep)
+                  }),
+                ),
+              )
+              const exit = yield* Effect.raceAll([
+                handle.exitCode.pipe(Effect.map((code) => ({ kind: "exit" as const, code }))),
+                Effect.sleep(`${timeout} millis`).pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
+              ])
+              if (exit.kind === "timeout") {
+                expired = true
+                yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.catch(() => Effect.void))
+              }
+              return exit.code
+            }),
+          ).pipe(Effect.orDie)
+
+          const result = parse(raw)
+          const passed = code === 0 && !expired
+          const lines: string[] = []
+          lines.push(`status=${expired ? "timeout" : passed ? "pass" : "fail"}`)
+          lines.push(`command=${command}`)
+          if (code !== null) lines.push(`exit=${code}`)
+          if (result.counts.pass !== undefined || result.counts.fail !== undefined) {
+            lines.push(`passed=${result.counts.pass ?? "?"} failed=${result.counts.fail ?? "?"}`)
+          }
+          if (!passed && result.failures.length > 0) {
+            lines.push("", "Failures:")
+            for (const failure of result.failures.slice(0, 50)) {
+              const loc = failure.file ? ` (${failure.file})` : ""
+              const msg = failure.message ? `: ${failure.message}` : ""
+              lines.push(`- ${failure.name}${loc}${msg}`)
+            }
+            if (result.failures.length > 50) lines.push(`...and ${result.failures.length - 50} more`)
+          }
+          if (!passed) {
+            const tail = raw.length > limits.maxBytes ? raw.slice(raw.length - limits.maxBytes) : raw
+            lines.push("", "Output tail:", tail.trimEnd() || "(no output)")
+          }
+
+          return {
+            title: `${command} [${expired ? "timeout" : passed ? "pass" : "fail"}]`,
+            output: lines.join("\n"),
+            metadata: {
+              command,
+              exit: code,
+              passed,
+              failureCount: result.failures.length,
+              ...(result.counts.pass !== undefined ? { passCount: result.counts.pass } : {}),
+              ...(result.counts.fail !== undefined ? { failCount: result.counts.fail } : {}),
+            },
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/testrun.txt
+++ b/packages/opencode/src/tool/testrun.txt
@@ -1,0 +1,9 @@
+Runs the project's tests and returns structured results: pass/fail status, counts, and a list of failing tests with file and message where available.
+
+Prefer this over running test commands with the bash tool: it detects the right test command, parses failures out of the noise, and keeps the output compact.
+
+Usage:
+- With no parameters, the project's test command is detected (package.json test script with the right package manager, cargo test, go test ./..., or pytest).
+- Pass `command` to run a specific test command instead, e.g. a single test file: `bun test ./test/foo.test.ts`.
+- Supported failure formats: pytest, go test, cargo test, bun test, jest/vitest/mocha, and TAP. Unrecognized output still returns status, exit code, and the output tail.
+- On failure the raw output tail is included after the structured list; use it when a failure needs more context.

--- a/packages/opencode/test/tool/background.test.ts
+++ b/packages/opencode/test/tool/background.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Cause, Effect, Exit, Layer } from "effect"
+import { BackgroundJob } from "@/background/job"
+import {
+  BackgroundKillTool,
+  BackgroundListTool,
+  BackgroundOutputTool,
+  BackgroundStartTool,
+} from "../../src/tool/background"
+import { Config } from "@/config/config"
+import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
+import { Agent } from "../../src/agent/agent"
+import { Truncate } from "@/tool/truncate"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Plugin } from "../../src/plugin"
+import { testEffect } from "../lib/effect"
+import { Tool } from "@/tool/tool"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+
+const layer = Layer.mergeAll(
+  LayerNode.compile(
+    LayerNode.group([
+      CrossSpawnSpawner.node,
+      FSUtil.node,
+      Plugin.node,
+      Truncate.node,
+      Config.node,
+      Agent.node,
+      RuntimeFlags.node,
+      BackgroundJob.node,
+    ]),
+  ),
+  testInstanceStoreLayer,
+)
+const it = testEffect(layer)
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-background"),
+  messageID: MessageID.make("msg_test"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+const tools = Effect.fn("BackgroundToolTest.tools")(function* () {
+  const start = yield* (yield* BackgroundStartTool).init()
+  const output = yield* (yield* BackgroundOutputTool).init()
+  const kill = yield* (yield* BackgroundKillTool).init()
+  const list = yield* (yield* BackgroundListTool).init()
+  return { start, output, kill, list }
+})
+
+const runIn = <A, E, R>(directory: string, self: Effect.Effect<A, E, R>) => self.pipe(provideInstance(directory))
+
+const node = process.execPath.replaceAll("\\", "/")
+
+describe("tool.background", () => {
+  it.live("runs a command to completion and exposes its output", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* runIn(
+        dir,
+        Effect.gen(function* () {
+          const t = yield* tools()
+          const started = yield* t.start.execute({ command: `"${node}" -e "console.log('hello-bg')"` }, ctx)
+          const id = started.metadata.id as string
+          expect(started.output).toContain(id)
+
+          const done = yield* t.output.execute({ id, wait: 15000 }, ctx)
+          expect(done.output).toContain("hello-bg")
+          expect(done.output).toMatch(/status=(completed|error)/)
+        }),
+      )
+    }),
+  )
+
+  it.live("streams live output from a running process and kills it", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* runIn(
+        dir,
+        Effect.gen(function* () {
+          const t = yield* tools()
+          const started = yield* t.start.execute(
+            {
+              command: `"${node}" -e "console.log('boot-marker'); setInterval(() => {}, 1000)"`,
+              title: "fake server",
+            },
+            ctx,
+          )
+          const id = started.metadata.id as string
+
+          // Poll until the boot marker shows up in the live buffer.
+          const seen = yield* Effect.gen(function* () {
+            const result = yield* t.output.execute({ id }, ctx)
+            if (!result.output.includes("boot-marker")) return yield* Effect.fail(new Error("not yet"))
+            return result
+          }).pipe(Effect.retry({ times: 50, schedule: undefined }), Effect.orDie)
+          expect(seen.output).toContain("status=running")
+
+          const killed = yield* t.kill.execute({ id }, ctx)
+          expect(killed.output).toContain("cancelled")
+
+          const after = yield* t.output.execute({ id }, ctx)
+          expect(after.output).toContain("status=cancelled")
+        }),
+      )
+    }),
+  )
+
+  it.live("lists background processes and rejects unknown ids", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* runIn(
+        dir,
+        Effect.gen(function* () {
+          const t = yield* tools()
+          const empty = yield* t.list.execute({}, ctx)
+          expect(empty.output).toContain("No background processes")
+
+          const started = yield* t.start.execute({ command: `"${node}" -e "console.log('x')"` }, ctx)
+          const id = started.metadata.id as string
+          const listed = yield* t.list.execute({}, ctx)
+          expect(listed.output).toContain(id)
+
+          const exit = yield* t.output.execute({ id: "job_does_not_exist" }, ctx).pipe(Effect.exit)
+          if (!Exit.isFailure(exit)) throw new Error("expected unknown id to fail")
+          const err = Cause.squash(exit.cause)
+          expect(String(err)).toContain("No background process found")
+        }),
+      )
+    }),
+  )
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -117,6 +117,10 @@ describe("tool.registry", () => {
       expect(ids).toContain("memory_save")
       expect(ids).toContain("memory_recall")
       expect(ids).toContain("multiedit")
+      expect(ids).toContain("bash_background")
+      expect(ids).toContain("process_output")
+      expect(ids).toContain("kill_process")
+      expect(ids).toContain("list_processes")
     }),
   )
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -121,6 +121,7 @@ describe("tool.registry", () => {
       expect(ids).toContain("process_output")
       expect(ids).toContain("kill_process")
       expect(ids).toContain("list_processes")
+      expect(ids).toContain("test_run")
     }),
   )
 

--- a/packages/opencode/test/tool/testrun.test.ts
+++ b/packages/opencode/test/tool/testrun.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect, Layer } from "effect"
+import { TestRunTool, parse } from "../../src/tool/testrun"
+import { Config } from "@/config/config"
+import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
+import { Agent } from "../../src/agent/agent"
+import { Truncate } from "@/tool/truncate"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Plugin } from "../../src/plugin"
+import { testEffect } from "../lib/effect"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+
+describe("testrun.parse", () => {
+  test("parses pytest failures with file and message", () => {
+    const out = [
+      "collected 3 items",
+      "FAILED tests/test_auth.py::test_login - AssertionError: expected 200",
+      "FAILED tests/test_auth.py::test_logout",
+      "1 failed, 2 passed in 0.5s",
+    ].join("\n")
+    const result = parse(out)
+    expect(result.failures).toEqual([
+      { name: "test_login", file: "tests/test_auth.py", message: "AssertionError: expected 200" },
+      { name: "test_logout", file: "tests/test_auth.py" },
+    ])
+    expect(result.counts).toEqual({ fail: 1, pass: 2 })
+  })
+
+  test("parses go test failures", () => {
+    const out = ["--- FAIL: TestDispatch (0.03s)", "    dispatch_test.go:42: budget exceeded", "FAIL"].join("\n")
+    expect(parse(out).failures).toEqual([{ name: "TestDispatch" }])
+  })
+
+  test("parses cargo test failures", () => {
+    const out = ["test retry::tests::exhausts_budget ... FAILED", "test result: FAILED. 1 passed; 1 failed"].join("\n")
+    expect(parse(out).failures).toEqual([{ name: "retry::tests::exhausts_budget" }])
+  })
+
+  test("parses bun test failures and counts", () => {
+    const out = ["(pass) tool.edit > replaces text [1.2ms]", "(fail) tool.edit > preserves BOM", "1 pass", "1 fail"].join(
+      "\n",
+    )
+    const result = parse(out)
+    expect(result.failures).toEqual([{ name: "tool.edit > preserves BOM" }])
+    expect(result.counts).toEqual({ pass: 1, fail: 1 })
+  })
+
+  test("parses jest/vitest glyph failures and TAP", () => {
+    const out = ["  ✕ renders the header (12 ms)", "not ok 2 - handles empty input"].join("\n")
+    const names = parse(out).failures.map((failure) => failure.name)
+    expect(names).toContain("renders the header")
+    expect(names).toContain("handles empty input")
+  })
+
+  test("deduplicates repeated failures", () => {
+    const out = ["--- FAIL: TestX", "--- FAIL: TestX"].join("\n")
+    expect(parse(out).failures).toHaveLength(1)
+  })
+
+  test("returns empty for passing output", () => {
+    const result = parse("all 12 tests passed\n12 pass\n0 fail")
+    expect(result.failures).toEqual([])
+    expect(result.counts.fail).toBe(0)
+  })
+})
+
+const layer = Layer.mergeAll(
+  LayerNode.compile(
+    LayerNode.group([
+      CrossSpawnSpawner.node,
+      FSUtil.node,
+      Plugin.node,
+      Truncate.node,
+      Config.node,
+      Agent.node,
+      RuntimeFlags.node,
+    ]),
+  ),
+  testInstanceStoreLayer,
+)
+const it = testEffect(layer)
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-testrun"),
+  messageID: MessageID.make("msg_test"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+const node = process.execPath.replaceAll("\\", "/")
+
+describe("tool.testrun", () => {
+  it.live("reports structured failures from a failing command", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.gen(function* () {
+        const info = yield* TestRunTool
+        const tool = yield* info.init()
+        const script = "console.log('--- FAIL: TestBroken'); console.log('1 fail'); process.exit(1)"
+        const result = yield* tool.execute({ command: `"${node}" -e "${script}"` }, ctx)
+        expect(result.output).toContain("status=fail")
+        expect(result.output).toContain("- TestBroken")
+        expect(result.metadata.passed).toBe(false)
+        expect(result.metadata.failureCount).toBe(1)
+      }).pipe(provideInstance(dir))
+    }),
+  )
+
+  it.live("reports pass for a succeeding command", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.gen(function* () {
+        const info = yield* TestRunTool
+        const tool = yield* info.init()
+        const result = yield* tool.execute({ command: `"${node}" -e "console.log('5 pass')"` }, ctx)
+        expect(result.output).toContain("status=pass")
+        expect(result.metadata.passed).toBe(true)
+      }).pipe(provideInstance(dir))
+    }),
+  )
+
+  it.live("errors when no test command can be detected", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.gen(function* () {
+        const info = yield* TestRunTool
+        const tool = yield* info.init()
+        const exit = yield* tool.execute({}, ctx).pipe(Effect.exit)
+        expect(exit._tag).toBe("Failure")
+      }).pipe(provideInstance(dir))
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #154

### Type of change

- [x] Bug fix

### What does this PR do?

The upstream merge (28049ac via #150/#151) silently dropped two previously merged features: the background process tools from #146 and the `test_run` tool from #148. Their tool modules, prompt .txt files, tests, and registry registrations all vanished from `dev`, while the memory and multiedit tools and the `BackgroundJob` engine survived. This restores both by cherry-picking the original commits (64ab5e3 and 0f0c85a) cleanly onto current `dev`; the registry once again registers all four background tools plus `test_run`:

```ts
import { BackgroundKillTool, BackgroundListTool, BackgroundOutputTool, BackgroundStartTool } from "./background"
import { TestRunTool } from "./testrun"
// ...
testrun: Tool.init(testrun),
```

No changes beyond the two cherry-picks.

### How did you verify your code works?

`bun run typecheck` passes in `packages/opencode`; `bun test ./test/tool/background.test.ts ./test/tool/testrun.test.ts` passes 13/13 (real processes, no mocks).

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background process tools to start, monitor, retrieve output from, and stop long-running shell commands.
  * Added a test-running tool that detects supported project test commands and reports structured results, failures, output, and timeouts.
* **Documentation**
  * Added usage guidance for background process management and test execution tools.
* **Tests**
  * Added coverage for process lifecycle handling, output retrieval, tool discovery, test detection, and result parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->