### PR TITLE
fix(session): correct compaction ordering, plan-switch reminder, and logs tail

### DIFF
--- a/packages/opencode/src/cli/cmd/logs.ts
+++ b/packages/opencode/src/cli/cmd/logs.ts
@@ -29,7 +29,9 @@ export const LogsCommand = effectCmd({
     const lines = text.split("\n")
     if (lines.at(-1) === "") lines.pop()
     const count = Math.max(0, Math.floor(args.tail))
-    for (const line of lines.slice(-count)) console.log(line)
+    // slice(-0) === slice(0) returns the whole array, so guard 0 explicitly to
+    // mean "print no history" (e.g. `logs --tail 0 --follow` to stream only new lines).
+    for (const line of count === 0 ? [] : lines.slice(-count)) console.log(line)
     if (!args.follow) return
     // Follow by re-reading appended bytes whenever the file changes; the log
     // is append-only so the previous size is always a valid resume offset.

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -339,27 +339,6 @@ const layer = Layer.effect(
         cfg,
         model,
       })
-      // Remove old messages that have been summarized (head and hidden) to prevent context buildup
-      if (!input.overflow) {
-        const messageIDsToRemove = new Set<MessageID>()
-        const messageIDsToPreserve = new Set<MessageID>()
-        // Add head messages (to be summarized in this compaction)
-        for (const msg of selected.head) {
-          messageIDsToRemove.add(msg.info.id)
-        }
-        // Add previously summarized messages (hidden)
-        for (const index of hidden) {
-          messageIDsToRemove.add(history[index].info.id)
-        }
-        // Preserve the parent message (needed as parent of the new compaction message)
-        messageIDsToPreserve.add(input.parentID)
-        // Remove messages marked for removal but not preserved
-        for (const msgID of messageIDsToRemove) {
-          if (!messageIDsToPreserve.has(msgID)) {
-            yield* session.removeMessage({ sessionID: input.sessionID, messageID: msgID })
-          }
-        }
-      }
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",
@@ -431,6 +410,30 @@ const layer = Layer.effect(
         processor.message.finish = "error"
         yield* session.updateMessage(processor.message)
         return "stop"
+      }
+
+      // Remove old messages that have been summarized (head and hidden) to prevent
+      // context buildup. This must run only after the summary has been generated
+      // and persisted above: deleting first would permanently lose the history if
+      // summarization failed or the session was too large to compact.
+      if (!input.overflow) {
+        const messageIDsToRemove = new Set<MessageID>()
+        const messageIDsToPreserve = new Set<MessageID>()
+        // Add head messages (summarized in this compaction)
+        for (const msg of selected.head) {
+          messageIDsToRemove.add(msg.info.id)
+        }
+        // Add previously summarized messages (hidden)
+        for (const index of hidden) {
+          messageIDsToRemove.add(history[index].info.id)
+        }
+        // Preserve the parent message (needed as parent of the new compaction message)
+        messageIDsToPreserve.add(input.parentID)
+        for (const msgID of messageIDsToRemove) {
+          if (!messageIDsToPreserve.has(msgID)) {
+            yield* session.removeMessage({ sessionID: input.sessionID, messageID: msgID })
+          }
+        }
       }
 
       if (compactionPart && selected.tail_start_id && compactionPart.tail_start_id !== selected.tail_start_id) {

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -415,8 +415,10 @@ const layer = Layer.effect(
       // Remove old messages that have been summarized (head and hidden) to prevent
       // context buildup. This must run only after the summary has been generated
       // and persisted above: deleting first would permanently lose the history if
-      // summarization failed or the session was too large to compact.
-      if (!input.overflow) {
+      // summarization failed or the session was too large to compact. A "stop"
+      // result with an errored message means no valid summary exists either, so
+      // the history must survive in that case too.
+      if (!input.overflow && !processor.message.error) {
         const messageIDsToRemove = new Set<MessageID>()
         const messageIDsToPreserve = new Set<MessageID>()
         // Add head messages (summarized in this compaction)

--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -35,7 +35,7 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
       })
     }
     const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
-    if (wasPlan && input.agent.name === "build") {
+    if (wasPlan && input.agent.name === "code") {
       userMessage.parts.push({
         id: PartID.ascending(),
         messageID: userMessage.info.id,

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -903,12 +903,13 @@ describe("session.compaction.process", () => {
       const msgs = yield* ssn.messages({ sessionID: session.id })
       const parent = msgs.at(-1)?.info.id
       expect(parent).toBeTruthy()
+      if (!parent) return
 
       // Non-overflow auto compaction whose summarization fails ("compact"): the
       // old head messages must survive, since deletion must happen only after a
       // summary has been produced. Regression for history-loss on failed compaction.
       const result = yield* SessionCompaction.use.process({
-        parentID: parent!,
+        parentID: parent,
         messages: msgs,
         sessionID: session.id,
         auto: true,

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -890,6 +890,39 @@ describe("session.compaction.process", () => {
     }).pipe(withCompaction({ result: "compact" })),
   )
 
+  itCompaction.instance(
+    "keeps summarized history when compaction fails",
+    Effect.gen(function* () {
+      const ssn = yield* SessionNs.Service
+      const session = yield* ssn.create({})
+      yield* createUserMessage(session.id, "first")
+      yield* createUserMessage(session.id, "second")
+      yield* createUserMessage(session.id, "third")
+      yield* createSummaryCompaction(session.id)
+
+      const msgs = yield* ssn.messages({ sessionID: session.id })
+      const parent = msgs.at(-1)?.info.id
+      expect(parent).toBeTruthy()
+
+      // Non-overflow auto compaction whose summarization fails ("compact"): the
+      // old head messages must survive, since deletion must happen only after a
+      // summary has been produced. Regression for history-loss on failed compaction.
+      const result = yield* SessionCompaction.use.process({
+        parentID: parent!,
+        messages: msgs,
+        sessionID: session.id,
+        auto: true,
+      })
+
+      expect(result).toBe("stop")
+      const texts = (yield* ssn.messages({ sessionID: session.id }))
+        .flatMap((msg) => msg.parts)
+        .flatMap((part) => (part.type === "text" ? [part.text] : []))
+      expect(texts).toContain("first")
+      expect(texts).toContain("second")
+    }).pipe(withCompaction({ result: "compact", config: cfg({ tail_turns: 1, preserve_recent_tokens: 100 }) })),
+  )
+
   it.instance(
     "adds synthetic continue prompt when auto is enabled",
     Effect.gen(function* () {

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -195,7 +195,7 @@ function createCompactionMarker(sessionID: SessionID) {
 
 function fake(
   input: Parameters<SessionProcessorModule.SessionProcessor.Interface["create"]>[0],
-  result: "continue" | "compact",
+  result: "continue" | "compact" | "stop",
 ) {
   const msg = input.assistantMessage
   return {
@@ -204,11 +204,21 @@ function fake(
     },
     updateToolCall: Effect.fn("TestSessionProcessor.updateToolCall")(() => Effect.succeed(undefined)),
     completeToolCall: Effect.fn("TestSessionProcessor.completeToolCall")(() => Effect.void),
-    process: Effect.fn("TestSessionProcessor.process")(() => Effect.succeed(result)),
+    process: Effect.fn("TestSessionProcessor.process")(() =>
+      Effect.sync(() => {
+        // The real processor returns "stop" after recording an error on the
+        // assistant message (aborted, provider failure, ...), so mirror that.
+        if (result === "stop") {
+          msg.error = new SessionV1.AbortedError({ message: "processor failed" }).toObject()
+          msg.finish = "error"
+        }
+        return result
+      }),
+    ),
   } satisfies SessionProcessorModule.SessionProcessor.Handle
 }
 
-function processorLayer(result: "continue" | "compact") {
+function processorLayer(result: "continue" | "compact" | "stop") {
   return Layer.succeed(
     SessionProcessorModule.SessionProcessor.Service,
     SessionProcessorModule.SessionProcessor.Service.of({
@@ -245,7 +255,7 @@ const compactionEnv = AppNodeBuilder.build(
 const itCompaction = testEffect(compactionEnv)
 
 type CompactionProcessOptions = {
-  result?: "continue" | "compact"
+  result?: "continue" | "compact" | "stop"
   llm?: Layer.Layer<LLM.Service>
   plugin?: Layer.Layer<Plugin.Service>
   provider?: ReturnType<typeof wide>
@@ -922,6 +932,40 @@ describe("session.compaction.process", () => {
       expect(texts).toContain("first")
       expect(texts).toContain("second")
     }).pipe(withCompaction({ result: "compact", config: cfg({ tail_turns: 1, preserve_recent_tokens: 100 }) })),
+  )
+
+  itCompaction.instance(
+    "keeps summarized history when processing stops with an error",
+    Effect.gen(function* () {
+      const ssn = yield* SessionNs.Service
+      const session = yield* ssn.create({})
+      yield* createUserMessage(session.id, "first")
+      yield* createUserMessage(session.id, "second")
+      yield* createUserMessage(session.id, "third")
+      yield* createSummaryCompaction(session.id)
+
+      const msgs = yield* ssn.messages({ sessionID: session.id })
+      const parent = msgs.at(-1)?.info.id
+      expect(parent).toBeTruthy()
+      if (!parent) return
+
+      // Processing that stops with an errored assistant message ("stop" +
+      // message.error) produced no valid summary either, so the summarized
+      // head messages must survive. Regression for history-loss on errored stop.
+      const result = yield* SessionCompaction.use.process({
+        parentID: parent,
+        messages: msgs,
+        sessionID: session.id,
+        auto: true,
+      })
+
+      expect(result).toBe("stop")
+      const texts = (yield* ssn.messages({ sessionID: session.id }))
+        .flatMap((msg) => msg.parts)
+        .flatMap((part) => (part.type === "text" ? [part.text] : []))
+      expect(texts).toContain("first")
+      expect(texts).toContain("second")
+    }).pipe(withCompaction({ result: "stop", config: cfg({ tail_turns: 1, preserve_recent_tokens: 100 }) })),
   )
 
   it.instance(


### PR DESCRIPTION
Three correctness bugs found by auditing the session runtime, each confirmed by reading the code paths end to end.

**1. Compaction deleted history before the summary existed (data loss).** In `session/compaction.ts`, the block that removes summarized head/hidden messages ran *before* `processor.process(...)` generated the summary. So when summarization failed (rate limit, network error, or the "Session too large to compact" branch that returns `"stop"`), the original messages were already hard-deleted by the projector and unrecoverable. Moved the removal to after the summary is produced and the `result === "compact"` early-return has been passed.

Added a regression test (`keeps summarized history when compaction fails`) that seeds head turns, forces a `"compact"` failure, and asserts the history survives. Verified it fails on the pre-fix ordering and passes after.

Follow-up from review: a `"stop"` result with an errored assistant message also means no valid summary exists, so the removal block is additionally gated on `!processor.message.error`, with a matching regression test (`keeps summarized history when processing stops with an error`).

**2. Plan->build switch reminder never fired.** The default agent was renamed (`build: { name: "code", ... }` in `agent/agent.ts`), but `session/reminders.ts` still gated on `input.agent.name === "build"`, which is now unreachable. So after working in the `plan` agent and switching back to implement, the BUILD_SWITCH reminder was never appended and the model often kept refusing edits. Changed the comparison to `"code"`.

**3. `bolt logs --tail 0` dumped the entire log.** `lines.slice(-count)` with `count === 0` is `slice(0)`, which returns everything. Guarded the zero case to print nothing.

Verified: `bun run typecheck` clean; full compaction suite 53 pass / 1 skip.

Note: the audit also flagged a server-side model-resolution change (`runner/model.ts` uses `catalog.model.cheapest()` where upstream used `default()`, so a configured default model is ignored for model-less v2 sessions). That one may be intentional fork behavior, so I left it out pending a product call.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `logs --tail 0` to hide existing log entries while continuing to stream new entries with `--follow`.

* **Bug Fixes**
  * Prevented failed or interrupted compaction from removing conversation history.
  * Preserved summarized history until compaction completes successfully.
  * Fixed the build-switch reminder when transitioning from plan mode to code mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
