### PR TITLE
chore(ci): run bolt CLI in github action instead of opencode

### DIFF
--- a/.github/workflows/bolt.yml
+++ b/.github/workflows/bolt.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-bun
       - name: Run Bolt
-        uses: bolt-builder/bolt-cli/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest
+        uses: ./github
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENCODE_PERMISSION: '{"bash": "deny"}'

--- a/.github/workflows/bolt.yml
+++ b/.github/workflows/bolt.yml
@@ -32,3 +32,4 @@ jobs:
           OPENCODE_PERMISSION: '{"bash": "deny"}'
         with:
           model: opencode/claude-fable-5
+          mentions: /opencode,/oc,/bc,/bolt

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run opencode
         if: steps.commits.outputs.has_commits == 'true'
-        uses: bolt-builder/bolt-cli/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest
+        uses: ./github
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         with:

--- a/github/action.yml
+++ b/github/action.yml
@@ -1,5 +1,5 @@
-name: "opencode GitHub Action"
-description: "Run opencode in GitHub Actions workflows"
+name: "Bolt GitHub Action"
+description: "Run Bolt in GitHub Actions workflows"
 branding:
   icon: "code"
   color: "orange"
@@ -41,33 +41,33 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Get opencode version
+    - name: Get bolt version
       id: version
       shell: bash
       run: |
         VERSION=$(curl -sf https://api.github.com/repos/bolt-builder/bolt-cli/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
         echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
 
-    - name: Cache opencode
+    - name: Cache bolt
       id: cache
       uses: actions/cache@v4
       with:
-        path: ~/.opencode/bin
-        key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
+        path: ~/.bolt/bin
+        key: bolt-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
 
-    - name: Install opencode
+    - name: Install bolt
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
-      run: curl -fsSL https://opencode.ai/install | bash
+      run: curl -fsSL https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install | bash
 
-    - name: Add opencode to PATH
+    - name: Add bolt to PATH
       shell: bash
-      run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
+      run: echo "$HOME/.bolt/bin" >> $GITHUB_PATH
 
-    - name: Run opencode
+    - name: Run bolt
       shell: bash
-      id: run_opencode
-      run: opencode github run
+      id: run_bolt
+      run: bolt github run
       env:
         MODEL: ${{ inputs.model }}
         AGENT: ${{ inputs.agent }}

--- a/github/action.yml
+++ b/github/action.yml
@@ -46,7 +46,11 @@ runs:
       shell: bash
       run: |
         VERSION=$(curl -sf https://api.github.com/repos/bolt-builder/bolt-cli/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
-        echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
+        if [ -z "$VERSION" ]; then
+          echo "Failed to resolve the latest bolt release version" >&2
+          exit 1
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Cache bolt
       id: cache
@@ -58,7 +62,10 @@ runs:
     - name: Install bolt
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
-      run: curl -fsSL https://raw.githubusercontent.com/bolt-builder/bolt-cli/dev/install | bash
+      # The install script ships with this action, so it is pinned to the same
+      # ref as the action itself instead of the mutable dev branch. Passing the
+      # resolved release tag keeps the installed binary tied to the cache key.
+      run: bash "${GITHUB_ACTION_PATH}/../install" --version "${{ steps.version.outputs.version }}"
 
     - name: Add bolt to PATH
       shell: bash


### PR DESCRIPTION
The composite action in `github/action.yml` fetched this repo's release version for its cache key but then installed the upstream opencode binary from `opencode.ai/install` and ran `opencode github run`. This switches it to install this repo's own CLI via the root `install` script and run it. The installer ships with the action (both workflows run it from the checked-out repo), so it is pinned to the same ref as the action itself, and the resolved release tag is passed through so the installed binary always matches the cache key:

```yaml
- name: Install bolt
  if: steps.cache.outputs.cache-hit != 'true'
  shell: bash
  run: bash "${GITHUB_ACTION_PATH}/../install" --version "${{ steps.version.outputs.version }}"

- name: Run bolt
  shell: bash
  id: run_bolt
  run: bolt github run
```

The version-lookup step now fails when the release tag cannot be resolved instead of silently falling back to `latest`. The cache path and PATH entry move from `~/.opencode/bin` to `~/.bolt/bin` to match the installer, and the cache key prefix follows. The installer already appends to `GITHUB_PATH` in Actions and skips voice setup in CI.

Both `docs-update.yml` and `bolt.yml` also now reference the action as `uses: ./github` instead of pinning the stale commit `2c14fc55`, so they always run the action as it exists on the checked-out ref (both workflows check out the repo before invoking it). `bolt.yml` additionally sets `mentions: /opencode,/oc,/bc,/bolt` so the action accepts the same trigger phrases the workflow fires on.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automation workflows to use the local Bolt action.
  * Rebranded the GitHub Action from OpenCode to Bolt.
  * Updated installation, caching, and command execution to use Bolt.
  * Added support for configured Bolt command mentions in workflow automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
