### PR TITLE
fix(app): collapse deletion-only edit parts (#40536)

### DIFF
--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -61,6 +61,7 @@ import { TextShimmer } from "@opencode-ai/ui/text-shimmer"
 import { AnimatedCountList } from "./tool-count-summary"
 import { ToolStatusTitle } from "./tool-status-title"
 import { patchFiles } from "./apply-patch-file"
+import { partDefaultOpen } from "./part-default-open"
 import { animate } from "motion"
 import { attached, inline, kind, typeLabel } from "./message-file"
 import { readPartText } from "./message-part-text"
@@ -718,15 +719,7 @@ export function renderable(part: PartType, showReasoningSummaries = true) {
   return !!PART_MAPPING[part.type]
 }
 
-function toolDefaultOpen(tool: string, shell = false, edit = false) {
-  if (tool === "bash" || tool === "shell") return shell
-  if (tool === "edit" || tool === "write" || tool === "patch" || tool === "apply_patch") return edit
-}
-
-export function partDefaultOpen(part: PartType, shell = false, edit = false) {
-  if (part.type !== "tool") return
-  return toolDefaultOpen(part.tool, shell, edit)
-}
+export { partDefaultOpen } from "./part-default-open"
 
 export function AssistantParts(props: {
   messages: AssistantMessage[]

--- a/packages/session-ui/src/components/part-default-open.test.ts
+++ b/packages/session-ui/src/components/part-default-open.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import type { Part as PartType } from "@opencode-ai/sdk/v2"
+import { partDefaultOpen } from "./part-default-open"
+
+describe("partDefaultOpen", () => {
+  test("keeps edited files expanded when enabled", () => {
+    expect(partDefaultOpen(tool("edit", { filediff: { additions: 1, deletions: 1 } }), false, true)).toBe(true)
+  })
+
+  test("collapses deletion-only edits when enabled", () => {
+    expect(partDefaultOpen(tool("edit", { filediff: { additions: 0, deletions: 1_200 } }), false, true)).toBe(false)
+  })
+
+  test("collapses patches containing only deleted files when enabled", () => {
+    expect(
+      partDefaultOpen(
+        tool("apply_patch", {
+          files: [
+            { filePath: "one.ts", type: "delete" },
+            { filePath: "two.ts", type: "delete" },
+          ],
+        }),
+        false,
+        true,
+      ),
+    ).toBe(false)
+  })
+
+  test("keeps mixed patches expanded when enabled", () => {
+    expect(
+      partDefaultOpen(
+        tool("apply_patch", {
+          files: [
+            { filePath: "one.ts", type: "delete" },
+            { filePath: "two.ts", type: "update" },
+          ],
+        }),
+        false,
+        true,
+      ),
+    ).toBe(true)
+  })
+
+  test("preserves shell defaults", () => {
+    expect(partDefaultOpen(tool("shell", {}), true, false)).toBe(true)
+  })
+})
+
+function tool(name: string, metadata: Record<string, unknown>): PartType {
+  return {
+    id: `part_${name}`,
+    sessionID: "session",
+    messageID: "message",
+    type: "tool",
+    callID: `call_${name}`,
+    tool: name,
+    state: {
+      status: "completed",
+      input: {},
+      output: "",
+      title: name,
+      metadata,
+      time: { start: 0, end: 1 },
+    },
+  }
+}

--- a/packages/session-ui/src/components/part-default-open.ts
+++ b/packages/session-ui/src/components/part-default-open.ts
@@ -1,0 +1,26 @@
+import type { Part as PartType, ToolPart } from "@opencode-ai/sdk/v2"
+
+function deletionOnly(part: ToolPart) {
+  if (!("metadata" in part.state)) return false
+  const metadata = part.state.metadata
+  if (!metadata) return false
+
+  const files = metadata.files
+  if (Array.isArray(files) && files.length > 0) {
+    return files.every((file) => !!file && typeof file === "object" && "type" in file && file.type === "delete")
+  }
+
+  const filediff = metadata.filediff
+  if (!filediff || typeof filediff !== "object") return false
+  if (!("additions" in filediff) || !("deletions" in filediff)) return false
+  return filediff.additions === 0 && typeof filediff.deletions === "number" && filediff.deletions > 0
+}
+
+export function partDefaultOpen(part: PartType, shell = false, edit = false) {
+  if (part.type !== "tool") return
+  if (part.tool === "bash" || part.tool === "shell") return shell
+  if (part.tool === "edit" || part.tool === "write" || part.tool === "patch" || part.tool === "apply_patch") {
+    if (!edit) return false
+    return !deletionOnly(part)
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool and edit sections now open or remain collapsed based on their type and configured preferences.
  * Deletion-only edits remain collapsed for easier review.
* **Bug Fixes**
  * Preserved existing shell-tool expansion behavior while improving edit-state handling.
* **Tests**
  * Added coverage for edited files, deletion-only changes, mixed patches, and configurable tool metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->