### PR TITLE
chore: relicense from PolyForm Noncommercial to AGPL-3.0

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -5,5 +5,5 @@ Copyright (c) 2025 Anomlyco
 
 The original MIT permissions remain intact for the foundational 
 OpenCode files. All custom features, additions, and modifications 
-created by [Your Name/Username] are licensed under the PolyForm 
-Noncommercial 1.0.0 License.
+created by [Your Name/Username] are licensed under the GNU Affero General Public 
+License v3.0 (AGPL-3.0).

--- a/CREDITS
+++ b/CREDITS
@@ -5,5 +5,5 @@ Copyright (c) 2025 Anomlyco
 
 The original MIT permissions remain intact for the foundational 
 OpenCode files. All custom features, additions, and modifications 
-created by [Your Name/Username] are licensed under the GNU Affero General Public 
-License v3.0 (AGPL-3.0).
+are licensed under the GNU Affero General Public License v3.0 
+(AGPL-3.0).

--- a/LICENSE
+++ b/LICENSE
@@ -1,142 +1,661 @@
-====================================================================
-HUMAN-READABLE SUMMARY:
-You are free to fork this project, modify it, and share your custom 
-builds for personal, educational, or hobbyist use. However, you 
-CANNOT monetize this software, use it for commercial purposes, 
-or host it as a paid service without explicit, written consent 
-from the author. 
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Full legal terms follow below.
-====================================================================
-# PolyForm Noncommercial License 1.0.0
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+                            Preamble
 
-## Acceptance
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-## Copyright License
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose.  However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-## Distribution License
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-## Notices
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+                       TERMS AND CONDITIONS
 
-## Changes and New Works License
+  0. Definitions.
 
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-## Patent License
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-## Noncommercial Purposes
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-Any noncommercial purpose is a permitted purpose.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-## Personal Uses
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application,
-is use for a permitted purpose.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-## Noncommercial Organizations
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-Use by any charitable organization, educational institution,
-public research organization, public safety or health
-organization, environmental protection organization,
-or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting
-from the funding.
+  1. Source Code.
 
-## Fair Use
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-## No Other Rights
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-## Patent Defense
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-## Violations
+  2. Basic Permissions.
 
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-## No Liability
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
 
-## Definitions
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
 
-**You** refers to the individual or entity agreeing to these
-terms.
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
 
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization.  **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise.  Control can be direct or indirect.
+  4. Conveying Verbatim Copies.
 
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
 
-**Use** means anything you do with the software requiring one
-of your licenses.
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
 
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/Bolt-builder/bolt-cli/actions/workflows/publish.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/Bolt-builder/bolt-cli/publish.yml?style=flat-square&branch=dev" /></a>
   <a href="https://www.npmjs.com/package/@bolt-builder/bolt-cli"><img alt="npm" src="https://img.shields.io/npm/v/@bolt-builder/bolt-cli?style=flat-square" /></a>
   <a href="https://github.com/Bolt-builder/bolt-cli"><img alt="GitHub stars" src="https://img.shields.io/github/stars/Bolt-builder/bolt-cli?style=flat-square" /></a>
-  <a href="LICENSE"><img alt="License: PolyForm Noncommercial 1.0.0" src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-blue?style=flat-square" /></a>
+  <a href="LICENSE"><img alt="License: AGPL-3.0" src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" /></a>
 </p>
 <p align="center">
   <a href="https://www.producthunt.com/products/bolt-cli?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-bolt-cli" target="_blank" rel="noopener noreferrer"><img alt="Bolt cli - Your terminal, now with a full AI engineering team inside it. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1211272&theme=light&t=1785541043666" /></a>
@@ -293,4 +293,4 @@ Consider giving it a star ⭐ — it helps other developers discover the project
 
 ## License
 
