### PR TITLE
feat(vscode): add sidebar chat MVP

### DIFF
--- a/sdks/vscode/.gitignore
+++ b/sdks/vscode/.gitignore
@@ -1,1 +1,3 @@
 dist
+out
+.vscode-test

--- a/sdks/vscode/README.md
+++ b/sdks/vscode/README.md
@@ -7,6 +7,8 @@ Run the [Bolt](https://github.com/bolt-builder/bolt-cli) AI coding agent inside 
 - **Open Bolt** (`Cmd+Esc` on Mac, `Ctrl+Esc` on Windows/Linux): opens Bolt in a split terminal, or focuses the existing Bolt terminal if one is already running.
 - **Open Bolt in a new tab** (`Cmd+Shift+Esc` / `Ctrl+Shift+Esc`, or the Bolt button in the editor title bar): always starts a fresh Bolt terminal.
 - **Add Filepath to Terminal** (`Cmd+Alt+K` / `Ctrl+Alt+K`): inserts a reference to the active file into the Bolt prompt, for example `@src/extension.ts#12-40` when lines 12 to 40 are selected.
+- **Sidebar chat**: a Bolt icon in the activity bar opens a chat that talks to a Bolt server. The extension starts `bolt serve` for your workspace automatically, or attaches to the server configured in `bolt.server.url`. Responses stream in live, Stop interrupts mid-stream, and the transcript survives hiding the sidebar.
+- **Add Filepath to Bolt Chat** (editor context menu): inserts the same file reference into the sidebar chat input.
 
 ## Requirements
 
@@ -19,6 +21,7 @@ The `bolt` CLI must be installed and on your PATH. See the [Bolt repository](htt
 | `bolt.path` | `""` | Path to the bolt CLI binary. Leave empty to look it up on your PATH. |
 | `bolt.args` | `[]` | Extra arguments appended when launching Bolt in the terminal. |
 | `bolt.terminal.reuse` | `true` | Focus an existing Bolt terminal instead of creating a new one when running Open Bolt. |
+| `bolt.server.url` | `""` | URL of a running Bolt server for the sidebar chat. Leave empty to let the extension start one. |
 
 In multi-root workspaces, opening Bolt asks which folder to run in and remembers your last choice. Diagnostics (binary resolution, terminal lifecycle) are written to the Bolt output channel; no file contents or prompt text are ever logged.
 
@@ -26,7 +29,9 @@ In multi-root workspaces, opening Bolt asks which folder to run in and remembers
 
 - The file reference is typed into the Bolt terminal prompt; it is not sent while Bolt is busy generating a response.
 - Values in `bolt.args` are passed to the shell as-is; quote them yourself if they contain spaces.
-- Screenshots are not yet included in this README. TODO: add screenshots of the terminal integration.
+- The sidebar chat renders only fenced code blocks and inline code; other markdown is shown as plain text.
+- The sidebar authenticates with the private credential the CLI keeps in its state directory; attaching to a remote `bolt.server.url` that uses a different password is not supported yet.
+- Screenshots are not yet included in this README. TODO: add screenshots of the terminal integration and the sidebar.
 
 ## Publishing note
 

--- a/sdks/vscode/esbuild.js
+++ b/sdks/vscode/esbuild.js
@@ -40,11 +40,26 @@ async function main() {
       esbuildProblemMatcherPlugin,
     ],
   })
+  const webview = await esbuild.context({
+    entryPoints: ["src/webview/main.ts"],
+    bundle: true,
+    format: "iife",
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: "browser",
+    outfile: "dist/webview.js",
+    logLevel: "silent",
+    plugins: [esbuildProblemMatcherPlugin],
+  })
   if (watch) {
     await ctx.watch()
+    await webview.watch()
   } else {
     await ctx.rebuild()
+    await webview.rebuild()
     await ctx.dispose()
+    await webview.dispose()
   }
 }
 

--- a/sdks/vscode/images/bolt-mono.svg
+++ b/sdks/vscode/images/bolt-mono.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="#424242"/></svg>

