### PR TITLE
chore(ci): use Gemini for docs-update workflow

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -45,9 +45,9 @@ jobs:
         if: steps.commits.outputs.has_commits == 'true'
         uses: bolt-builder/bolt-cli/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         with:
-          model: opencode/gpt-5.2
+          model: google/gemini-3.5-flash
           agent: docs
           prompt: |
             Review the following commits from the last ${{ env.LOOKBACK_HOURS }} hours and identify any new features that may need documentation.


### PR DESCRIPTION
The docs-update workflow has been failing at the Run opencode step with "Failed to parse JSON" because `OPENCODE_API_KEY` is empty in this repo. Switches the step to authenticate with the repo's existing `GEMINI_API_KEY` secret (already used by commit-message.yml) and run on Gemini 3.5 Flash instead:

```yaml
env:
  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
with:
  model: google/gemini-3.5-flash
```

`gemini-3.5-flash` is a valid model id for the `google` provider, and `GEMINI_API_KEY` is one of its accepted auth env vars, so no `OPENCODE_API_KEY` is needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated documentation workflow to use the Gemini API and Gemini Flash model for documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->