### PR TITLE
feat(cli): add bolt arena command

### DIFF
--- a/packages/opencode/src/cli/cmd/arena.ts
+++ b/packages/opencode/src/cli/cmd/arena.ts
@@ -52,7 +52,7 @@ export const ArenaCommand = effectCmd({
     const { ServerAuth } = yield* Effect.promise(() => import("@/server/auth"))
     const { parseModels, runArena } = yield* Effect.promise(() => import("./run/arena"))
     yield* Effect.promise(async () => {
-      const die = (message: string): never => {
+      function die(message: string): never {
         UI.error(message)
         process.exit(1)
       }
@@ -64,7 +64,7 @@ export const ArenaCommand = effectCmd({
       if (message.trim().length === 0) die("You must provide a message")
 
       const models = parseModels(args.models)
-      if (typeof models === "string") return die(models)
+      if (typeof models === "string") die(models)
 
       const judge = (() => {
         if (!args.judge) return models[0]

--- a/packages/opencode/src/cli/cmd/arena.ts
+++ b/packages/opencode/src/cli/cmd/arena.ts
@@ -1,0 +1,110 @@
+// CLI entry point for `bolt arena`: run the same task on several agents in
+// parallel, each isolated in its own git worktree, then have a judge model
+// rank the results. The winning worktree (and branch) is kept for review;
+// --cleanup deletes the losers. Orchestration lives in ./run/arena.
+import type { Argv } from "yargs"
+import type { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { Effect } from "effect"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
+import { UI } from "../ui"
+import { effectCmd } from "../effect-cmd"
+
+export const ArenaCommand = effectCmd({
+  command: "arena [message..]",
+  describe: "race agents on the same task in isolated worktrees and keep the best result",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("message", {
+        describe: "task to send to every contender",
+        type: "string",
+        array: true,
+        default: [],
+      })
+      .option("models", {
+        type: "string",
+        demandOption: true,
+        describe: "comma-separated provider/model list (duplicates allowed, one worktree each)",
+      })
+      .option("judge", {
+        type: "string",
+        describe: "judge model as provider/model (defaults to the first entry in --models)",
+      })
+      .option("agent", {
+        type: "string",
+        describe: "agent to use for every contender",
+      })
+      .option("variant", {
+        type: "string",
+        describe: "model variant (provider-specific reasoning effort, e.g., high, max, minimal)",
+      })
+      .option("format", {
+        type: "string",
+        choices: ["default", "json"],
+        default: "default",
+        describe: "format: default (formatted) or json (single JSON result)",
+      })
+      .option("cleanup", {
+        type: "boolean",
+        default: false,
+        describe: "remove losing worktrees and their branches after judging",
+      }),
+  handler: Effect.fn("Cli.arena")(function* (args) {
+    const { ServerAuth } = yield* Effect.promise(() => import("@/server/auth"))
+    const { parseModels, runArena } = yield* Effect.promise(() => import("./run/arena"))
+    yield* Effect.promise(async () => {
+      const die = (message: string): never => {
+        UI.error(message)
+        process.exit(1)
+      }
+
+      const piped = process.stdin.isTTY ? undefined : await Bun.stdin.text()
+      const message = [[...args.message, ...(args["--"] || [])].join(" "), piped?.trim() ?? ""]
+        .filter(Boolean)
+        .join("\n")
+      if (message.trim().length === 0) die("You must provide a message")
+
+      const models = parseModels(args.models)
+      if (typeof models === "string") return die(models)
+
+      const judge = (() => {
+        if (!args.judge) return models[0]
+        const slash = args.judge.indexOf("/")
+        if (slash <= 0 || slash === args.judge.length - 1) return die("--judge must be in provider/model format")
+        const [providerID, ...rest] = args.judge.split("/")
+        return { providerID, modelID: rest.join("/") } as (typeof models)[number]
+      })()
+
+      const rules: PermissionV1.Ruleset = [
+        { permission: "question", action: "deny", pattern: "*" },
+        { permission: "plan_enter", action: "deny", pattern: "*" },
+        { permission: "plan_exit", action: "deny", pattern: "*" },
+      ]
+
+      const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const { Server } = await import("@/server/server")
+        const request = new Request(input, init)
+        const headers = new Headers(request.headers)
+        const auth = ServerAuth.header()
+        if (auth) headers.set("Authorization", auth)
+        return Server.Default().app.fetch(new Request(request, { headers }))
+      }) as typeof globalThis.fetch
+      const client = (directory: string) =>
+        createOpencodeClient({ baseUrl: "http://opencode.internal", fetch: fetchFn, directory })
+
+      const exit = await runArena({
+        sdk: client(process.cwd()),
+        client,
+        models,
+        judge,
+        message,
+        parts: [{ type: "text", text: message }],
+        agent: args.agent,
+        variant: args.variant,
+        permission: [...rules],
+        json: args.format === "json",
+        cleanup: args.cleanup,
+      })
+      if (exit) process.exitCode = exit
+    })
+  }),
+})

--- a/packages/opencode/src/cli/cmd/run/arena.ts
+++ b/packages/opencode/src/cli/cmd/run/arena.ts
@@ -1,0 +1,275 @@
+import { EOL } from "os"
+import type { OpencodeClient } from "@opencode-ai/sdk/v2"
+import { GlobalBus, type GlobalEvent } from "@/bus/global"
+import { UI } from "../../ui"
+import { LABELS, LIMIT, format, judgePrompt, parseVerdict, type Model, type Parts } from "./best-of"
+
+// Arena runs: fire the same task at several agents in parallel, each in its
+// own isolated git worktree, then have a judge model rank the anonymized
+// outputs (final answer + code diff). The winner's worktree survives; with
+// --cleanup the losers' worktrees and branches are deleted. The winner's text
+// goes to stdout; the scoreboard and progress notes go to stderr.
+
+type Prompt = Parameters<OpencodeClient["session"]["prompt"]>[0]
+type Create = NonNullable<Parameters<OpencodeClient["session"]["create"]>[0]>
+type Worktree = NonNullable<Awaited<ReturnType<OpencodeClient["worktree"]["create"]>>["data"]>
+
+export interface Contender {
+  label: string
+  model: Model
+  worktree?: Worktree
+  sessionID?: string
+  text?: string
+  diff?: string
+  error?: string
+}
+
+// Parses the comma-separated provider/model list for arena. Unlike --best-of,
+// duplicates are allowed: racing the same model against itself in separate
+// worktrees is a legitimate arena setup.
+export function parseModels(value: string): Model[] | string {
+  const entries = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+  if (entries.length < 2) return "--models needs at least two comma-separated provider/model entries"
+  if (entries.length > LIMIT) return `--models supports at most ${LIMIT} entries`
+  const invalid = entries.find((item) => {
+    const slash = item.indexOf("/")
+    return slash <= 0 || slash === item.length - 1
+  })
+  if (invalid) return `--models entries must be in provider/model format, got: ${invalid}`
+  return entries.map((item) => {
+    const [providerID, ...rest] = item.split("/")
+    return { providerID, modelID: rest.join("/") } as Model
+  })
+}
+
+const READY_TIMEOUT = 5 * 60 * 1000
+const DIFF_LIMIT = 20_000
+
+// Watches GlobalBus for worktree boot results, keyed by worktree directory.
+// The listener attaches before any worktree is created so a fast boot cannot
+// slip past it; results are buffered until someone waits for them.
+function watcher() {
+  const results = new Map<string, string | undefined>()
+  const waiters = new Map<string, (error?: string) => void>()
+  const handler = (event: GlobalEvent) => {
+    const dir = event.directory
+    if (!dir) return
+    const type = event.payload?.type
+    if (type !== "worktree.ready" && type !== "worktree.failed") return
+    const error =
+      type === "worktree.failed" ? String(event.payload?.properties?.message ?? "worktree boot failed") : undefined
+    const waiter = waiters.get(dir)
+    if (waiter) {
+      waiters.delete(dir)
+      waiter(error)
+      return
+    }
+    results.set(dir, error)
+  }
+  GlobalBus.on("event", handler)
+  return {
+    wait(directory: string) {
+      return new Promise<void>((resolve, reject) => {
+        const settle = (error?: string) => (error === undefined ? resolve() : reject(new Error(error)))
+        if (results.has(directory)) {
+          const error = results.get(directory)
+          results.delete(directory)
+          settle(error)
+          return
+        }
+        const timer = setTimeout(() => {
+          waiters.delete(directory)
+          reject(new Error(`worktree boot timed out after ${READY_TIMEOUT / 1000}s`))
+        }, READY_TIMEOUT)
+        waiters.set(directory, (error) => {
+          clearTimeout(timer)
+          settle(error)
+        })
+      })
+    },
+    dispose() {
+      GlobalBus.off("event", handler)
+    },
+  }
+}
+
+// Captures what the agent actually changed in its worktree. `add -N` records
+// intent-to-add so new files show up in the diff; the worktree is disposable
+// so mutating its index is fine.
+async function capture(directory: string) {
+  await Bun.spawn(["git", "add", "-N", "."], { cwd: directory, stdout: "ignore", stderr: "ignore" }).exited
+  const proc = Bun.spawn(["git", "diff"], { cwd: directory, stdout: "pipe", stderr: "ignore" })
+  const text = await new Response(proc.stdout).text()
+  await proc.exited
+  if (text.length <= DIFF_LIMIT) return text
+  return text.slice(0, DIFF_LIMIT) + `\n... (diff truncated at ${DIFF_LIMIT} characters)`
+}
+
+export async function runArena(input: {
+  sdk: OpencodeClient
+  client: (directory: string) => OpencodeClient
+  models: Model[]
+  judge: Model
+  message: string
+  parts: Parts
+  agent?: string
+  variant?: string
+  permission: Create["permission"]
+  json: boolean
+  cleanup: boolean
+}): Promise<number> {
+  const note = (text: string) => {
+    if (!input.json) UI.println(UI.Style.TEXT_DIM + text + UI.Style.TEXT_NORMAL)
+  }
+
+  const answer = (result: Awaited<ReturnType<OpencodeClient["session"]["prompt"]>>) =>
+    (result.data?.parts ?? []).flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n\n")
+
+  const events = watcher()
+
+  const attempt = async (model: Model, label: string): Promise<Contender> => {
+    const created = await input.sdk.worktree.create({
+      worktreeCreateInput: { name: `arena-${label.toLowerCase()}` },
+    })
+    const worktree = created.data
+    if (!worktree)
+      return { label, model, error: created.error ? JSON.stringify(created.error) : "failed to create worktree" }
+    await events.wait(worktree.directory)
+    note(`${label} · ${format(model)} worktree ready at ${worktree.directory}`)
+
+    const sdk = input.client(worktree.directory)
+    const session = await sdk.session.create({
+      title: `arena ${label}: ${format(model)}`,
+      permission: input.permission,
+    })
+    const id = session.data?.id
+    if (!id) return { label, model, worktree, error: "failed to create session" }
+    const result = await sdk.session.prompt({
+      sessionID: id,
+      model,
+      agent: input.agent,
+      variant: input.variant,
+      parts: input.parts,
+    })
+    if (result.error) return { label, model, worktree, sessionID: id, error: JSON.stringify(result.error) }
+    const diff = await capture(worktree.directory).catch(() => "")
+    note(`${label} · ${format(model)} finished`)
+    return { label, model, worktree, sessionID: id, text: answer(result), diff }
+  }
+
+  note(`arena: racing ${input.models.length} agents in isolated worktrees, judged by ${format(input.judge)}`)
+  const settled = await Promise.all(
+    input.models.map((model, i) =>
+      attempt(model, LABELS[i]).catch((err): Contender => ({ label: LABELS[i], model, error: String(err) })),
+    ),
+  ).finally(() => events.dispose())
+  const done = settled.filter((item): item is Contender & { text: string } => item.text !== undefined)
+
+  const summary = (item: Contender) => ({
+    label: item.label,
+    model: format(item.model),
+    sessionID: item.sessionID,
+    worktree: item.worktree ? { directory: item.worktree.directory, branch: item.worktree.branch } : undefined,
+    error: item.error,
+  })
+
+  if (done.length === 0) {
+    if (input.json) {
+      process.stdout.write(
+        JSON.stringify({ type: "arena", timestamp: Date.now(), candidates: settled.map(summary) }) + EOL,
+      )
+      return 1
+    }
+    settled.forEach((item) => UI.error(`${item.label} · ${format(item.model)}: ${item.error}`))
+    return 1
+  }
+
+  // The judge sees the final answer plus the code diff so it can rank on what
+  // was actually built, not just what was claimed.
+  const exhibit = (item: Contender & { text: string }) => {
+    const diff = item.diff?.trim()
+    if (!diff) return { label: item.label, text: item.text }
+    return { label: item.label, text: `${item.text}\n\n#### Diff\n\n\`\`\`diff\n${diff}\n\`\`\`` }
+  }
+
+  const verdict = await (async () => {
+    if (done.length === 1) return { order: [done[0].label], sessionID: undefined }
+    const session = await input.sdk.session.create({
+      title: `arena judge: ${format(input.judge)}`,
+      permission: input.permission,
+    })
+    const id = session.data?.id
+    if (!id) return undefined
+    const result = await input.sdk.session.prompt({
+      sessionID: id,
+      model: input.judge,
+      variant: input.variant,
+      parts: [{ type: "text", text: judgePrompt(input.message, done.map(exhibit)) }],
+    })
+    if (result.error) return undefined
+    const order = parseVerdict(
+      answer(result),
+      done.map((item) => item.label),
+    )
+    if (!order) return undefined
+    return { order, sessionID: id }
+  })().catch(() => undefined)
+
+  if (!verdict) note("judge produced no usable verdict; keeping the first successful candidate in submission order")
+  const order = verdict?.order ?? done.map((item) => item.label)
+  const ranked = new Map(settled.map((item) => [item.label, item]))
+  const winner = ranked.get(order[0])!
+
+  if (input.cleanup) {
+    const losers = settled.filter((item) => item.label !== winner.label && item.worktree)
+    await Promise.all(
+      losers.map((item) =>
+        input.sdk.worktree
+          .remove({ worktreeRemoveInput: { directory: item.worktree!.directory } })
+          .catch(() => undefined),
+      ),
+    )
+    if (losers.length) note(`cleaned up ${losers.length} losing worktree${losers.length === 1 ? "" : "s"}`)
+  }
+
+  if (input.json) {
+    process.stdout.write(
+      JSON.stringify({
+        type: "arena",
+        timestamp: Date.now(),
+        winner: { ...summary(winner), text: winner.text },
+        ranking: order,
+        judge: { model: format(input.judge), sessionID: verdict?.sessionID },
+        candidates: settled.map(summary),
+      }) + EOL,
+    )
+    return 0
+  }
+
+  UI.empty()
+  order.forEach((label, i) => {
+    const item = ranked.get(label)!
+    const marker = i === 0 ? UI.Style.TEXT_SUCCESS + "★" : UI.Style.TEXT_DIM + `${i + 1}.`
+    UI.println(
+      `${marker} ${label} · ${format(item.model)} ${UI.Style.TEXT_DIM}${item.sessionID}${UI.Style.TEXT_NORMAL}`,
+    )
+    if (item.worktree) {
+      UI.println(
+        `  ${UI.Style.TEXT_DIM}${item.worktree.directory}${item.worktree.branch ? ` (${item.worktree.branch})` : ""}${UI.Style.TEXT_NORMAL}`,
+      )
+    }
+  })
+  settled
+    .filter((item) => item.error !== undefined)
+    .forEach((item) =>
+      UI.println(
+        `${UI.Style.TEXT_DANGER_BOLD}✗${UI.Style.TEXT_NORMAL} ${item.label} · ${format(item.model)} ${UI.Style.TEXT_DIM}${item.error}${UI.Style.TEXT_NORMAL}`,
+      ),
+    )
+  UI.empty()
+  process.stdout.write((winner.text ?? "") + EOL)
+  return 0
+}

--- a/packages/opencode/src/cli/cmd/run/arena.ts
+++ b/packages/opencode/src/cli/cmd/run/arena.ts
@@ -105,7 +105,7 @@ async function capture(directory: string) {
   const text = await new Response(proc.stdout).text()
   await proc.exited
   if (text.length <= DIFF_LIMIT) return text
-  return text.slice(0, DIFF_LIMIT) + `\n... (diff truncated at ${DIFF_LIMIT} characters)`
+  return `${text.slice(0, DIFF_LIMIT)}\n... (diff truncated at ${DIFF_LIMIT} characters)`
 }
 
 export async function runArena(input: {
@@ -137,7 +137,11 @@ export async function runArena(input: {
     const worktree = created.data
     if (!worktree)
       return { label, model, error: created.error ? JSON.stringify(created.error) : "failed to create worktree" }
-    await events.wait(worktree.directory)
+    const boot = await events
+      .wait(worktree.directory)
+      .then(() => undefined)
+      .catch((err) => String(err))
+    if (boot) return { label, model, worktree, error: boot }
     note(`${label} · ${format(model)} worktree ready at ${worktree.directory}`)
 
     const sdk = input.client(worktree.directory)
@@ -203,10 +207,11 @@ export async function runArena(input: {
     })
     const id = session.data?.id
     if (!id) return undefined
+    // --variant is contender-specific (provider reasoning effort); the judge
+    // may be a different provider that rejects it, so prompt the judge plain.
     const result = await input.sdk.session.prompt({
       sessionID: id,
       model: input.judge,
-      variant: input.variant,
       parts: [{ type: "text", text: judgePrompt(input.message, done.map(exhibit)) }],
     })
     if (result.error) return undefined
@@ -221,18 +226,25 @@ export async function runArena(input: {
   if (!verdict) note("judge produced no usable verdict; keeping the first successful candidate in submission order")
   const order = verdict?.order ?? done.map((item) => item.label)
   const ranked = new Map(settled.map((item) => [item.label, item]))
-  const winner = ranked.get(order[0])!
+  const winner = ranked.get(order[0]) ?? done[0]
 
   if (input.cleanup) {
-    const losers = settled.filter((item) => item.label !== winner.label && item.worktree)
-    await Promise.all(
+    const losers = settled.filter(
+      (item): item is Contender & { worktree: Worktree } => item.label !== winner.label && item.worktree !== undefined,
+    )
+    const removed = await Promise.all(
       losers.map((item) =>
         input.sdk.worktree
-          .remove({ worktreeRemoveInput: { directory: item.worktree!.directory } })
-          .catch(() => undefined),
+          .remove({ worktreeRemoveInput: { directory: item.worktree.directory } })
+          .then((result) => !result.error)
+          .catch(() => false),
       ),
     )
-    if (losers.length) note(`cleaned up ${losers.length} losing worktree${losers.length === 1 ? "" : "s"}`)
+    const count = removed.filter(Boolean).length
+    if (count) note(`cleaned up ${count} losing worktree${count === 1 ? "" : "s"}`)
+    losers
+      .filter((_, i) => !removed[i])
+      .forEach((item) => note(`could not remove worktree ${item.worktree.directory}`))
   }
 
   if (input.json) {
@@ -251,8 +263,9 @@ export async function runArena(input: {
 
   UI.empty()
   order.forEach((label, i) => {
-    const item = ranked.get(label)!
-    const marker = i === 0 ? UI.Style.TEXT_SUCCESS + "★" : UI.Style.TEXT_DIM + `${i + 1}.`
+    const item = ranked.get(label)
+    if (!item) return
+    const marker = i === 0 ? `${UI.Style.TEXT_SUCCESS}★` : `${UI.Style.TEXT_DIM}${i + 1}.`
     UI.println(
       `${marker} ${label} · ${format(item.model)} ${UI.Style.TEXT_DIM}${item.sessionID}${UI.Style.TEXT_NORMAL}`,
     )

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,6 +1,7 @@
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"
+import { ArenaCommand } from "./cli/cmd/arena"
 import { GenerateCommand } from "./cli/cmd/generate"
 import { ConsoleCommand } from "./cli/cmd/account"
 import { ProvidersCommand } from "./cli/cmd/providers"
@@ -87,6 +88,7 @@ const cli = yargs(args)
   .command(TuiThreadCommand)
   .command(AttachCommand)
   .command(RunCommand)
+  .command(ArenaCommand)
   .command(GenerateCommand)
   .command(DebugCommand)
   .command(ConsoleCommand)

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -86,8 +86,12 @@ Options:
   -s, --session      session id to continue                                                 [string]
       --fork         fork the session before continuing (requires --continue or --session) [boolean]
       --share        share the session                                                     [boolean]
-  -m, --model        model to use in the format of provider/model                           [string]
-      --agent        agent to use                                                           [string]
+  -m, --model        model to use in the format of provider/model (or 'auto' for cheapest available)
+                                                                                            [string]
+      --best-of      comma-separated provider/model list: run the same task on every model in
+                     parallel, rank the results with a judge (--model, or the first entry), keep the
+                     winner                                                                 [string]
+      --agent        agent to use (or 'auto' for automatic selection)                       [string]
       --format       format: default (formatted) or json (raw JSON events)
                                           [string] [choices: "default", "json"] [default: "default"]
   -f, --file         file(s) to attach to message                                            [array]
@@ -104,6 +108,32 @@ Options:
       --thinking     show thinking blocks                                                  [boolean]
   -i, --interactive  run in direct interactive split-footer mode          [boolean] [default: false]
       --auto         auto-approve permissions that are not explicitly denied (dangerous!)
+                                                                          [boolean] [default: false]"
+`;
+
+exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode arena --help 1`] = `
+"bolt arena [message..]
+
+race agents on the same task in isolated worktrees and keep the best result
+
+Positionals:
+  message  task to send to every contender                                     [array] [default: []]
+
+Options:
+  -h, --help        show help                                                              [boolean]
+  -v, --version     show version number                                                    [boolean]
+      --print-logs  print logs to stderr                                                   [boolean]
+      --log-level   log level                   [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
+      --pure        run without external plugins                                           [boolean]
+      --models      comma-separated provider/model list (duplicates allowed, one worktree each)
+                                                                                 [string] [required]
+      --judge       judge model as provider/model (defaults to the first entry in --models) [string]
+      --agent       agent to use for every contender                                        [string]
+      --variant     model variant (provider-specific reasoning effort, e.g., high, max, minimal)
+                                                                                            [string]
+      --format      format: default (formatted) or json (single JSON result)
+                                          [string] [choices: "default", "json"] [default: "default"]
+      --cleanup     remove losing worktrees and their branches after judging
                                                                           [boolean] [default: false]"
 `;
 

--- a/packages/opencode/test/cli/help/help-snapshots.test.ts
+++ b/packages/opencode/test/cli/help/help-snapshots.test.ts
@@ -47,6 +47,7 @@ const TOP_LEVEL = [
   "mcp",
   "attach",
   "run",
+  "arena",
   "debug",
   "providers", // aliased to `auth`
   "agent",

--- a/packages/opencode/test/cli/run/arena.test.ts
+++ b/packages/opencode/test/cli/run/arena.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import { LIMIT } from "../../../src/cli/cmd/run/best-of"
+import { parseModels } from "../../../src/cli/cmd/run/arena"
+
+describe("cli.run.arena", () => {
+  test("parseModels splits and trims provider/model entries", () => {
+    const result = parseModels(" anthropic/claude-sonnet-4 , openai/gpt-5 ")
+    expect(result).toEqual([
+      { providerID: "anthropic", modelID: "claude-sonnet-4" },
+      { providerID: "openai", modelID: "gpt-5" },
+    ])
+  })
+
+  test("parseModels keeps duplicates so a model can race itself", () => {
+    const result = parseModels("anthropic/claude-sonnet-4,anthropic/claude-sonnet-4")
+    expect(result).toEqual([
+      { providerID: "anthropic", modelID: "claude-sonnet-4" },
+      { providerID: "anthropic", modelID: "claude-sonnet-4" },
+    ])
+  })
+
+  test("parseModels keeps nested model paths intact", () => {
+    const result = parseModels("openrouter/openai/gpt-5-chat,anthropic/claude-sonnet-4")
+    expect(result).toEqual([
+      { providerID: "openrouter", modelID: "openai/gpt-5-chat" },
+      { providerID: "anthropic", modelID: "claude-sonnet-4" },
+    ])
+  })
+
+  test("parseModels rejects fewer than two entries", () => {
+    expect(typeof parseModels("anthropic/claude-sonnet-4")).toBe("string")
+    expect(typeof parseModels("")).toBe("string")
+  })
+
+  test("parseModels rejects entries without a provider/model shape", () => {
+    expect(typeof parseModels("anthropic/claude,gpt-5")).toBe("string")
+    expect(typeof parseModels("anthropic/claude,/gpt-5")).toBe("string")
+    expect(typeof parseModels("anthropic/claude,openai/")).toBe("string")
+  })
+
+  test("parseModels enforces the entry limit", () => {
+    const many = Array.from({ length: LIMIT + 1 }, (_, i) => `p/m${i}`).join(",")
+    expect(typeof parseModels(many)).toBe("string")
+    const max = Array.from({ length: LIMIT }, () => "p/m").join(",")
+    expect(Array.isArray(parseModels(max))).toBe(true)
+  })
+})


### PR DESCRIPTION
Adds `bolt arena`: race the same task across several agents in parallel, each isolated in its own git worktree, then have a judge model rank the anonymized results. Unlike `run --best-of` (which shares one working directory and only compares answer text), arena contenders can freely edit files without stepping on each other, and the judge sees each contender's final answer **plus its git diff**, so it ranks on what was actually built.

```
bolt arena --models anthropic/claude-sonnet-4,openai/gpt-5 "add retry logic to the fetch helper"
```

Each contender gets a worktree via the existing Worktree service (`sdk.worktree.create` over the in-process server, same plumbing as `run`'s local mode) and its own per-directory SDK client. Duplicates in `--models` are allowed — racing a model against itself is a legitimate arena setup — so arena has its own `parseModels` instead of best-of's deduping `parseCandidates`. Judge helpers (`judgePrompt`, `parseVerdict`, labels) are reused from `run/best-of.ts`.

Worktree boot is async (`git reset --hard` + instance bootstrap forked in the background), so the orchestrator listens on `GlobalBus` for `worktree.ready` / `worktree.failed` keyed by directory, with the listener attached before any create so a fast boot can't be missed:

```ts
const handler = (event: GlobalEvent) => {
  const type = event.payload?.type
  if (type !== "worktree.ready" && type !== "worktree.failed") return
  const waiter = waiters.get(event.directory)
  if (waiter) return waiter(error)
  results.set(event.directory, error)
}
```

The winner's text goes to stdout (scoreboard and worktree paths on stderr, `--format json` for machine consumption). All worktrees are kept by default so the user can inspect or merge the winning branch; `--cleanup` removes losing worktrees and their branches after judging.

The help-snapshot update includes a pre-existing staleness fix: the committed `run --help` snapshot predated `--best-of`/auto-model flags and the test was already failing on `dev`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `arena` command to run tasks concurrently across multiple AI models in isolated workspaces.
  * Added automated judging to select the strongest successful result.
  * Supports task input from arguments or standard input.
  * Added formatted or JSON output, progress updates, and optional cleanup of unsuccessful workspaces.
  * Added validation for model configuration and graceful handling of failed attempts.

* **Tests**
  * Added coverage for model parsing and command help output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->