### PR TITLE
feat(vscode): harden terminal integration with settings and discovery

### DIFF
--- a/sdks/vscode/README.md
+++ b/sdks/vscode/README.md
@@ -14,11 +14,18 @@ The `bolt` CLI must be installed and on your PATH. See the [Bolt repository](htt
 
 ## Extension Settings
 
-This extension currently contributes no settings. Configuration for the CLI path and terminal behavior is planned.
+| Setting | Default | Description |
+| --- | --- | --- |
+| `bolt.path` | `""` | Path to the bolt CLI binary. Leave empty to look it up on your PATH. |
+| `bolt.args` | `[]` | Extra arguments appended when launching Bolt in the terminal. |
+| `bolt.terminal.reuse` | `true` | Focus an existing Bolt terminal instead of creating a new one when running Open Bolt. |
+
+In multi-root workspaces, opening Bolt asks which folder to run in and remembers your last choice. Diagnostics (binary resolution, terminal lifecycle) are written to the Bolt output channel; no file contents or prompt text are ever logged.
 
 ## Known Limitations
 
 - The file reference is typed into the Bolt terminal prompt; it is not sent while Bolt is busy generating a response.
+- Values in `bolt.args` are passed to the shell as-is; quote them yourself if they contain spaces.
 - Screenshots are not yet included in this README. TODO: add screenshots of the terminal integration.
 
 ## Publishing note

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -69,6 +69,29 @@
         }
       ]
     },