-PolyForm Noncommercial 1.0.0 License © [Bolt CLI](https://github.com/Bolt-builder/bolt-cli)
+AGPL-3.0 © [Bolt CLI](https://github.com/Bolt-builder/bolt-cli)

--- a/github/package.json
+++ b/github/package.json
@@ -3,7 +3,7 @@
   "module": "index.ts",
   "type": "module",
   "private": true,
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "devDependencies": {
     "@types/bun": "catalog:"
   },

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "type": "git",
     "url": "https://github.com/Bolt-builder/bolt-cli/actions/workflows/publish.ym"
   },
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "prettier": {
     "semi": false,
     "printWidth": 120

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -30,7 +30,7 @@
     "test:stability": "bun test ./e2e/performance/unit/visual-stability.test.ts && playwright test --config e2e/performance/timeline-stability/playwright.config.ts",
     "test:bench": "bun test ./e2e/performance/unit && playwright test --config e2e/performance/playwright.config.ts"
   },
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "devDependencies": {
     "@happy-dom/global-registrator": "20.0.11",
     "@playwright/test": "catalog:",

--- a/packages/app/vendor/package/package.json
+++ b/packages/app/vendor/package/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/client",
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/anomalyco/opencode.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/cli",
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "bin": {
     "bolt": "./bin/bolt.cjs"
   },

--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -104,7 +104,7 @@ for (const item of targets) {
       {
         name: `@opencode-ai/${name}`,
         version: Script.version,
-        license: "PolyForm Noncommercial 1.0.0 License ",
+        license: "AGPL-3.0-only",
         repository: {
           type: "git",
           url: "git+https://github.com/Bolt-builder/bolt-cli/actions/workflows/publish.ym.git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/client",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "exports": {
     ".": "./src/index.ts",
     "./effect": "./src/effect.ts"

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -5,7 +5,7 @@
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/console-app",
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "vite dev --host 0.0.0.0",

--- a/packages/console/app/src/i18n/ar.ts
+++ b/packages/console/app/src/i18n/ar.ts
@@ -182,7 +182,7 @@ export const dict = {
   "home.faq.q8": "هل OpenCode مفتوح المصدر؟",
   "home.faq.a8.p1": "نعم، OpenCode مفتوح المصدر بالكامل. الكود المصدري متاح علنًا على",
   "home.faq.a8.p2": "بموجب",
-  "home.faq.a8.mitLicense": "رخصة PolyForm Noncommercial 1.0.0 License ",
+  "home.faq.a8.mitLicense": "رخصة AGPL-3.0",
   "home.faq.a8.p3":
     "، مما يعني أن أي شخص يستطيع استخدامه أو تعديله أو المساهمة في تطويره. يمكن لأي شخص من المجتمع فتح قضايا، وتقديم طلبات سحب، وتوسيع الوظائف.",
 

--- a/packages/console/app/src/i18n/br.ts
+++ b/packages/console/app/src/i18n/br.ts
@@ -186,7 +186,7 @@ export const dict = {
   "home.faq.q8": "OpenCode é código aberto?",
   "home.faq.a8.p1": "Sim, OpenCode é totalmente open source. O código-fonte é público no",
   "home.faq.a8.p2": "sob a",
-  "home.faq.a8.mitLicense": "Licença PolyForm Noncommercial 1.0.0 License ",
+  "home.faq.a8.mitLicense": "Licença AGPL-3.0",
   "home.faq.a8.p3":
     ", o que significa que qualquer pessoa pode usar, modificar ou contribuir para o seu desenvolvimento. Qualquer pessoa da comunidade pode abrir issues, enviar pull requests e estender a funcionalidade.",
 

--- a/packages/console/app/src/i18n/da.ts
+++ b/packages/console/app/src/i18n/da.ts
@@ -184,7 +184,7 @@ export const dict = {
   "home.faq.q8": "Er OpenCode open source?",
   "home.faq.a8.p1": "Ja, OpenCode er fuldt open source. Kildekoden er offentlig på",
   "home.faq.a8.p2": "under",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License -licensen",
+  "home.faq.a8.mitLicense": "AGPL-3.0-licensen",
   "home.faq.a8.p3":
     ", hvilket betyder at alle kan bruge, ændre eller bidrage til udviklingen. Alle i communityet kan oprette issues, indsende pull requests og udvide funktionalitet.",
 

--- a/packages/console/app/src/i18n/de.ts
+++ b/packages/console/app/src/i18n/de.ts
@@ -185,7 +185,7 @@ export const dict = {
   "home.faq.q8": "Ist OpenCode Open Source?",
   "home.faq.a8.p1": "Ja, OpenCode ist vollständig Open Source. Der Quellcode ist öffentlich auf",
   "home.faq.a8.p2": "unter der",
-  "home.faq.a8.mitLicense": "AGPL-3.0 Lizenz",
+  "home.faq.a8.mitLicense": "AGPL-3.0-Lizenz",
   "home.faq.a8.p3":
     ", was bedeutet, dass jeder ihn nutzen, modifizieren oder zu seiner Entwicklung beitragen kann. Jeder aus der Community kann Issues melden, Pull Requests einreichen und die Funktionalität erweitern.",
 

--- a/packages/console/app/src/i18n/de.ts
+++ b/packages/console/app/src/i18n/de.ts
@@ -185,7 +185,7 @@ export const dict = {
   "home.faq.q8": "Ist OpenCode Open Source?",
   "home.faq.a8.p1": "Ja, OpenCode ist vollständig Open Source. Der Quellcode ist öffentlich auf",
   "home.faq.a8.p2": "unter der",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License  Lizenz",
+  "home.faq.a8.mitLicense": "AGPL-3.0 Lizenz",
   "home.faq.a8.p3":
     ", was bedeutet, dass jeder ihn nutzen, modifizieren oder zu seiner Entwicklung beitragen kann. Jeder aus der Community kann Issues melden, Pull Requests einreichen und die Funktionalität erweitern.",
 

--- a/packages/console/app/src/i18n/en.ts
+++ b/packages/console/app/src/i18n/en.ts
@@ -184,7 +184,7 @@ export const dict = {
   "home.faq.q8": "Is OpenCode open source?",
   "home.faq.a8.p1": "Yes, OpenCode is fully open source. The source code is public on",
   "home.faq.a8.p2": "under the",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License  License",
+  "home.faq.a8.mitLicense": "AGPL-3.0 License",
   "home.faq.a8.p3":
     ", meaning anyone can use, modify, or contribute to its development. Anyone from the community can file issues, submit pull requests, and extend functionality.",
 

--- a/packages/console/app/src/i18n/es.ts
+++ b/packages/console/app/src/i18n/es.ts
@@ -186,7 +186,7 @@ export const dict = {
   "home.faq.q8": "¿Es OpenCode de código abierto?",
   "home.faq.a8.p1": "Sí, OpenCode es totalmente de código abierto. El código fuente es público en",
   "home.faq.a8.p2": "bajo la",
-  "home.faq.a8.mitLicense": "Licencia PolyForm Noncommercial 1.0.0 License ",
+  "home.faq.a8.mitLicense": "Licencia AGPL-3.0",
   "home.faq.a8.p3":
     ", lo que significa que cualquiera puede usar, modificar o contribuir a su desarrollo. Cualquiera de la comunidad puede abrir problemas, enviar solicitudes de extracción y extender la funcionalidad.",
 

--- a/packages/console/app/src/i18n/fr.ts
+++ b/packages/console/app/src/i18n/fr.ts
@@ -184,7 +184,7 @@ export const dict = {
   "home.faq.q8": "OpenCode est-il open source ?",
   "home.faq.a8.p1": "Oui, OpenCode est entièrement open source. Le code source est public sur",
   "home.faq.a8.p2": "sous la",
-  "home.faq.a8.mitLicense": "Licence PolyForm Noncommercial 1.0.0 License ",
+  "home.faq.a8.mitLicense": "Licence AGPL-3.0",
   "home.faq.a8.p3":
     ", ce qui signifie que tout le monde peut l'utiliser, le modifier ou contribuer à son développement. Toute personne de la communauté peut ouvrir des tickets, soumettre des pull requests et étendre les fonctionnalités.",
 

--- a/packages/console/app/src/i18n/it.ts
+++ b/packages/console/app/src/i18n/it.ts
@@ -184,7 +184,7 @@ export const dict = {
   "home.faq.q8": "OpenCode è open source?",
   "home.faq.a8.p1": "Sì, OpenCode è completamente open source. Il codice sorgente è pubblico su",
   "home.faq.a8.p2": "sotto la",
-  "home.faq.a8.mitLicense": "Licenza PolyForm Noncommercial 1.0.0 License ",
+  "home.faq.a8.mitLicense": "Licenza AGPL-3.0",
   "home.faq.a8.p3":
     ", il che significa che chiunque può usarlo, modificarlo o contribuire al suo sviluppo. Chiunque nella comunità può aprire issue, inviare pull request ed estendere le funzionalità.",
 

--- a/packages/console/app/src/i18n/ko.ts
+++ b/packages/console/app/src/i18n/ko.ts
@@ -182,7 +182,7 @@ export const dict = {
   "home.faq.q8": "OpenCode는 오픈 소스인가요?",
   "home.faq.a8.p1": "네, OpenCode는 완전히 오픈 소스입니다. 소스 코드는",
   "home.faq.a8.p2": "에 공개되어 있으며,",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License  라이선스",
+  "home.faq.a8.mitLicense": "AGPL-3.0 라이선스",
   "home.faq.a8.p3":
     "를 따릅니다. 즉, 누구나 사용, 수정 또는 개발에 기여할 수 있습니다. 커뮤니티의 누구든지 이슈를 등록하고, 풀 리퀘스트를 제출하고, 기능을 확장할 수 있습니다.",
 

--- a/packages/console/app/src/i18n/no.ts
+++ b/packages/console/app/src/i18n/no.ts
@@ -184,7 +184,7 @@ export const dict = {
   "home.faq.q8": "Er OpenCode åpen kildekode?",
   "home.faq.a8.p1": "Ja, OpenCode er fullt open source. Kildekoden er offentlig på",
   "home.faq.a8.p2": "under",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License -lisensen",
+  "home.faq.a8.mitLicense": "AGPL-3.0-lisensen",
   "home.faq.a8.p3":
     ", som betyr at hvem som helst kan bruke, endre eller bidra til utviklingen. Alle i communityet kan opprette issues, sende inn pull requests og utvide funksjonalitet.",
 

--- a/packages/console/app/src/i18n/pl.ts
+++ b/packages/console/app/src/i18n/pl.ts
@@ -184,7 +184,7 @@ export const dict = {
   "home.faq.q8": "Czy OpenCode jest open source?",
   "home.faq.a8.p1": "Tak, OpenCode jest w pełni open source. Kod źródłowy jest publicznie dostępny na",
   "home.faq.a8.p2": "na licencji",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License  License",
+  "home.faq.a8.mitLicense": "AGPL-3.0 License",
   "home.faq.a8.p3":
     ", co oznacza, że każdy może go używać, modyfikować i wspierać jego rozwój. Każdy ze społeczności może zgłaszać błędy, przesyłać pull requesty i rozszerzać funkcjonalność.",
 

--- a/packages/console/app/src/i18n/pl.ts
+++ b/packages/console/app/src/i18n/pl.ts
@@ -184,7 +184,7 @@ export const dict = {
   "home.faq.q8": "Czy OpenCode jest open source?",
   "home.faq.a8.p1": "Tak, OpenCode jest w pełni open source. Kod źródłowy jest publicznie dostępny na",
   "home.faq.a8.p2": "na licencji",
-  "home.faq.a8.mitLicense": "AGPL-3.0 License",
+  "home.faq.a8.mitLicense": "AGPL-3.0",
   "home.faq.a8.p3":
     ", co oznacza, że każdy może go używać, modyfikować i wspierać jego rozwój. Każdy ze społeczności może zgłaszać błędy, przesyłać pull requesty i rozszerzać funkcjonalność.",
 

--- a/packages/console/app/src/i18n/ru.ts
+++ b/packages/console/app/src/i18n/ru.ts
@@ -186,7 +186,7 @@ export const dict = {
   "home.faq.q8": "OpenCode — это open source?",
   "home.faq.a8.p1": "Да, OpenCode полностью open source. Исходный код доступен публично на",
   "home.faq.a8.p2": "под",
-  "home.faq.a8.mitLicense": "лицензией PolyForm Noncommercial 1.0.0 License ",
+  "home.faq.a8.mitLicense": "лицензией AGPL-3.0",
   "home.faq.a8.p3":
     ", что означает, что любой может использовать, изменять или вносить вклад в его развитие. Любой участник сообщества может создавать issues, отправлять pull requests и расширять функциональность.",
 

--- a/packages/console/app/src/i18n/th.ts
+++ b/packages/console/app/src/i18n/th.ts
@@ -182,7 +182,7 @@ export const dict = {
   "home.faq.q8": "OpenCode เป็นโอเพนซอร์สหรือไม่?",
   "home.faq.a8.p1": "ใช่ OpenCode เป็นโอเพนซอร์สเต็มรูปแบบ ซอร์สโค้ดเปิดเผยต่อสาธารณะบน",
   "home.faq.a8.p2": "ภายใต้",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License  License",
+  "home.faq.a8.mitLicense": "AGPL-3.0 License",
   "home.faq.a8.p3":
     " ซึ่งหมายความว่าใครๆ ก็สามารถใช้ แก้ไข หรือร่วมพัฒนาได้ ทุกคนในชุมชนสามารถเปิด issue, ส่ง pull request และขยายฟังก์ชันการทำงานได้",
 

--- a/packages/console/app/src/i18n/tr.ts
+++ b/packages/console/app/src/i18n/tr.ts
@@ -183,7 +183,7 @@ export const dict = {
   "home.faq.q8": "OpenCode açık kaynak mı?",
   "home.faq.a8.p1": "Evet, OpenCode tamamen açık kaynaktır. Kaynak kodu",
   "home.faq.a8.p2": "'da",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License  Lisansı",
+  "home.faq.a8.mitLicense": "AGPL-3.0 Lisansı",
   "home.faq.a8.p3":
     "altında herkese açıktır, yani herkes kullanabilir, değiştirebilir veya geliştirmeye katkıda bulunabilir. Topluluktan herkes issue açabilir, pull request gönderebilir ve işlevselliği genişletebilir.",
 

--- a/packages/console/app/src/i18n/uk.ts
+++ b/packages/console/app/src/i18n/uk.ts
@@ -185,7 +185,7 @@ export const dict = {
   "home.faq.q8": "Чи є OpenCode відкритим?",
   "home.faq.a8.p1": "Так, OpenCode повністю відкритий. Вихідний код доступний публічно на",
   "home.faq.a8.p2": "під ліцензією",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License  License",
+  "home.faq.a8.mitLicense": "AGPL-3.0 License",
   "home.faq.a8.p3":
     ", тобто кожен може використовувати, змінювати або сприяти його розвитку. Будь-хто зі спільноти може створювати issues, надсилати pull request'и та розширювати функціональність.",
 

--- a/packages/console/app/src/i18n/zh.ts
+++ b/packages/console/app/src/i18n/zh.ts
@@ -179,7 +179,7 @@ export const dict = {
   "home.faq.q8": "OpenCode 是开源的吗？",
   "home.faq.a8.p1": "是的，OpenCode 是完全开源的。源代码公开在",
   "home.faq.a8.p2": "遵循",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License  许可证",
+  "home.faq.a8.mitLicense": "AGPL-3.0 许可证",
   "home.faq.a8.p3":
     "，这意味着任何人都可以使用、修改或为它的发展做贡献。社区中的任何人都可以提交 issue、提交 PR 并扩展功能。",
 

--- a/packages/console/app/src/i18n/zht.ts
+++ b/packages/console/app/src/i18n/zht.ts
@@ -180,7 +180,7 @@ export const dict = {
   "home.faq.q8": "OpenCode 是開源的嗎？",
   "home.faq.a8.p1": "是的，OpenCode 完全開源。原始碼公開在",
   "home.faq.a8.p2": "並採用",
-  "home.faq.a8.mitLicense": "PolyForm Noncommercial 1.0.0 License  授權條款",
+  "home.faq.a8.mitLicense": "AGPL-3.0 授權條款",
   "home.faq.a8.p3": "，意味著任何人都可以使用、修改或貢獻。社群中的任何人都可以提交 issue、pull requests 並擴充功能。",
 
   "home.zenCta.title": "存取可靠且最佳化的編碼代理模型",

--- a/packages/console/app/src/routes/download/index.tsx
+++ b/packages/console/app/src/routes/download/index.tsx
@@ -472,7 +472,7 @@ export default function Download() {
                 </a>{" "}
                 {i18n.t("home.faq.a8.p2")}{" "}
                 <a
-                  href={`${config.github.repoUrl}?tab=PolyForm Noncommercial 1.0.0 License -1-ov-file#readme`}
+                  href={`${config.github.repoUrl}?tab=AGPL-3.0-1-ov-file#readme`}
                   target="_blank"
                 >
                   {i18n.t("home.faq.a8.mitLicense")}

--- a/packages/console/app/src/routes/index.tsx
+++ b/packages/console/app/src/routes/index.tsx
@@ -719,7 +719,7 @@ export default function Home() {
                   </a>{" "}
                   {i18n.t("home.faq.a8.p2")}{" "}
                   <a
-                    href={`${config.github.repoUrl}?tab=PolyForm Noncommercial 1.0.0 License -1-ov-file#readme`}
+                    href={`${config.github.repoUrl}?tab=AGPL-3.0-1-ov-file#readme`}
                     target="_blank"
                   >
                     {i18n.t("home.faq.a8.mitLicense")}

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -4,7 +4,7 @@
   "version": "1.20.6",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "dependencies": {
     "@aws-sdk/client-sts": "3.782.0",
     "@jsx-email/render": "1.1.1",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -4,7 +4,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -18,5 +18,5 @@
     "dev": "email preview emails/templates"
   },
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License "
+  "license": "AGPL-3.0-only"
 }

--- a/packages/console/resource/package.json
+++ b/packages/console/resource/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-resource",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "dependencies": {
     "@cloudflare/workers-types": "catalog:"
   },

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/console-support",
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "sst shell --stage production -- vite dev"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "1.20.6",
   "name": "@opencode-ai/core",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "private": true,
   "scripts": {
     "db": "bun drizzle-kit",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "homepage": "https://opencode.ai",
   "author": {
     "name": "Bolt",

--- a/packages/desktop/scripts/copy-metainfo.ts
+++ b/packages/desktop/scripts/copy-metainfo.ts
@@ -12,7 +12,7 @@ const xml = `<?xml version="1.0" encoding="UTF-8"?>
   <id>${appId}</id>
 
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>PolyForm Noncommercial 1.0.0 License </project_license>
+  <project_license>AGPL-3.0-only</project_license>
 
   <name>${productName}</name>
   <summary>${summary}</summary>

--- a/packages/desktop/src/renderer/webview-zoom.ts
+++ b/packages/desktop/src/renderer/webview-zoom.ts
@@ -1,6 +1,6 @@
 // Copyright 2019-2024 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-License-Identifier: PolyForm Noncommercial 1.0.0 License
+// SPDX-License-Identifier: MIT
 
 import { createSignal } from "solid-js"
 

--- a/packages/docs/LICENSE
+++ b/packages/docs/LICENSE
@@ -1,4 +1,4 @@
-PolyForm Noncommercial 1.0.0 License  License
+MIT License
 
 Copyright (c) 2023 Mintlify
 

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -3,7 +3,7 @@
   "version": "1.20.6",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "private": true,
   "scripts": {
     "test": "bun test --timeout 30000 --only-failures",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -3,7 +3,7 @@
   "version": "1.20.6",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "private": true,
   "scripts": {
     "typecheck": "tsgo --noEmit"

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -3,7 +3,7 @@
   "version": "1.20.6",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "vite dev",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -4,7 +4,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
     "@tsconfig/node22": "22.0.2",

--- a/packages/http-recorder/LICENSE
+++ b/packages/http-recorder/LICENSE
@@ -1,4 +1,4 @@
-PolyForm Noncommercial 1.0.0 License  License
+MIT License
 
 Copyright (c) 2025 opencode
 

--- a/packages/http-recorder/README.md
+++ b/packages/http-recorder/README.md
@@ -214,4 +214,4 @@ Cassettes are readable JSON files intended to be committed with your tests. HTTP
 
 ## License
 
-PolyForm Noncommercial 1.0.0 License
+MIT

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -4,7 +4,7 @@
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",
-  "license": "AGPL-3.0-only",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Bolt-builder/bolt-cli/actions/workflows/publish.ym.git",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -4,7 +4,7 @@
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Bolt-builder/bolt-cli/actions/workflows/publish.ym.git",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -3,7 +3,7 @@
   "version": "1.20.6",
   "name": "@opencode-ai/llm",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "private": true,
   "scripts": {
     "setup:recording-env": "bun run script/setup-recording-env.ts",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/memory",
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "description": "Project memory storage, indexing, recall, and command helpers for Bolt",
   "keywords": [
     "bolt",

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/Bolt-builder/bolt-cli/actions/workflows/publish.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/Bolt-builder/bolt-cli/publish.yml?style=flat-square&branch=dev" /></a>
   <a href="https://www.npmjs.com/package/@bolt-builder/bolt-cli"><img alt="npm" src="https://img.shields.io/npm/v/@bolt-builder/bolt-cli?style=flat-square" /></a>
   <a href="https://github.com/Bolt-builder/bolt-cli"><img alt="GitHub stars" src="https://img.shields.io/github/stars/Bolt-builder/bolt-cli?style=flat-square" /></a>
-  <a href="LICENSE"><img alt="License: PolyForm Noncommercial 1.0.0" src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-blue?style=flat-square" /></a>
+  <a href="LICENSE"><img alt="License: AGPL-3.0" src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" /></a>
 </p>
 <p align="center">
   <a href="https://www.producthunt.com/products/bolt-cli?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-bolt-cli" target="_blank" rel="noopener noreferrer"><img alt="Bolt cli - Your terminal, now with a full AI engineering team inside it. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1211272&theme=light&t=1785541043666" /></a>
@@ -286,4 +286,4 @@ Consider giving it a star ⭐ — it helps other developers discover the project
 
 ## License
 
-PolyForm Noncommercial 1.0.0 License © [Bolt CLI](https://github.com/Bolt-builder/bolt-cli)
+AGPL-3.0 © [Bolt CLI](https://github.com/Bolt-builder/bolt-cli)

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -3,7 +3,7 @@
   "version": "1.20.6",
   "name": "@bolt-builder/bolt-cli",
   "type": "module",
-  "license": "PolyForm Licenese 1.0.0",
+  "license": "AGPL-3.0-only",
   "readme": "README.md",
   "private": false,
   "scripts": {

--- a/packages/opencode/src/util/proxy-env.ts
+++ b/packages/opencode/src/util/proxy-env.ts
@@ -1,7 +1,7 @@
 /*
  * Adapted from proxy-from-env: https://github.com/Rob--W/proxy-from-env
  *
- * The PolyForm Noncommercial 1.0.0 License  License
+ * The MIT License
  *
  * Copyright (C) 2016-2018 Rob Wu <rob@robwu.nl>
  *

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/plugin",
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "build": "tsc"

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/protocol",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "exports": {
     "./*": "./src/*.ts"
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/schema",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts"

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@opencode-ai/script",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "dependencies": {
     "semver": "^7.6.3"
   },

--- a/packages/sdk-next/package.json
+++ b/packages/sdk-next/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/sdk-next",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/sdk",
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "test": "bun test",
     "typecheck": "tsgo --noEmit",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,7 @@
   "version": "1.20.6",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "exports": {
     "./*": "./src/*.ts"
   },

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -3,7 +3,7 @@
   "version": "1.20.6",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "exports": {
     "./*": "./src/components/*.tsx",
     "./session-diff": "./src/components/session-diff.ts",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/slack",
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "dev": "bun run src/index.ts",
     "typecheck": "tsgo --noEmit"

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -4,7 +4,7 @@
   "version": "1.20.6",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "vite dev --host 0.0.0.0",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -4,7 +4,7 @@
   "version": "1.20.6",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "exports": {
     ".": "./src/index.ts",
     "./athena": "./src/athena.ts",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -4,7 +4,7 @@
   "version": "1.20.6",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "main": "./src/server.ts",
   "exports": {
     ".": "./src/server.ts"

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -4,7 +4,7 @@
   "version": "1.20.6",
   "private": true,
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "test": "bun test --timeout 30000 --only-failures",
     "typecheck": "tsgo --noEmit"

--- a/packages/ui/LICENSE
+++ b/packages/ui/LICENSE
@@ -1,4 +1,4 @@
-PolyForm Noncommercial 1.0.0 License  License
+MIT License
 
 Copyright (c) 2025 opencode
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/ui",
   "version": "1.20.6",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Bolt-builder/bolt-cli/actions/workflows/publish.ym.git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/web",
   "type": "module",
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "version": "1.20.6",
   "scripts": {
     "dev": "astro dev",

--- a/packages/web/src/content/docs/ar/skills.mdx
+++ b/packages/web/src/content/docs/ar/skills.mdx
@@ -79,7 +79,7 @@ description: "عرّف سلوكاً قابلاً لإعادة الاستخدام
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/bs/skills.mdx
+++ b/packages/web/src/content/docs/bs/skills.mdx
@@ -79,7 +79,7 @@ Kreirajte `.opencode/skills/git-release/SKILL.md` ovako:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/da/skills.mdx
+++ b/packages/web/src/content/docs/da/skills.mdx
@@ -79,7 +79,7 @@ Lag `.opencode/skills/git-release/SKILL.md` slik:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/de/skills.mdx
+++ b/packages/web/src/content/docs/de/skills.mdx
@@ -79,7 +79,7 @@ Erstelle `.opencode/skills/git-release/SKILL.md` zum Beispiel so:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/es/skills.mdx
+++ b/packages/web/src/content/docs/es/skills.mdx
@@ -79,7 +79,7 @@ Crea `.opencode/skills/git-release/SKILL.md` así:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/fr/skills.mdx
+++ b/packages/web/src/content/docs/fr/skills.mdx
@@ -79,7 +79,7 @@ Créez `.opencode/skills/git-release/SKILL.md` comme ceci :
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/it/skills.mdx
+++ b/packages/web/src/content/docs/it/skills.mdx
@@ -79,7 +79,7 @@ Crea `.opencode/skills/git-release/SKILL.md` cosi':
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/ja/skills.mdx
+++ b/packages/web/src/content/docs/ja/skills.mdx
@@ -79,7 +79,7 @@ OpenCode は次の場所を検索します。
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/ko/skills.mdx
+++ b/packages/web/src/content/docs/ko/skills.mdx
@@ -79,7 +79,7 @@ Project-local paths의 경우, opencode는 git worktree에 도달 할 때까지 
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/nb/skills.mdx
+++ b/packages/web/src/content/docs/nb/skills.mdx
@@ -79,7 +79,7 @@ Lag `.opencode/skills/git-release/SKILL.md` slik:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/pl/skills.mdx
+++ b/packages/web/src/content/docs/pl/skills.mdx
@@ -79,7 +79,7 @@ Utwórz `.opencode/skills/git-release/SKILL.md` w ten sposób:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/pt-br/skills.mdx
+++ b/packages/web/src/content/docs/pt-br/skills.mdx
@@ -79,7 +79,7 @@ Crie `.opencode/skills/git-release/SKILL.md` assim:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/ru/skills.mdx
+++ b/packages/web/src/content/docs/ru/skills.mdx
@@ -79,7 +79,7 @@ opencode выполняет поиск в следующих местах:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -79,7 +79,7 @@ Create `.opencode/skills/git-release/SKILL.md` like this:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/th/skills.mdx
+++ b/packages/web/src/content/docs/th/skills.mdx
@@ -79,7 +79,7 @@ regex ที่เทียบเท่า:
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/tr/skills.mdx
+++ b/packages/web/src/content/docs/tr/skills.mdx
@@ -79,7 +79,7 @@ Ajanin dogru secim yapmasi icin yeterince acik yazin.
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/zh-cn/skills.mdx
+++ b/packages/web/src/content/docs/zh-cn/skills.mdx
@@ -79,7 +79,7 @@ OpenCode 会搜索以下位置：
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/packages/web/src/content/docs/zh-tw/skills.mdx
+++ b/packages/web/src/content/docs/zh-tw/skills.mdx
@@ -79,7 +79,7 @@ OpenCode 會搜尋以下位置：
 ---
 name: git-release
 description: Create consistent releases and changelogs
-license: PolyForm Noncommercial 1.0.0 License
+license: MIT
 compatibility: opencode
 metadata:
   audience: maintainers

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/Bolt-builder/bolt-cli/actions/workflows/publish.ym"
   },
-  "license": "PolyForm Noncommercial 1.0.0 License ",
+  "license": "AGPL-3.0-only",
   "icon": "images/icon.png",
   "galleryBanner": {
     "color": "#000000",


### PR DESCRIPTION
Closes #174

PolyForm Noncommercial is source-available, not OSI-approved open source, which undercuts the project's open-source positioning and eligibility for programs like Claude for Open Source. This switches the project license to AGPL-3.0-only: still fully open source, but anyone hosting a modified version as a service must publish their changes.

The root `LICENSE` is now the verbatim GNU AGPL-3.0 text, and every first-party `package.json` declares the SPDX id:

```json
"license": "AGPL-3.0-only"
```

The switch also repairs damage from the earlier blind `MIT -> PolyForm` string replace, restoring third-party notices that must remain MIT: the Mintlify docs license, upstream opencode package licenses (`packages/ui`, `packages/http-recorder`), the vendored `proxy-from-env` header, the Tauri-derived SPDX header in `webview-zoom.ts`, and the vendored package under `packages/app/vendor/`. It also fixes the broken GitHub license-tab URLs in the console routes (`?tab=AGPL-3.0-1-ov-file`) and the doubled "License License" strings in the console i18n files.

Verification: `rg -i polyform` returns no matches outside lockfiles; the pre-push `bun typecheck` hook segfaults in the sandbox (no installed deps), so relying on CI for typecheck of these string-only changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project licensing information from PolyForm Noncommercial to AGPL-3.0.
  * Updated localized FAQ translations, license links, badges, and related documentation.
  * Updated example skill metadata to use the MIT license.

* **Chores**
  * Synchronized package and application metadata with the revised licensing terms.
  * Clarified MIT licensing for separately licensed components across the project.
  * Updated license references for bundled and supporting components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->