### PR TITLE
fix(server): harden serve auth and UI proxy

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -15,11 +15,17 @@ export const ServeCommand = effectCmd({
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
-    const opts = yield* resolveNetworkOptions(args)
+    const resolved = yield* resolveNetworkOptions(args)
+    // "localhost" resolves through DNS/hosts and may map to a non-loopback
+    // address, so pin unauthenticated binds to a literal loopback IP.
+    const opts =
+      !Flag.OPENCODE_SERVER_PASSWORD && resolved.hostname === "localhost"
+        ? { ...resolved, hostname: "127.0.0.1" }
+        : resolved
     // Refuse to expose an unauthenticated server beyond loopback: the API
     // grants file read/write and shell execution, so binding 0.0.0.0 (or
     // advertising over mDNS) without a password hands that to the whole LAN.
-    const loopback = ["127.0.0.1", "localhost", "::1"].includes(opts.hostname)
+    const loopback = ["127.0.0.1", "::1"].includes(opts.hostname)
     if (!Flag.OPENCODE_SERVER_PASSWORD && (!loopback || opts.mdns)) {
       return yield* fail(
         "Refusing to listen on a non-loopback interface without authentication. Set OPENCODE_SERVER_PASSWORD or bind to 127.0.0.1.",

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect"
-import { effectCmd } from "../effect-cmd"
+import { effectCmd, fail } from "../effect-cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 
@@ -16,6 +16,15 @@ export const ServeCommand = effectCmd({
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = yield* resolveNetworkOptions(args)
+    // Refuse to expose an unauthenticated server beyond loopback: the API
+    // grants file read/write and shell execution, so binding 0.0.0.0 (or
+    // advertising over mDNS) without a password hands that to the whole LAN.
+    const loopback = ["127.0.0.1", "localhost", "::1"].includes(opts.hostname)
+    if (!Flag.OPENCODE_SERVER_PASSWORD && (!loopback || opts.mdns)) {
+      return yield* fail(
+        "Refusing to listen on a non-loopback interface without authentication. Set OPENCODE_SERVER_PASSWORD or bind to 127.0.0.1.",
+      )
+    }
     const server = yield* Effect.promise(() => Server.listen(opts))
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
 

--- a/packages/opencode/src/server/shared/ui.ts
+++ b/packages/opencode/src/server/shared/ui.ts
@@ -38,7 +38,11 @@ function proxyResponseHeaders(headers: Record<string, string>) {
 }
 
 export function upstreamURL(path: string) {
-  return new URL(path, UI_UPSTREAM).toString()
+  const url = new URL(path, UI_UPSTREAM)
+  // A path like "//evil.com/x" resolves to a different host, turning the UI
+  // fallback proxy into an open relay (SSRF). Pin the resolved origin.
+  if (url.origin !== UI_UPSTREAM.origin) return UI_UPSTREAM.toString()
+  return url.toString()
 }
 
 export function embeddedUI(disableEmbeddedWebUi: boolean) {

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,5 +1,6 @@
 export * as ServerAuth from "./auth"
 
+import { createHash, timingSafeEqual } from "node:crypto"
 import { Config as EffectConfig, Context, Effect, Layer, Option, Redacted } from "effect"
 
 export type Credentials = {
@@ -44,9 +45,17 @@ export function required(config: Info) {
 export function authorized(credentials: DecodedCredentials, config: Info) {
   return (
     Option.isSome(config.password) &&
-    credentials.username === config.username &&
-    Redacted.value(credentials.password) === config.password.value
+    equals(credentials.username, config.username) &&
+    equals(Redacted.value(credentials.password), config.password.value)
   )
+}
+
+// Constant-time comparison so the password cannot be recovered byte-by-byte
+// through response timing. Hashing first equalizes lengths, which
+// timingSafeEqual requires (and avoids leaking the length itself).
+function equals(a: string, b: string) {
+  const hash = (value: string) => createHash("sha256").update(value).digest()
+  return timingSafeEqual(hash(a), hash(b))
 }
 
 export function header(credentials?: Credentials) {

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -43,11 +43,12 @@ export function required(config: Info) {
 }
 
 export function authorized(credentials: DecodedCredentials, config: Info) {
-  return (
-    Option.isSome(config.password) &&
-    equals(credentials.username, config.username) &&
-    equals(Redacted.value(credentials.password), config.password.value)
-  )
+  if (Option.isNone(config.password)) return false
+  // Evaluate both comparisons so a username mismatch does not skip the
+  // password hash, which would leak username validity through timing.
+  const username = equals(credentials.username, config.username)
+  const password = equals(Redacted.value(credentials.password), config.password.value)
+  return username && password
 }
 
 // Constant-time comparison so the password cannot be recovered byte-by-byte


### PR DESCRIPTION
Three security fixes from a codebase audit of the server surface.

**1. `bolt serve` refuses non-loopback binds without auth.** The API grants file read/write and shell execution, and enabling mDNS silently rebinds to `0.0.0.0` (`cli/network.ts`), so an unauthenticated server was one config flag away from LAN-wide exposure:

```ts
const loopback = ["127.0.0.1", "localhost", "::1"].includes(opts.hostname)
if (!Flag.OPENCODE_SERVER_PASSWORD && (!loopback || opts.mdns)) {
  return yield* fail(
    "Refusing to listen on a non-loopback interface without authentication. Set OPENCODE_SERVER_PASSWORD or bind to 127.0.0.1.",
  )
}
```

Default loopback serve is unchanged (verified: still starts on `127.0.0.1:4096`; `--hostname 0.0.0.0` without a password now dies with the error above). The daemon and desktop sidecar always inject a generated password, so they are unaffected.

**2. Timing-safe password comparison** in `ServerAuth.authorized` (`packages/server/src/auth.ts`): the `===` compare leaked a byte-by-byte timing side-channel; now both values are sha256-hashed and compared with `crypto.timingSafeEqual` (hashing also equalizes lengths, which `timingSafeEqual` requires).

**3. UI fallback proxy SSRF fix** (`server/shared/ui.ts`): `new URL("//evil.com/x", UI_UPSTREAM)` resolves to a different host, turning the non-embedded-UI proxy path into an open relay. `upstreamURL` now pins the resolved origin to `app.opencode.ai`.

Audit notes for the record: `bun audit` reports 65 advisories, but the two actionable transitive pins (`ws@8.18.0` via miniflare, `fast-uri@4.1.1` via fast-json-stringify) are dev-only tooling and cannot be bumped without npm-style nested overrides, which bun does not support; a global override would force `ws@7`/`fast-uri@3` consumers across a major. Left as-is deliberately. Remaining audit recommendations (Host-header allowlist for DNS-rebinding defense in depth, CORS on the v2 API) are follow-up candidates.

Verified: typecheck clean in `packages/opencode` and `packages/server`; auth tests 14/14 pass; `upstreamURL("//evil.com/x")` now returns `https://app.opencode.ai/`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Prevented unauthenticated servers from binding to network interfaces or advertising through mDNS.
  * Strengthened authentication checks against timing-based attacks.
  * Improved protection for UI requests that target external origins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->