--- a/sdks/vscode/media/webview.css
+++ b/sdks/vscode/media/webview.css
@@ -1,0 +1,142 @@
+html,
+body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  color: var(--vscode-foreground);
+  background: var(--vscode-sideBar-background);
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+#status {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--vscode-sideBarSectionHeader-border, transparent);
+  color: var(--vscode-descriptionForeground);
+}
+
+#backend.connected {
+  color: var(--vscode-testing-iconPassed, var(--vscode-descriptionForeground));
+}
+
+#backend.error {
+  color: var(--vscode-errorForeground);
+}
+
+#streaming {
+  font-style: italic;
+}
+
+#messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bubble {
+  max-width: 100%;
+  padding: 6px 10px;
+  border-radius: 6px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.bubble.user {
+  align-self: flex-end;
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, transparent);
+}
+
+.bubble.assistant {
+  align-self: flex-start;
+  background: var(--vscode-editorWidget-background);
+  border: 1px solid var(--vscode-editorWidget-border, transparent);
+}
+
+.error {
+  color: var(--vscode-errorForeground);
+  padding: 2px 10px;
+}
+
+pre {
+  background: var(--vscode-textCodeBlock-background);
+  padding: 8px;
+  border-radius: 4px;
+  overflow-x: auto;
+  margin: 6px 0;
+}
+
+code {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: var(--vscode-editor-font-size);
+  background: var(--vscode-textCodeBlock-background);
+  border-radius: 3px;
+  padding: 0 3px;
+}
+
+pre code {
+  padding: 0;
+  background: transparent;
+}
+
+#composer {
+  border-top: 1px solid var(--vscode-sideBarSectionHeader-border, transparent);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#input {
+  resize: vertical;
+  color: var(--vscode-input-foreground);
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, transparent);
+  border-radius: 4px;
+  padding: 6px;
+  font-family: var(--vscode-font-family);
+}
+
+#input:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+}
+
+#actions {
+  display: flex;
+  gap: 6px;
+}
+
+button {
+  color: var(--vscode-button-foreground);
+  background: var(--vscode-button-background);
+  border: none;
+  border-radius: 4px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--vscode-button-hoverBackground);
+}
+
+#stop,
+#new {
+  color: var(--vscode-button-secondaryForeground);
+  background: var(--vscode-button-secondaryBackground);
+}
+
+#stop:hover,
+#new:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -59,13 +59,43 @@
       {
         "command": "bolt.addFilepathToTerminal",
         "title": "Add Filepath to Terminal"
+      },
+      {
+        "command": "bolt.addFilepathToChat",
+        "title": "Add Filepath to Bolt Chat"
       }
     ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "bolt",
+          "title": "Bolt",
+          "icon": "images/bolt-mono.svg"
+        }
+      ]
+    },
+    "views": {
+      "bolt": [
+        {
+          "type": "webview",
+          "id": "bolt.chat",
+          "name": "Chat",
+          "icon": "images/bolt-mono.svg",
+          "contextualTitle": "Bolt"
+        }
+      ]
+    },
     "menus": {
       "editor/title": [
         {
           "command": "bolt.openNewTerminal",
           "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "bolt.addFilepathToChat",
+          "group": "bolt"
         }
       ]
     },
@@ -89,6 +119,11 @@
           "type": "boolean",
           "default": true,
           "description": "Focus an existing Bolt terminal instead of creating a new one when running Open Bolt."
+        },
+        "bolt.server.url": {
+          "type": "string",
+          "default": "",
+          "description": "URL of a running Bolt server for the sidebar chat. Leave empty to let the extension start one."
         }
       }
     },

--- a/sdks/vscode/src/backend.ts
+++ b/sdks/vscode/src/backend.ts
@@ -1,0 +1,143 @@
+import { spawn } from "node:child_process"
+import { readFile } from "node:fs/promises"
+import { createInterface } from "node:readline"
+import os from "node:os"
+import path from "node:path"
+
+// Manages the Bolt server the sidebar talks to: attaches to bolt.server.url
+// when set, otherwise spawns `bolt serve` for the window and parses the
+// listening address from its stdout. At most one child per window; at most
+// two automatic restarts after unexpected exits.
+
+export type Connection = { url: string; password?: string }
+
+export type Child = {
+  onLine: (handler: (line: string) => void) => void
+  onExit: (handler: () => void) => void
+  kill: () => void
+}
+
+export type Spawner = (binary: string, cwd: string | undefined) => Child
+
+export class Backend {
+  private child: Child | undefined
+  private starting: Promise<Connection | undefined> | undefined
+  private connection: Connection | undefined
+  private restarts = 0
+  private disposed = false
+
+  constructor(
+    private input: {
+      url: () => string
+      binary: () => Promise<string | undefined>
+      spawn: Spawner
+      log: (text: string) => void
+      onExit: (fatal: boolean) => void
+    },
+  ) {}
+
+  // Resolves the connection, spawning the server when needed. Concurrent
+  // callers share one startup so a window never spawns two servers.
+  start(cwd?: string): Promise<Connection | undefined> {
+    if (this.connection) {
+      return Promise.resolve(this.connection)
+    }
+    if (!this.starting) {
+      this.starting = this.connect(cwd).finally(() => {
+        this.starting = undefined
+      })
+    }
+    return this.starting
+  }
+
+  dispose() {
+    this.disposed = true
+    this.child?.kill()
+    this.child = undefined
+    this.connection = undefined
+  }
+
+  private async connect(cwd?: string): Promise<Connection | undefined> {
+    const url = this.input.url()
+    if (url) {
+      this.input.log(`attaching to configured server url ${url}`)
+      this.connection = { url, password: await password() }
+      return this.connection
+    }
+
+    const binary = await this.input.binary()
+    if (!binary) {
+      return undefined
+    }
+
+    this.input.log(`spawning ${binary} serve`)
+    const child = this.input.spawn(binary, cwd)
+    this.child = child
+
+    const listening = await new Promise<string | undefined>((resolve) => {
+      const timeout = setTimeout(() => resolve(undefined), 30_000)
+      child.onLine((line) => {
+        this.input.log(`serve: ${line}`)
+        const match = line.match(/server listening on (\S+)/)
+        if (match) {
+          clearTimeout(timeout)
+          resolve(match[1])
+        }
+      })
+      child.onExit(() => {
+        clearTimeout(timeout)
+        resolve(undefined)
+        this.exited()
+      })
+    })
+
+    if (!listening) {
+      this.input.log("server did not report a listening address")
+      return undefined
+    }
+    this.connection = { url: listening, password: await password() }
+    this.input.log(`server ready at ${listening}`)
+    return this.connection
+  }
+
+  private exited() {
+    if (this.disposed) {
+      return
+    }
+    this.child = undefined
+    this.connection = undefined
+    this.input.log(`server exited unexpectedly (restarts so far: ${this.restarts})`)
+    if (this.restarts >= 2) {
+      this.input.onExit(true)
+      return
+    }
+    this.restarts++
+    this.input.onExit(false)
+  }
+}
+
+// The serve command authenticates with the private credential the CLI keeps
+// in its state directory; read it so the sidebar can send the same Basic
+// auth header the CLI's own clients use.
+async function password() {
+  const state = process.env["XDG_STATE_HOME"] ?? path.join(os.homedir(), ".local", "state")
+  return readFile(path.join(state, "opencode", "password"), "utf8").then(
+    (value) => value.trim(),
+    () => undefined,
+  )
+}
+
+// Real child process spawner used outside tests.
+export function spawner(log: (text: string) => void): Spawner {
+  return (binary, cwd) => {
+    const child = spawn(binary, ["serve"], { cwd, stdio: ["ignore", "pipe", "pipe"] })
+    const lines = createInterface({ input: child.stdout })
+    const errors = createInterface({ input: child.stderr })
+    errors.on("line", (line) => log(`serve stderr: ${line}`))
+    return {
+      onLine: (handler) => lines.on("line", handler),
+      onExit: (handler) => child.on("exit", () => handler()),
+      kill: () => child.kill(),
+    }
+  }
+}