+    "configuration": {
+      "title": "Bolt",
+      "properties": {
+        "bolt.path": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the bolt CLI binary. Leave empty to look it up on your PATH."
+        },
+        "bolt.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Extra arguments appended when launching Bolt in the terminal."
+        },
+        "bolt.terminal.reuse": {
+          "type": "boolean",
+          "default": true,
+          "description": "Focus an existing Bolt terminal instead of creating a new one when running Open Bolt."
+        }
+      }
+    },
     "keybindings": [
       {
         "command": "bolt.openTerminal",

--- a/sdks/vscode/src/binary.ts
+++ b/sdks/vscode/src/binary.ts
@@ -1,0 +1,24 @@
+import { access, constants } from "node:fs/promises"
+import path from "node:path"
+
+// Resolves the bolt CLI binary. An explicit setting wins; otherwise the
+// directories in the given PATH string are searched in order.
+export async function locate(explicit: string, env: string) {
+  if (explicit) {
+    return (await executable(explicit)) ? explicit : undefined
+  }
+  const names = process.platform === "win32" ? ["bolt.exe", "bolt.cmd", "bolt.bat"] : ["bolt"]
+  const checks = env
+    .split(path.delimiter)
+    .filter(Boolean)
+    .flatMap((dir) => names.map((name) => path.join(dir, name)))
+  const results = await Promise.all(checks.map(async (file) => ((await executable(file)) ? file : undefined)))
+  return results.find((file) => file !== undefined)
+}
+
+function executable(file: string) {
+  return access(file, constants.X_OK).then(
+    () => true,
+    () => false,
+  )
+}

--- a/sdks/vscode/src/config.ts
+++ b/sdks/vscode/src/config.ts
@@ -1,8 +1,8 @@
-import * as vscode from "vscode"
+import { workspace } from "vscode"
 
 // Single place to read the bolt.* configuration with correct types.
 export function config() {
-  const cfg = vscode.workspace.getConfiguration("bolt")
+  const cfg = workspace.getConfiguration("bolt")
   return {
     path: cfg.get<string>("path", ""),
     args: cfg.get<string[]>("args", []),

--- a/sdks/vscode/src/config.ts
+++ b/sdks/vscode/src/config.ts
@@ -1,0 +1,11 @@
+import * as vscode from "vscode"
+
+// Single place to read the bolt.* configuration with correct types.
+export function config() {
+  const cfg = vscode.workspace.getConfiguration("bolt")
+  return {
+    path: cfg.get<string>("path", ""),
+    args: cfg.get<string[]>("args", []),
+    reuse: cfg.get<boolean>("terminal.reuse", true),
+  }
+}

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -1,23 +1,37 @@
 import * as vscode from "vscode"
-import { access, constants } from "node:fs/promises"
-import path from "node:path"
+import { locate } from "./binary"
+import { config } from "./config"
+import { display, reference } from "./format"
 
-const TERMINAL = "Bolt"
-const BINARY = "bolt"
 const DOCS = "https://github.com/bolt-builder/bolt-cli"
 
+const output = vscode.window.createOutputChannel("Bolt")
+
 export function activate(context: vscode.ExtensionContext) {
+  // Seed with terminals restored by VS Code across window reloads so reuse
+  // and filepath insertion keep targeting them.
+  const terminals: vscode.Terminal[] = vscode.window.terminals.filter((t) => /^Bolt( \(\d+\))?$/.test(t.name))
+
   context.subscriptions.push(
+    output,
+    vscode.window.onDidCloseTerminal((terminal) => {
+      const index = terminals.indexOf(terminal)
+      if (index === -1) {
+        return
+      }
+      terminals.splice(index, 1)
+      log(`terminal closed: ${terminal.name}`)
+    }),
     vscode.commands.registerCommand("bolt.openTerminal", async () => {
-      const existing = vscode.window.terminals.find((t) => t.name === TERMINAL)
-      if (existing) {
+      const existing = terminals.at(-1)
+      if (config().reuse && existing) {
         existing.show()
         return
       }
-      await launch(context)
+      await launch(context, terminals)
     }),
     vscode.commands.registerCommand("bolt.openNewTerminal", async () => {
-      await launch(context)
+      await launch(context, terminals)
     }),
     vscode.commands.registerCommand("bolt.addFilepathToTerminal", () => {
       const editor = vscode.window.activeTextEditor
@@ -25,50 +39,47 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage("Open a file to add its path to the Bolt terminal.")
         return
       }
-      const terminal = vscode.window.terminals.find((t) => t.name === TERMINAL)
+      const terminal = terminals.at(-1)
       if (!terminal) {
         vscode.window.showInformationMessage("No Bolt terminal is open. Run the Open Bolt command first.")
         return
       }
-      terminal.sendText(reference(editor) + " ", false)
+      terminal.sendText(active(editor) + " ", false)
       terminal.show()
     }),
   )
 }
 
-// Builds the file reference the Bolt TUI prompt understands: @path, with an
-// optional #start or #start-end line suffix when the editor has a selection.
-export function reference(editor: vscode.TextEditor) {
-  const uri = editor.document.uri
-  const inside = vscode.workspace.getWorkspaceFolder(uri) !== undefined
-  const file = inside ? vscode.workspace.asRelativePath(uri, false) : uri.fsPath
-  const selection = editor.selection
-  if (selection.isEmpty) {
-    return `@${file}`
-  }
-  const start = selection.start.line + 1
-  const end = selection.end.line + 1
-  if (start === end) {
-    return `@${file}#${start}`
-  }
-  return `@${file}#${start}-${end}`
-}
-
-async function launch(context: vscode.ExtensionContext) {
-  const found = await locate()
+async function launch(context: vscode.ExtensionContext, terminals: vscode.Terminal[]) {
+  const cfg = config()
+  const found = await locate(cfg.path, process.env["PATH"] ?? "")
+  log(`binary resolution: setting=${JSON.stringify(cfg.path)} resolved=${found ?? "not found"}`)
   if (!found) {
     const action = await vscode.window.showErrorMessage(
-      "The Bolt CLI was not found on your PATH. Install it and try again.",
+      cfg.path
+        ? "The bolt.path setting does not point to an executable Bolt CLI."
+        : "The Bolt CLI was not found on your PATH. Install it and try again.",
       "Open install docs",
+      "Open Settings",
     )
     if (action === "Open install docs") {
       vscode.env.openExternal(vscode.Uri.parse(DOCS))
     }
+    if (action === "Open Settings") {
+      vscode.commands.executeCommand("workbench.action.openSettings", "bolt.path")
+    }
+    return
+  }
+
+  const folders = vscode.workspace.workspaceFolders ?? []
+  const dir = folders.length > 1 ? await pick(context, folders) : folders[0]
+  if (folders.length > 1 && !dir) {
     return
   }
 
   const terminal = vscode.window.createTerminal({
-    name: TERMINAL,
+    name: terminals.length === 0 ? "Bolt" : `Bolt (${terminals.length + 1})`,
+    cwd: dir?.uri,
     iconPath: {
       light: vscode.Uri.file(context.asAbsolutePath("images/bolt-light.svg")),
       dark: vscode.Uri.file(context.asAbsolutePath("images/bolt-dark.svg")),
@@ -83,21 +94,39 @@ async function launch(context: vscode.ExtensionContext) {
       OPENCODE_CALLER: "vscode",
     },
   })
+  terminals.push(terminal)
+  log(`terminal opened: ${terminal.name} cwd=${dir?.uri.fsPath ?? "none"}`)
   terminal.show()
-  terminal.sendText(BINARY)
+  // Send the bare name when resolved via PATH so the shell handles quoting;
+  // an explicit setting is sent as-is and may need quoting by the user.
+  const command = cfg.path ? cfg.path : "bolt"
+  terminal.sendText([command, ...cfg.args].join(" "))
 }
 
-async function locate() {
-  const dirs = (process.env["PATH"] ?? "").split(path.delimiter).filter(Boolean)
-  const names = process.platform === "win32" ? [`${BINARY}.exe`, `${BINARY}.cmd`, `${BINARY}.bat`] : [BINARY]
-  const checks = dirs.flatMap((dir) => names.map((name) => path.join(dir, name)))
-  const results = await Promise.all(
-    checks.map((file) =>
-      access(file, constants.X_OK).then(
-        () => file,
-        () => undefined,
-      ),
-    ),
-  )
-  return results.find((file) => file !== undefined)
+async function pick(context: vscode.ExtensionContext, folders: readonly vscode.WorkspaceFolder[]) {
+  const last = context.workspaceState.get<string>("bolt.folder")
+  const items = folders
+    .map((folder) => ({ label: folder.name, description: folder.uri.fsPath, folder }))
+    .sort((a, b) => Number(b.folder.uri.toString() === last) - Number(a.folder.uri.toString() === last))
+  const item = await vscode.window.showQuickPick(items, { placeHolder: "Select the folder to run Bolt in" })
+  if (!item) {
+    return
+  }
+  await context.workspaceState.update("bolt.folder", item.folder.uri.toString())
+  return item.folder
+}
+
+function active(editor: vscode.TextEditor) {
+  const uri = editor.document.uri
+  const folder = vscode.workspace.getWorkspaceFolder(uri)
+  const file = display(uri.fsPath, folder?.uri.fsPath)
+  const selection = editor.selection
+  if (selection.isEmpty) {
+    return reference({ file })
+  }
+  return reference({ file, start: selection.start.line + 1, end: selection.end.line + 1 })
+}
+
+function log(text: string) {
+  output.appendLine(`${new Date().toISOString()} ${text}`)
 }

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -1,20 +1,20 @@
-import * as vscode from "vscode"
+import { commands, env, ExtensionContext, Terminal, TextEditor, Uri, ViewColumn, window, workspace, WorkspaceFolder } from "vscode"
 import { locate } from "./binary"
 import { config } from "./config"
 import { display, reference } from "./format"
 
 const DOCS = "https://github.com/bolt-builder/bolt-cli"
 
-const output = vscode.window.createOutputChannel("Bolt")
+const output = window.createOutputChannel("Bolt")
 
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: ExtensionContext) {
   // Seed with terminals restored by VS Code across window reloads so reuse
   // and filepath insertion keep targeting them.
-  const terminals: vscode.Terminal[] = vscode.window.terminals.filter((t) => /^Bolt( \(\d+\))?$/.test(t.name))
+  const terminals: Terminal[] = window.terminals.filter((t) => /^Bolt( \(\d+\))?$/.test(t.name))
 
   context.subscriptions.push(
     output,
-    vscode.window.onDidCloseTerminal((terminal) => {
+    window.onDidCloseTerminal((terminal) => {
       const index = terminals.indexOf(terminal)
       if (index === -1) {
         return
@@ -22,7 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
       terminals.splice(index, 1)
       log(`terminal closed: ${terminal.name}`)
     }),
-    vscode.commands.registerCommand("bolt.openTerminal", async () => {
+    commands.registerCommand("bolt.openTerminal", async () => {
       const existing = terminals.at(-1)
       if (config().reuse && existing) {
         existing.show()
@@ -30,62 +30,50 @@ export function activate(context: vscode.ExtensionContext) {
       }
       await launch(context, terminals)
     }),
-    vscode.commands.registerCommand("bolt.openNewTerminal", async () => {
+    commands.registerCommand("bolt.openNewTerminal", async () => {
       await launch(context, terminals)
     }),
-    vscode.commands.registerCommand("bolt.addFilepathToTerminal", () => {
-      const editor = vscode.window.activeTextEditor
+    commands.registerCommand("bolt.addFilepathToTerminal", () => {
+      const editor = window.activeTextEditor
       if (!editor) {
-        vscode.window.showInformationMessage("Open a file to add its path to the Bolt terminal.")
+        window.showInformationMessage("Open a file to add its path to the Bolt terminal.")
         return
       }
       const terminal = terminals.at(-1)
       if (!terminal) {
-        vscode.window.showInformationMessage("No Bolt terminal is open. Run the Open Bolt command first.")
+        window.showInformationMessage("No Bolt terminal is open. Run the Open Bolt command first.")
         return
       }
-      terminal.sendText(active(editor) + " ", false)
+      terminal.sendText(`${active(editor)} `, false)
       terminal.show()
     }),
   )
 }
 
-async function launch(context: vscode.ExtensionContext, terminals: vscode.Terminal[]) {
+async function launch(context: ExtensionContext, terminals: Terminal[]) {
   const cfg = config()
   const found = await locate(cfg.path, process.env["PATH"] ?? "")
   log(`binary resolution: setting=${JSON.stringify(cfg.path)} resolved=${found ?? "not found"}`)
   if (!found) {
-    const action = await vscode.window.showErrorMessage(
-      cfg.path
-        ? "The bolt.path setting does not point to an executable Bolt CLI."
-        : "The Bolt CLI was not found on your PATH. Install it and try again.",
-      "Open install docs",
-      "Open Settings",
-    )
-    if (action === "Open install docs") {
-      vscode.env.openExternal(vscode.Uri.parse(DOCS))
-    }
-    if (action === "Open Settings") {
-      vscode.commands.executeCommand("workbench.action.openSettings", "bolt.path")
-    }
+    await missing(cfg.path)
     return
   }
 
-  const folders = vscode.workspace.workspaceFolders ?? []
+  const folders = workspace.workspaceFolders ?? []
   const dir = folders.length > 1 ? await pick(context, folders) : folders[0]
   if (folders.length > 1 && !dir) {
     return
   }
 
-  const terminal = vscode.window.createTerminal({
+  const terminal = window.createTerminal({
     name: terminals.length === 0 ? "Bolt" : `Bolt (${terminals.length + 1})`,
     cwd: dir?.uri,
     iconPath: {
-      light: vscode.Uri.file(context.asAbsolutePath("images/bolt-light.svg")),
-      dark: vscode.Uri.file(context.asAbsolutePath("images/bolt-dark.svg")),
+      light: Uri.file(context.asAbsolutePath("images/bolt-light.svg")),
+      dark: Uri.file(context.asAbsolutePath("images/bolt-dark.svg")),
     },
     location: {
-      viewColumn: vscode.ViewColumn.Beside,
+      viewColumn: ViewColumn.Beside,
       preserveFocus: false,
     },
     env: {
@@ -103,22 +91,40 @@ async function launch(context: vscode.ExtensionContext, terminals: vscode.Termin
   terminal.sendText([command, ...cfg.args].join(" "))
 }
 
-async function pick(context: vscode.ExtensionContext, folders: readonly vscode.WorkspaceFolder[]) {
+// Tells the user the CLI could not be resolved and offers the docs or the
+// bolt.path setting as fixes.
+async function missing(explicit: string) {
+  const action = await window.showErrorMessage(
+    explicit
+      ? "The bolt.path setting does not point to an executable Bolt CLI."
+      : "The Bolt CLI was not found on your PATH. Install it and try again.",
+    "Open install docs",
+    "Open Settings",
+  )
+  if (action === "Open install docs") {
+    env.openExternal(Uri.parse(DOCS))
+  }
+  if (action === "Open Settings") {
+    commands.executeCommand("workbench.action.openSettings", "bolt.path")
+  }
+}
+
+async function pick(context: ExtensionContext, folders: readonly WorkspaceFolder[]) {
   const last = context.workspaceState.get<string>("bolt.folder")
   const items = folders
     .map((folder) => ({ label: folder.name, description: folder.uri.fsPath, folder }))
     .sort((a, b) => Number(b.folder.uri.toString() === last) - Number(a.folder.uri.toString() === last))
-  const item = await vscode.window.showQuickPick(items, { placeHolder: "Select the folder to run Bolt in" })
+  const item = await window.showQuickPick(items, { placeHolder: "Select the folder to run Bolt in" })
   if (!item) {
-    return
+    return undefined
   }
   await context.workspaceState.update("bolt.folder", item.folder.uri.toString())
   return item.folder
 }
 
-function active(editor: vscode.TextEditor) {
+function active(editor: TextEditor) {
   const uri = editor.document.uri
-  const folder = vscode.workspace.getWorkspaceFolder(uri)
+  const folder = workspace.getWorkspaceFolder(uri)
   const file = display(uri.fsPath, folder?.uri.fsPath)
   const selection = editor.selection
   if (selection.isEmpty) {

--- a/sdks/vscode/src/format.ts
+++ b/sdks/vscode/src/format.ts
@@ -1,0 +1,27 @@
+import path from "node:path"
+
+// Returns the path to show in a file reference: workspace-relative when the
+// file is inside the given root, absolute otherwise, always forward-slashed
+// to match how the Bolt TUI normalizes mention paths.
+export function display(file: string, root?: string) {
+  if (!root) {
+    return file.split(path.sep).join("/")
+  }
+  const relative = path.relative(root, file)
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return file.split(path.sep).join("/")
+  }
+  return relative.split(path.sep).join("/")
+}
+
+// Builds the file reference the Bolt TUI prompt understands: @path, with an
+// optional #start or #start-end line suffix (1-based, digits only).
+export function reference(input: { file: string; start?: number; end?: number }) {
+  if (input.start === undefined) {
+    return `@${input.file}`
+  }
+  if (input.end === undefined || input.end === input.start) {
+    return `@${input.file}#${input.start}`
+  }
+  return `@${input.file}#${input.start}-${input.end}`
+}

--- a/sdks/vscode/src/test/binary.test.ts
+++ b/sdks/vscode/src/test/binary.test.ts
@@ -1,0 +1,56 @@
+import * as assert from "node:assert"
+import { chmod, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { locate } from "../binary"
+
+const windows = process.platform === "win32"
+
+async function fake(name: string) {
+  const dir = await mkdtemp(path.join(tmpdir(), "bolt-test-"))
+  const file = path.join(dir, name)
+  await writeFile(file, "#!/bin/sh\n")
+  await chmod(file, 0o755)
+  return { dir, file }
+}
+
+suite("binary", function () {
+  test("finds the binary on PATH", async () => {
+    if (windows) {
+      return
+    }
+    const { dir, file } = await fake("bolt")
+    assert.strictEqual(await locate("", dir), file)
+  })
+
+  test("searches PATH directories in order", async () => {
+    if (windows) {
+      return
+    }
+    const first = await fake("bolt")
+    const second = await fake("bolt")
+    assert.strictEqual(await locate("", [first.dir, second.dir].join(path.delimiter)), first.file)
+  })
+
+  test("explicit setting wins over PATH", async () => {
+    if (windows) {
+      return
+    }
+    const onPath = await fake("bolt")
+    const explicit = await fake("bolt")
+    assert.strictEqual(await locate(explicit.file, onPath.dir), explicit.file)
+  })
+
+  test("invalid explicit setting resolves to nothing", async () => {
+    if (windows) {
+      return
+    }
+    const { dir } = await fake("bolt")
+    assert.strictEqual(await locate(path.join(dir, "missing"), dir), undefined)
+  })
+
+  test("missing binary resolves to nothing", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "bolt-empty-"))
+    assert.strictEqual(await locate("", dir), undefined)
+  })
+})

--- a/sdks/vscode/src/test/binary.test.ts
+++ b/sdks/vscode/src/test/binary.test.ts
@@ -1,4 +1,4 @@
-import * as assert from "node:assert"
+import { strictEqual } from "node:assert"
 import { chmod, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
@@ -20,7 +20,7 @@ suite("binary", function () {
       return
     }
     const { dir, file } = await fake("bolt")
-    assert.strictEqual(await locate("", dir), file)
+    strictEqual(await locate("", dir), file)
   })
 
   test("searches PATH directories in order", async () => {
@@ -29,7 +29,7 @@ suite("binary", function () {
     }
     const first = await fake("bolt")
     const second = await fake("bolt")
-    assert.strictEqual(await locate("", [first.dir, second.dir].join(path.delimiter)), first.file)
+    strictEqual(await locate("", [first.dir, second.dir].join(path.delimiter)), first.file)
   })
 
   test("explicit setting wins over PATH", async () => {
@@ -38,7 +38,7 @@ suite("binary", function () {
     }
     const onPath = await fake("bolt")
     const explicit = await fake("bolt")
-    assert.strictEqual(await locate(explicit.file, onPath.dir), explicit.file)
+    strictEqual(await locate(explicit.file, onPath.dir), explicit.file)
   })
 
   test("invalid explicit setting resolves to nothing", async () => {
@@ -46,11 +46,11 @@ suite("binary", function () {
       return
     }
     const { dir } = await fake("bolt")
-    assert.strictEqual(await locate(path.join(dir, "missing"), dir), undefined)
+    strictEqual(await locate(path.join(dir, "missing"), dir), undefined)
   })
 
   test("missing binary resolves to nothing", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "bolt-empty-"))
-    assert.strictEqual(await locate("", dir), undefined)
+    strictEqual(await locate("", dir), undefined)
   })
 })

--- a/sdks/vscode/src/test/extension.test.ts
+++ b/sdks/vscode/src/test/extension.test.ts
@@ -1,0 +1,19 @@
+import * as assert from "node:assert"
+import * as vscode from "vscode"
+
+suite("extension", () => {
+  test("registers every bolt command", async () => {
+    await vscode.extensions.getExtension("bolt-builder.bolt-vscode")?.activate()
+    const commands = await vscode.commands.getCommands(true)
+    for (const id of ["bolt.openTerminal", "bolt.openNewTerminal", "bolt.addFilepathToTerminal"]) {
+      assert.ok(commands.includes(id), `missing command ${id}`)
+    }
+  })
+
+  test("settings have the documented defaults", () => {
+    const cfg = vscode.workspace.getConfiguration("bolt")
+    assert.strictEqual(cfg.get("path"), "")
+    assert.deepStrictEqual(cfg.get("args"), [])
+    assert.strictEqual(cfg.get("terminal.reuse"), true)
+  })
+})

--- a/sdks/vscode/src/test/extension.test.ts
+++ b/sdks/vscode/src/test/extension.test.ts
@@ -1,19 +1,19 @@
-import * as assert from "node:assert"
-import * as vscode from "vscode"
+import { deepStrictEqual, ok, strictEqual } from "node:assert"
+import { commands, extensions, workspace } from "vscode"
 
 suite("extension", () => {
   test("registers every bolt command", async () => {
-    await vscode.extensions.getExtension("bolt-builder.bolt-vscode")?.activate()
-    const commands = await vscode.commands.getCommands(true)
+    await extensions.getExtension("bolt-builder.bolt-vscode")?.activate()
+    const registered = await commands.getCommands(true)
     for (const id of ["bolt.openTerminal", "bolt.openNewTerminal", "bolt.addFilepathToTerminal"]) {
-      assert.ok(commands.includes(id), `missing command ${id}`)
+      ok(registered.includes(id), `missing command ${id}`)
     }
   })
 
   test("settings have the documented defaults", () => {
-    const cfg = vscode.workspace.getConfiguration("bolt")
-    assert.strictEqual(cfg.get("path"), "")
-    assert.deepStrictEqual(cfg.get("args"), [])
-    assert.strictEqual(cfg.get("terminal.reuse"), true)
+    const cfg = workspace.getConfiguration("bolt")
+    strictEqual(cfg.get("path"), "")
+    deepStrictEqual(cfg.get("args"), [])
+    strictEqual(cfg.get("terminal.reuse"), true)
   })
 })

--- a/sdks/vscode/src/test/format.test.ts
+++ b/sdks/vscode/src/test/format.test.ts
@@ -1,0 +1,30 @@
+import * as assert from "node:assert"
+import { display, reference } from "../format"
+
+suite("format", () => {
+  test("reference without lines", () => {
+    assert.strictEqual(reference({ file: "src/extension.ts" }), "@src/extension.ts")
+  })
+
+  test("reference with a single line", () => {
+    assert.strictEqual(reference({ file: "src/extension.ts", start: 12 }), "@src/extension.ts#12")
+    assert.strictEqual(reference({ file: "src/extension.ts", start: 12, end: 12 }), "@src/extension.ts#12")
+  })
+
+  test("reference with a range", () => {
+    assert.strictEqual(reference({ file: "src/extension.ts", start: 12, end: 40 }), "@src/extension.ts#12-40")
+  })
+
+  test("display is relative inside the root", () => {
+    assert.strictEqual(display("/work/repo/src/a.ts", "/work/repo"), "src/a.ts")
+  })
+
+  test("display is absolute outside the root", () => {
+    assert.strictEqual(display("/elsewhere/a.ts", "/work/repo"), "/elsewhere/a.ts")
+    assert.strictEqual(display("/work/repo-sibling/a.ts", "/work/repo"), "/work/repo-sibling/a.ts")
+  })
+
+  test("display is absolute without a root", () => {
+    assert.strictEqual(display("/work/a.ts"), "/work/a.ts")
+  })
+})

--- a/sdks/vscode/src/test/format.test.ts
+++ b/sdks/vscode/src/test/format.test.ts
@@ -1,30 +1,30 @@
-import * as assert from "node:assert"
+import { strictEqual } from "node:assert"
 import { display, reference } from "../format"
 
 suite("format", () => {
   test("reference without lines", () => {
-    assert.strictEqual(reference({ file: "src/extension.ts" }), "@src/extension.ts")
+    strictEqual(reference({ file: "src/extension.ts" }), "@src/extension.ts")
   })
 
   test("reference with a single line", () => {
-    assert.strictEqual(reference({ file: "src/extension.ts", start: 12 }), "@src/extension.ts#12")
-    assert.strictEqual(reference({ file: "src/extension.ts", start: 12, end: 12 }), "@src/extension.ts#12")
+    strictEqual(reference({ file: "src/extension.ts", start: 12 }), "@src/extension.ts#12")
+    strictEqual(reference({ file: "src/extension.ts", start: 12, end: 12 }), "@src/extension.ts#12")
   })
 
   test("reference with a range", () => {
-    assert.strictEqual(reference({ file: "src/extension.ts", start: 12, end: 40 }), "@src/extension.ts#12-40")
+    strictEqual(reference({ file: "src/extension.ts", start: 12, end: 40 }), "@src/extension.ts#12-40")
   })
 
   test("display is relative inside the root", () => {
-    assert.strictEqual(display("/work/repo/src/a.ts", "/work/repo"), "src/a.ts")
+    strictEqual(display("/work/repo/src/a.ts", "/work/repo"), "src/a.ts")
   })
 
   test("display is absolute outside the root", () => {
-    assert.strictEqual(display("/elsewhere/a.ts", "/work/repo"), "/elsewhere/a.ts")
-    assert.strictEqual(display("/work/repo-sibling/a.ts", "/work/repo"), "/work/repo-sibling/a.ts")
+    strictEqual(display("/elsewhere/a.ts", "/work/repo"), "/elsewhere/a.ts")
+    strictEqual(display("/work/repo-sibling/a.ts", "/work/repo"), "/work/repo-sibling/a.ts")
   })
 
   test("display is absolute without a root", () => {
-    assert.strictEqual(display("/work/a.ts"), "/work/a.ts")
+    strictEqual(display("/work/a.ts"), "/work/a.ts")
   })
 })


### PR DESCRIPTION
**Stacked PR**: this branch is cut from `vscode-rebrand` (#177) because it builds directly on the rebranded extension. It targets that branch; retarget to `dev` once #177 merges.

### Issue for this PR

Closes #178

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Phase 2 of the Bolt extension work: makes the terminal integration configurable, observable, and correct in multi-root workspaces.

- New settings under the `bolt` section: `bolt.path` (explicit binary path, empty means PATH lookup), `bolt.args` (extra launch args), `bolt.terminal.reuse` (whether Open Bolt focuses an existing terminal). Reads live in one typed `config()` accessor (`src/config.ts`) instead of scattered `getConfiguration` calls.
- Binary discovery moved to `src/binary.ts` with the order: explicit setting, then PATH directories in order (with `.exe`/`.cmd`/`.bat` candidates on Windows):

```ts
export async function locate(explicit: string, env: string) {
  if (explicit) {
    return (await executable(explicit)) ? explicit : undefined
  }
  const names = process.platform === "win32" ? ["bolt.exe", "bolt.cmd", "bolt.bat"] : ["bolt"]
  const checks = env
    .split(path.delimiter)
    .filter(Boolean)
    .flatMap((dir) => names.map((name) => path.join(dir, name)))
  const results = await Promise.all(checks.map(async (file) => ((await executable(file)) ? file : undefined)))
  return results.find((file) => file !== undefined)
}
```

  On failure the user gets one notification with "Open install docs" and "Open Settings" (filtered to `bolt.path`) buttons; details go to the output channel, never a raw ENOENT.
- A `Bolt` output channel logs binary resolution and terminal lifecycle with ISO timestamps. No file contents or prompt text are logged.
- Multi-root workspaces: Open Bolt shows a quick pick (last choice remembered in `workspaceState` and sorted first); single-folder windows never see a picker. The chosen folder becomes the terminal cwd.
- Terminal lifecycle: created terminals are tracked, pruned on `onDidCloseTerminal`, seeded from restored terminals after window reload, and named "Bolt", "Bolt (2)", etc. Filepath insertion targets the most recent live Bolt terminal.
- File reference formatting lives in pure, exported `display()`/`reference()` functions (`src/format.ts`): workspace-relative inside the workspace, absolute outside, forward-slashed, `#start` / `#start-end` suffix for selections, matching the TUI's `extractLineRange` grammar.

### How did you verify your code works?

From `sdks/vscode`: `bun run check-types`, `bun run lint` (both clean), and the full integration suite in a real VS Code extension host via `xvfb-run -a bun run test`: 13 passing (command registration, settings defaults, discovery order with fake executables in temp dirs, invalid explicit path, and all formatting cases). No mocks; tests exercise the real `locate` and format implementations. `vsce package` still produces a clean `.vsix`.

### Screenshots / recordings

Headless environment; no display beyond xvfb for the test host, so no screenshots. Settings render from the `contributes.configuration` descriptions above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->