--- a/sdks/vscode/src/chat.ts
+++ b/sdks/vscode/src/chat.ts
@@ -1,0 +1,244 @@
+import * as vscode from "vscode"
+import { randomBytes } from "node:crypto"
+import { Backend } from "./backend"
+import { client, Event } from "./client"
+import { Down, Message, State, up } from "./protocol"
+import { append } from "./transcript"
+
+// Sidebar chat: bridges the webview to the Bolt server through the typed
+// message protocol. The host owns the transcript (persisted in
+// workspaceState) and the session; the webview only renders chat text and
+// status.
+
+export class Chat implements vscode.WebviewViewProvider {
+  static readonly id = "bolt.chat"
+
+  private view: vscode.WebviewView | undefined
+  private state: State = { backend: "starting", streaming: false }
+  private session: string | undefined
+  private api: ReturnType<typeof client> | undefined
+  private abort: AbortController | undefined
+  private pending: string | undefined
+
+  constructor(
+    private context: vscode.ExtensionContext,
+    private backend: Backend,
+    private log: (text: string) => void,
+  ) {
+    this.session = context.workspaceState.get("bolt.session")
+  }
+
+  resolveWebviewView(view: vscode.WebviewView) {
+    this.view = view
+    view.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [
+        vscode.Uri.joinPath(this.context.extensionUri, "dist"),
+        vscode.Uri.joinPath(this.context.extensionUri, "media"),
+      ],
+    }
+    view.webview.html = this.html(view.webview)
+    view.webview.onDidReceiveMessage((raw) => this.receive(raw))
+    view.onDidDispose(() => {
+      if (this.view === view) {
+        this.view = undefined
+      }
+    })
+  }
+
+  // Inserts text into the webview input, holding it until the webview has
+  // signalled readiness when the view is still opening.
+  insert(text: string) {
+    if (!this.view) {
+      this.pending = this.pending ? this.pending + text : text
+      return
+    }
+    this.post({ v: 1, type: "insert", text })
+  }
+
+  dispose() {
+    this.abort?.abort()
+  }
+
+  private async receive(raw: unknown) {
+    const message = up(raw)
+    if (!message) {
+      this.log(`dropped malformed webview message`)
+      return
+    }
+    if (message.type === "ready") {
+      this.hydrate()
+      if (this.pending) {
+        this.post({ v: 1, type: "insert", text: this.pending })
+        this.pending = undefined
+      }
+      return
+    }
+    if (message.type === "prompt") {
+      await this.prompt(message.text)
+      return
+    }
+    if (message.type === "stop") {
+      if (this.api && this.session) {
+        await this.api.interrupt(this.session).catch((error) => this.fail("interrupt", error))
+      }
+      return
+    }
+    this.abort?.abort()
+    this.abort = undefined
+    this.session = undefined
+    await this.context.workspaceState.update("bolt.session", undefined)
+    await this.context.workspaceState.update("bolt.transcript", undefined)
+    await this.context.workspaceState.update("bolt.seq", undefined)
+    this.update({ streaming: false })
+    this.hydrate()
+  }
+
+  private async prompt(text: string) {
+    const connected = await this.connect()
+    if (!connected || !this.api) {
+      return
+    }
+    await this.save({ role: "user", text })
+    try {
+      if (!this.session) {
+        const folders = vscode.workspace.workspaceFolders ?? []
+        this.session = (await this.api.create()).id
+        await this.context.workspaceState.update("bolt.session", this.session)
+        this.log(`created session ${this.session} (folders: ${folders.length})`)
+      }
+      this.subscribe()
+      await this.api.prompt(this.session, text)
+      this.update({ streaming: true })
+    } catch (error) {
+      this.fail("prompt", error)
+    }
+  }
+
+  private async connect() {
+    const folder = vscode.workspace.workspaceFolders?.[0]
+    this.update({ backend: "starting" })
+    const connection = await this.backend.start(folder?.uri.fsPath)
+    if (!connection) {
+      this.update({ backend: "error" })
+      this.post({ v: 1, type: "error", message: "The Bolt server could not be started. Check the Bolt output channel." })
+      return false
+    }
+    this.api = client(connection.url, connection.password)
+    try {
+      await this.api.health()
+    } catch (error) {
+      this.fail("health check", error)
+      return false
+    }
+    this.update({ backend: "connected" })
+    return true
+  }
+
+  // (Re)subscribes to the session event stream from the last durable
+  // sequence so history is not replayed into the transcript.
+  private subscribe() {
+    if (this.abort || !this.api || !this.session) {
+      return
+    }
+    const abort = new AbortController()
+    this.abort = abort
+    const after = this.context.workspaceState.get<number>("bolt.seq")
+    this.api
+      .events(this.session, after, abort.signal, (event) => this.event(event))
+      .catch((error) => {
+        if (!abort.signal.aborted) {
+          this.fail("event stream", error)
+        }
+      })
+      .finally(() => {
+        if (this.abort === abort) {
+          this.abort = undefined
+        }
+      })
+  }
+
+  private event(event: Event) {
+    if (event.durable) {
+      this.context.workspaceState.update("bolt.seq", event.durable.seq)
+    }
+    if (event.type === "session.next.step.started") {
+      const model = event.data["model"] as { id: string; providerID: string } | undefined
+      this.update({ streaming: true, model: model ? `${model.providerID}/${model.id}` : this.state.model })
+      return
+    }
+    if (event.type === "session.next.text.delta") {
+      this.post({ v: 1, type: "token", text: String(event.data["delta"] ?? "") })
+      return
+    }
+    if (event.type === "session.next.text.ended") {
+      this.save({ role: "assistant", text: String(event.data["text"] ?? "") })
+      return
+    }
+    if (event.type === "session.next.step.ended") {
+      this.update({ streaming: false })
+      return
+    }
+    if (event.type === "session.next.step.failed") {
+      this.update({ streaming: false })
+      this.post({ v: 1, type: "error", message: "The agent step failed. Check the Bolt output channel." })
+      this.log(`step failed: ${JSON.stringify(event.data["error"])}`)
+    }
+  }
+
+  private hydrate() {
+    this.post({ v: 1, type: "hydrate", messages: this.transcript(), state: this.state })
+  }
+
+  private transcript() {
+    return this.context.workspaceState.get<Message[]>("bolt.transcript") ?? []
+  }
+
+  private async save(message: Message) {
+    await this.context.workspaceState.update("bolt.transcript", append(this.transcript(), message))
+  }
+
+  private update(patch: Partial<State>) {
+    this.state = { ...this.state, ...patch }
+    this.post({ v: 1, type: "state", state: this.state })
+  }
+
+  private fail(operation: string, error: unknown) {
+    this.log(`${operation} failed: ${error instanceof Error ? error.message : String(error)}`)
+    this.update({ backend: "error", streaming: false })
+    this.post({ v: 1, type: "error", message: `The ${operation} request failed. Check the Bolt output channel.` })
+  }
+
+  private post(message: Down) {
+    this.view?.webview.postMessage(message)
+  }
+
+  private html(webview: vscode.Webview) {
+    const nonce = randomBytes(16).toString("base64")
+    const script = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "dist", "webview.js"))
+    const style = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "media", "webview.css"))
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="${style}">
+<title>Bolt</title>
+</head>
+<body>
+<div id="status"><span id="backend"></span><span id="model"></span><span id="streaming" hidden>streaming</span></div>
+<div id="messages"></div>
+<div id="composer">
+<textarea id="input" rows="3" placeholder="Ask Bolt (Enter to send, Shift+Enter for a new line)"></textarea>
+<div id="actions">
+<button id="send">Send</button>
+<button id="stop" hidden>Stop</button>
+<button id="new">New session</button>
+</div>
+</div>
+<script nonce="${nonce}" src="${script}"></script>
+</body>
+</html>`
+  }
+}

--- a/sdks/vscode/src/client.ts
+++ b/sdks/vscode/src/client.ts
@@ -1,0 +1,88 @@
+// Minimal stopgap client for the Bolt server HTTP API.
+//
+// The repo's SDK packages (@opencode-ai/sdk and @opencode-ai/client) resolve
+// their dependencies through the root workspace catalog and workspace:
+// protocols, which this standalone extension package (own lockfile, not a
+// workspace member) cannot consume; the generated Effect client would also
+// pull the whole effect runtime into the extension bundle. Replace this
+// module with the published SDK once one exists. It implements exactly what
+// the sidebar needs: health, session create, prompt, interrupt, and the
+// session event stream.
+
+export type Event = {
+  id: string
+  type: string
+  data: Record<string, unknown>
+  durable?: { aggregateID: string; seq: number; version: number }
+}
+
+export function client(base: string, password?: string) {
+  const auth: Record<string, string> = password
+    ? { Authorization: `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}` }
+    : {}
+
+  async function request(method: string, route: string, body?: unknown) {
+    const response = await fetch(new URL(route, base), {
+      method,
+      headers: body === undefined ? auth : { ...auth, "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    })
+    if (!response.ok) {
+      throw new Error(`${method} ${route} failed with status ${response.status}`)
+    }
+    if (response.status === 204) {
+      return undefined
+    }
+    return response.json()
+  }
+
+  return {
+    health: () => request("GET", "/api/health"),
+
+    create: async () => {
+      const result = (await request("POST", "/api/session", {})) as { data: { id: string } }
+      return result.data
+    },
+
+    prompt: (session: string, text: string) =>
+      request("POST", `/api/session/${session}/prompt`, { prompt: { text } }),
+
+    interrupt: (session: string) => request("POST", `/api/session/${session}/interrupt`),
+
+    // Subscribes to the session's SSE event stream and invokes the handler
+    // for every event until the stream ends or the signal aborts.
+    events: async (session: string, after: number | undefined, signal: AbortSignal, handler: (event: Event) => void) => {
+      const url = new URL(`/api/session/${session}/event`, base)
+      if (after !== undefined) {
+        url.searchParams.set("after", String(after))
+      }
+      const response = await fetch(url, { headers: { ...auth, Accept: "text/event-stream" }, signal })
+      if (!response.ok || !response.body) {
+        throw new Error(`event stream failed with status ${response.status}`)
+      }
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ""
+      while (true) {
+        const chunk = await reader.read()
+        if (chunk.done) {
+          return
+        }
+        buffer += decoder.decode(chunk.value, { stream: true })
+        const blocks = buffer.split("\n\n")
+        buffer = blocks.pop() ?? ""
+        for (const block of blocks) {
+          const data = block
+            .split("\n")
+            .filter((line) => line.startsWith("data:"))
+            .map((line) => line.slice(5).trimStart())
+            .join("\n")
+          if (!data) {
+            continue
+          }
+          handler(JSON.parse(data) as Event)
+        }
+      }
+    },
+  }
+}

--- a/sdks/vscode/src/config.ts
+++ b/sdks/vscode/src/config.ts
@@ -7,5 +7,6 @@ export function config() {
     path: cfg.get<string>("path", ""),
     args: cfg.get<string[]>("args", []),
     reuse: cfg.get<boolean>("terminal.reuse", true),
+    server: cfg.get<string>("server.url", ""),
   }
 }

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -1,5 +1,7 @@
 import { commands, env, ExtensionContext, Terminal, TextEditor, Uri, ViewColumn, window, workspace, WorkspaceFolder } from "vscode"
+import { Backend, spawner } from "./backend"
 import { locate } from "./binary"
+import { Chat } from "./chat"
 import { config } from "./config"
 import { display, reference } from "./format"
 
@@ -12,8 +14,33 @@ export function activate(context: ExtensionContext) {
   // and filepath insertion keep targeting them.
   const terminals: Terminal[] = window.terminals.filter((t) => /^Bolt( \(\d+\))?$/.test(t.name))
 
+  const backend = new Backend({
+    url: () => config().server,
+    binary: () => locate(config().path, process.env["PATH"] ?? ""),
+    spawn: spawner(log),
+    log,
+    onExit: (fatal) => {
+      if (fatal) {
+        window.showErrorMessage("The Bolt server keeps exiting. Check the Bolt output channel for details.")
+      }
+    },
+  })
+  const chat = new Chat(context, backend, log)
+
   context.subscriptions.push(
     output,
+    backend,
+    chat,
+    window.registerWebviewViewProvider(Chat.id, chat),
+    commands.registerCommand("bolt.addFilepathToChat", async () => {
+      const editor = window.activeTextEditor
+      if (!editor) {
+        window.showInformationMessage("Open a file to add its path to the Bolt chat.")
+        return
+      }
+      chat.insert(`${active(editor)} `)
+      await commands.executeCommand("bolt.chat.focus")
+    }),
     window.onDidCloseTerminal((terminal) => {
       const index = terminals.indexOf(terminal)
       if (index === -1) {

--- a/sdks/vscode/src/protocol.ts
+++ b/sdks/vscode/src/protocol.ts
@@ -1,0 +1,55 @@
+// Typed message protocol between the extension host and the chat webview.
+// Every message carries v: 1 so future shape changes are detectable on both
+// sides. Upward messages travel webview to host, downward messages host to
+// webview.
+
+export type Up =
+  | { v: 1; type: "ready" }
+  | { v: 1; type: "prompt"; text: string }
+  | { v: 1; type: "stop" }
+  | { v: 1; type: "newSession" }
+
+export type State = {
+  backend: "starting" | "connected" | "error"
+  streaming: boolean
+  model?: string
+}
+
+export type Message = { role: "user" | "assistant"; text: string }
+
+export type Down =
+  | { v: 1; type: "token"; text: string }
+  | { v: 1; type: "state"; state: State }
+  | { v: 1; type: "error"; message: string }
+  | { v: 1; type: "hydrate"; messages: Message[]; state: State }
+  | { v: 1; type: "insert"; text: string }
+
+// Narrows an untrusted value posted by the webview to an upward message.
+export function up(value: unknown): Up | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined
+  }
+  const record = value as Record<string, unknown>
+  if (record["v"] !== 1) {
+    return undefined
+  }
+  if (record["type"] === "ready" || record["type"] === "stop" || record["type"] === "newSession") {
+    return { v: 1, type: record["type"] }
+  }
+  if (record["type"] === "prompt" && typeof record["text"] === "string") {
+    return { v: 1, type: "prompt", text: record["text"] }
+  }
+  return undefined
+}
+
+// Narrows an untrusted value posted by the host to a downward message.
+export function down(value: unknown): Down | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined
+  }
+  const record = value as Record<string, unknown>
+  if (record["v"] !== 1 || typeof record["type"] !== "string") {
+    return undefined
+  }
+  return value as Down
+}

--- a/sdks/vscode/src/test/backend.test.ts
+++ b/sdks/vscode/src/test/backend.test.ts
@@ -1,0 +1,65 @@
+import * as assert from "node:assert"
+import { Backend } from "../backend"
+
+suite("backend", () => {
+  test("a configured server url short-circuits spawning", async () => {
+    const spawned: string[] = []
+    const backend = new Backend({
+      url: () => "http://127.0.0.1:4242",
+      binary: async () => "/nowhere/bolt",
+      spawn: (binary) => {
+        spawned.push(binary)
+        return { onLine: () => {}, onExit: () => {}, kill: () => {} }
+      },
+      log: () => {},
+      onExit: () => {},
+    })
+    const connection = await backend.start()
+    assert.strictEqual(connection?.url, "http://127.0.0.1:4242")
+    assert.deepStrictEqual(spawned, [])
+    backend.dispose()
+  })
+
+  test("an unresolved binary yields no connection", async () => {
+    const backend = new Backend({
+      url: () => "",
+      binary: async () => undefined,
+      spawn: () => {
+        throw new Error("must not spawn")
+      },
+      log: () => {},
+      onExit: () => {},
+    })
+    assert.strictEqual(await backend.start(), undefined)
+    backend.dispose()
+  })
+
+  test("parses the listening address from server output", async () => {
+    let emit: ((line: string) => void) | undefined
+    const backend = new Backend({
+      url: () => "",
+      binary: async () => "/fake/bolt",
+      spawn: () => ({
+        onLine: (handler) => {
+          emit = handler
+        },
+        onExit: () => {},
+        kill: () => {},
+      }),
+      log: () => {},
+      onExit: () => {},
+    })
+    const starting = backend.start("/tmp")
+    // The line handler is registered after a few microtasks (binary
+    // resolution is async); drain them until the fake child is wired up.
+    for (let i = 0; i < 100 && !emit; i++) {
+      await Promise.resolve()
+    }
+    assert.ok(emit, "spawner was not invoked")
+    emit?.("some startup noise")
+    emit?.("server listening on http://127.0.0.1:5150")
+    const connection = await starting
+    assert.strictEqual(connection?.url, "http://127.0.0.1:5150")
+    backend.dispose()
+  })
+})

--- a/sdks/vscode/src/test/extension.test.ts
+++ b/sdks/vscode/src/test/extension.test.ts
@@ -5,9 +5,16 @@ suite("extension", () => {
   test("registers every bolt command", async () => {
     await extensions.getExtension("bolt-builder.bolt-vscode")?.activate()
     const registered = await commands.getCommands(true)
-    for (const id of ["bolt.openTerminal", "bolt.openNewTerminal", "bolt.addFilepathToTerminal"]) {
+    for (const id of ["bolt.openTerminal", "bolt.openNewTerminal", "bolt.addFilepathToTerminal", "bolt.addFilepathToChat"]) {
       ok(registered.includes(id), `missing command ${id}`)
     }
+  })
+
+  test("the chat view is registered", async () => {
+    await extensions.getExtension("bolt-builder.bolt-vscode")?.activate()
+    // Focusing the contributed view resolves the webview provider; it throws
+    // when the view id is not registered.
+    await commands.executeCommand("bolt.chat.focus")
   })
 
   test("settings have the documented defaults", () => {

--- a/sdks/vscode/src/test/protocol.test.ts
+++ b/sdks/vscode/src/test/protocol.test.ts
@@ -1,0 +1,24 @@
+import * as assert from "node:assert"
+import { up } from "../protocol"
+
+suite("protocol", () => {
+  test("accepts well formed upward messages", () => {
+    assert.deepStrictEqual(up({ v: 1, type: "ready" }), { v: 1, type: "ready" })
+    assert.deepStrictEqual(up({ v: 1, type: "stop" }), { v: 1, type: "stop" })
+    assert.deepStrictEqual(up({ v: 1, type: "newSession" }), { v: 1, type: "newSession" })
+    assert.deepStrictEqual(up({ v: 1, type: "prompt", text: "hi" }), { v: 1, type: "prompt", text: "hi" })
+  })
+
+  test("rejects unknown versions", () => {
+    assert.strictEqual(up({ v: 2, type: "ready" }), undefined)
+    assert.strictEqual(up({ type: "ready" }), undefined)
+  })
+
+  test("rejects malformed messages", () => {
+    assert.strictEqual(up(undefined), undefined)
+    assert.strictEqual(up("prompt"), undefined)
+    assert.strictEqual(up({ v: 1, type: "prompt" }), undefined)
+    assert.strictEqual(up({ v: 1, type: "prompt", text: 42 }), undefined)
+    assert.strictEqual(up({ v: 1, type: "unknown" }), undefined)
+  })
+})

--- a/sdks/vscode/src/test/transcript.test.ts
+++ b/sdks/vscode/src/test/transcript.test.ts
@@ -1,0 +1,22 @@
+import * as assert from "node:assert"
+import type { Message } from "../protocol"
+import { append, CAP } from "../transcript"
+
+suite("transcript", () => {
+  test("appends messages in order", () => {
+    const one = append([], { role: "user", text: "a" })
+    const two = append(one, { role: "assistant", text: "b" })
+    assert.deepStrictEqual(
+      two.map((message) => message.text),
+      ["a", "b"],
+    )
+  })
+
+  test("caps the transcript at the newest messages", () => {
+    const full = Array.from({ length: CAP }, (_, index): Message => ({ role: "user", text: String(index) }))
+    const result = append(full, { role: "assistant", text: "newest" })
+    assert.strictEqual(result.length, CAP)
+    assert.strictEqual(result.at(-1)?.text, "newest")
+    assert.strictEqual(result[0]?.text, "1")
+  })
+})

--- a/sdks/vscode/src/transcript.ts
+++ b/sdks/vscode/src/transcript.ts
@@ -1,0 +1,8 @@
+import type { Message } from "./protocol"
+
+// The persisted chat transcript is capped so workspaceState stays small.
+export const CAP = 50
+
+export function append(messages: readonly Message[], message: Message) {
+  return [...messages, message].slice(-CAP)
+}

--- a/sdks/vscode/src/webview/main.ts
+++ b/sdks/vscode/src/webview/main.ts
@@ -1,0 +1,140 @@
+import { Down, Message, State, Up } from "../protocol"
+
+declare function acquireVsCodeApi(): { postMessage: (message: Up) => void }
+
+const vscode = acquireVsCodeApi()
+
+const messages = element("messages")
+const input = element("input") as HTMLTextAreaElement
+const send = element("send") as HTMLButtonElement
+const stop = element("stop") as HTMLButtonElement
+const fresh = element("new") as HTMLButtonElement
+const backend = element("backend")
+const model = element("model")
+const streaming = element("streaming")
+
+let bubble: HTMLElement | undefined
+let streamed = ""
+let follow = true
+
+window.addEventListener("message", (event: MessageEvent<Down>) => {
+  const message = event.data
+  if (message.type === "hydrate") {
+    messages.textContent = ""
+    bubble = undefined
+    streamed = ""
+    message.messages.forEach(add)
+    state(message.state)
+    scroll()
+    return
+  }
+  if (message.type === "token") {
+    streamed += message.text
+    if (!bubble) {
+      bubble = add({ role: "assistant", text: "" })
+    }
+    render(streamed, bubble)
+    scroll()
+    return
+  }
+  if (message.type === "state") {
+    state(message.state)
+    return
+  }
+  if (message.type === "error") {
+    const item = document.createElement("div")
+    item.className = "error"
+    item.textContent = message.message
+    messages.appendChild(item)
+    scroll()
+    return
+  }
+  input.value = input.value + message.text
+  input.focus()
+})
+
+messages.addEventListener("scroll", () => {
+  follow = messages.scrollTop + messages.clientHeight >= messages.scrollHeight - 8
+})
+
+input.addEventListener("keydown", (event) => {
+  if (event.key === "Enter" && !event.shiftKey) {
+    event.preventDefault()
+    submit()
+  }
+})
+send.addEventListener("click", submit)
+stop.addEventListener("click", () => vscode.postMessage({ v: 1, type: "stop" }))
+fresh.addEventListener("click", () => vscode.postMessage({ v: 1, type: "newSession" }))
+
+vscode.postMessage({ v: 1, type: "ready" })
+
+function submit() {
+  const text = input.value.trim()
+  if (!text) {
+    return
+  }
+  input.value = ""
+  add({ role: "user", text })
+  scroll()
+  vscode.postMessage({ v: 1, type: "prompt", text })
+}
+
+function add(message: Message) {
+  const item = document.createElement("div")
+  item.className = `bubble ${message.role}`
+  render(message.text, item)
+  messages.appendChild(item)
+  return item
+}
+
+function state(next: State) {
+  backend.textContent = next.backend
+  backend.className = next.backend
+  model.textContent = next.model ?? ""
+  streaming.hidden = !next.streaming
+  stop.hidden = !next.streaming
+  if (!next.streaming) {
+    bubble = undefined
+    streamed = ""
+  }
+}
+
+// Minimal markdown: fenced code blocks and inline code, everything built
+// from text nodes so assistant output is never parsed as HTML.
+function render(text: string, parent: HTMLElement) {
+  parent.textContent = ""
+  text.split("```").forEach((part, index) => {
+    if (index % 2 === 1) {
+      const pre = document.createElement("pre")
+      const code = document.createElement("code")
+      code.textContent = part.replace(/^[\w-]*\n/, "")
+      pre.appendChild(code)
+      parent.appendChild(pre)
+      return
+    }
+    part.split(/`([^`\n]+)`/).forEach((piece, position) => {
+      if (position % 2 === 1) {
+        const code = document.createElement("code")
+        code.textContent = piece
+        parent.appendChild(code)
+        return
+      }
+      parent.appendChild(document.createTextNode(piece))
+    })
+  })
+}
+
+function scroll() {
+  if (follow) {
+    messages.scrollTop = messages.scrollHeight
+  }
+}
+
+function element(id: string) {
+  const found = document.getElementById(id)
+  if (!found) {
+    throw new Error(`missing element ${id}`)
+  }
+  return found
+}

--- a/sdks/vscode/tsconfig.json
+++ b/sdks/vscode/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "Node16",
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": true,
     "rootDir": "src",
     "typeRoots": ["./node_modules/@types"],


### PR DESCRIPTION
**Stacked PR**: cut from `vscode-terminal` (#179), which is itself stacked on `vscode-rebrand` (#177). It targets #179; retarget as the stack merges.

### Issue for this PR

Closes #180

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

First sidebar experience for the Bolt extension: an activity bar icon opens a chat webview that starts (or attaches to) a Bolt server, creates a session, sends prompts, and streams responses.

- **Backend** (`src/backend.ts`): attaches to `bolt.server.url` when set, otherwise spawns `bolt serve` for the workspace folder and parses `server listening on <url>` from stdout (the exact line `packages/cli/src/commands/handlers/serve.ts` prints). One child per window (concurrent starts share a promise), at most two automatic restarts on unexpected exit, then an error notification; killed on deactivate. Auth reuses the private credential the CLI keeps in its state directory (the same file `Daemon.password()` maintains), sent as the Basic header `ServerAuth.headers` expects.
- **Client** (`src/client.ts`): a deliberately minimal stopgap (about 90 lines): health, session create, prompt, interrupt, and the session SSE event stream (`/api/session/:id/event`). The repo's SDK packages were evaluated first per plan: `@opencode-ai/client` is private with `workspace:*` deps and an effect peer, `@opencode-ai/sdk` exports TS sources with `catalog:` deps; both resolve through the root workspace, which this standalone extension package (own lockfile, deliberately not a workspace member) cannot consume, and the effect runtime would dominate the extension bundle. Marked clearly for replacement once a published SDK exists.
- **Protocol** (`src/protocol.ts`): one typed, versioned message union shared by host and webview:

```ts
export type Up =
  | { v: 1; type: "ready" }
  | { v: 1; type: "prompt"; text: string }
  | { v: 1; type: "stop" }
  | { v: 1; type: "newSession" }

export type Down =
  | { v: 1; type: "token"; text: string }
  | { v: 1; type: "state"; state: State }
  | { v: 1; type: "error"; message: string }
  | { v: 1; type: "hydrate"; messages: Message[]; state: State }
  | { v: 1; type: "insert"; text: string }
```

  (`ready` and `insert` extend the planned set: `ready` removes the host/webview startup race, `insert` carries the context command's file reference into the input box.)
- **Webview**: plain TypeScript compiled by the existing esbuild setup into a separate `dist/webview.js` (browser/iife) plus one `media/webview.css`. Strict CSP (`default-src 'none'`, nonce'd script, styles from the extension URI only), `retainContextWhenHidden` left false; the transcript persists in `workspaceState` capped at 50 messages and rehydrates on resolve. UI: user/assistant bubbles, minimal markdown (fenced and inline code only, built exclusively from `textContent` nodes, no HTML parsing of model output), Enter to send / Shift+Enter newline, Stop while streaming, New session, and a status row (backend state plus model from `step.started` events). Auto-scroll disengages when the user scrolls up. Colors are `--vscode-*` variables only.
- **Streaming**: the host subscribes to durable session events after the last stored sequence (so history is not replayed into the transcript), forwards `text.delta` as tokens, finalizes messages on `text.ended`, and flips streaming state on `step.started`/`step.ended`/`step.failed`. Stop posts `/interrupt`.
- **Context command**: `bolt.addFilepathToChat` (editor context menu) reuses Phase 2's pure `reference()` formatting and inserts into the chat input, held until the webview is ready when the view is still opening.
- The extension host never reads or sends file contents; the server owns all file access. No new runtime dependencies, no telemetry, no network calls except to the user's own server.

### How did you verify your code works?

From `sdks/vscode`: `bun run check-types`, `bun run lint`, production esbuild, all clean; `bunx @vscode/vsce package` produces a clean 12-file `.vsix`. 22 integration/unit tests pass in a real extension host via `xvfb-run -a bun run test`, including new suites for the protocol guards, the transcript cap, backend URL short-circuit (injected fake spawner, no mock library), listening-address parsing, and chat view registration (`bolt.chat.focus`). A live end-to-end run against a real `bolt serve` was not possible: the sandbox has a 4GB disk and the root `bun install` fails with NoSpaceLeft, so the CLI could not be built locally. The client was written against the protocol definitions in `packages/protocol/src/groups/session.ts` and the SSE encoding in `packages/server`; please give the sidebar one manual smoke test with a real CLI before release.

### Screenshots / recordings

Headless environment (xvfb only, no CLI binary available); no screenshots. The webview uses theme variables exclusively, so light/dark/high-contrast follow the active theme.

### Checklist

- [x] I have tested my changes locally (extension-scoped checks and extension host tests; see verification notes)
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->