### PR TITLE
fix(bolt): keep sessions fast after repeated compactions

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -157,7 +157,7 @@ export const Info = Schema.Struct({
         description: "Enable automatic compaction when context is full (default: true)",
       }),
       prune: Schema.optional(Schema.Boolean).annotate({
-        description: "Enable pruning of old tool outputs (default: false)",
+        description: "Enable pruning of old tool outputs (default: true)",
       }),
       tail_turns: Schema.optional(NonNegativeInt).annotate({
         description:

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -242,7 +242,7 @@ const layer = Layer.effect(
     // calls, then erases output of older tool calls to free context space
     const prune = Effect.fn("SessionCompaction.prune")(function* (input: { sessionID: SessionID }) {
       const cfg = yield* config.get()
-      if (!cfg.compaction?.prune) return
+      if (cfg.compaction?.prune === false) return
       yield* Effect.logInfo("pruning")
 
       const msgs = yield* session
@@ -326,9 +326,17 @@ const layer = Layer.effect(
       }
 
       const agent = yield* agents.get("compaction")
+      // Summarize with the provider's small/fast model when possible so the
+      // hidden compaction request does not cost a full slow-model turn. Only
+      // use it when its context window fits at least as much as the session
+      // model's; an explicit compaction agent model always wins.
+      const base = yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID).pipe(Effect.orDie)
+      const small = agent.model ? undefined : yield* provider.getSmallModel(userMessage.model.providerID)
       const model = agent.model
         ? yield* provider.getModel(agent.model.providerID, agent.model.modelID).pipe(Effect.orDie)
-        : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID).pipe(Effect.orDie)
+        : small && small.limit.context >= base.limit.context
+          ? small
+          : base
       const cfg = yield* config.get()
       const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
       const prior = completedCompactions(history)

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -805,6 +805,129 @@ describe("session.compaction.prune", () => {
       }),
     ),
   )
+
+  const seedPrunable = (dir: string) =>
+    Effect.gen(function* () {
+      const ssn = yield* SessionNs.Service
+      const info = yield* ssn.create({})
+      const a = yield* ssn.updateMessage({
+        id: MessageID.ascending(),
+        role: "user",
+        sessionID: info.id,
+        agent: "build",
+        model: ref,
+        time: { created: Date.now() },
+      })
+      yield* ssn.updatePart({
+        id: PartID.ascending(),
+        messageID: a.id,
+        sessionID: info.id,
+        type: "text",
+        text: "first",
+      })
+      const b: SessionV1.Assistant = {
+        id: MessageID.ascending(),
+        role: "assistant",
+        sessionID: info.id,
+        mode: "build",
+        agent: "build",
+        path: { cwd: dir, root: dir },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        parentID: a.id,
+        time: { created: Date.now() },
+        finish: "end_turn",
+      }
+      yield* ssn.updateMessage(b)
+      yield* ssn.updatePart({
+        id: PartID.ascending(),
+        messageID: b.id,
+        sessionID: info.id,
+        type: "tool",
+        callID: crypto.randomUUID(),
+        tool: "bash",
+        state: {
+          status: "completed",
+          input: {},
+          output: "x".repeat(200_000),
+          title: "done",
+          metadata: {},
+          time: { start: Date.now(), end: Date.now() },
+        },
+      })
+      for (const text of ["second", "third"]) {
+        const msg = yield* ssn.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: info.id,
+          agent: "build",
+          model: ref,
+          time: { created: Date.now() },
+        })
+        yield* ssn.updatePart({
+          id: PartID.ascending(),
+          messageID: msg.id,
+          sessionID: info.id,
+          type: "text",
+          text,
+        })
+      }
+      return info.id
+    })
+
+  it.live(
+    "prunes by default without config",
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const compact = yield* SessionCompaction.Service
+        const ssn = yield* SessionNs.Service
+        const sessionID = yield* seedPrunable(dir)
+
+        yield* compact.prune({ sessionID })
+
+        const msgs = yield* ssn.messages({ sessionID })
+        const part = msgs.flatMap((msg) => msg.parts).find((part) => part.type === "tool")
+        expect(part?.type).toBe("tool")
+        expect(part?.state.status).toBe("completed")
+        if (part?.type === "tool" && part.state.status === "completed") {
+          expect(part.state.time.compacted).toBeNumber()
+        }
+      }),
+    ),
+  )
+
+  it.live(
+    "skips pruning when disabled via config",
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const compact = yield* SessionCompaction.Service
+          const ssn = yield* SessionNs.Service
+          const sessionID = yield* seedPrunable(dir)
+
+          yield* compact.prune({ sessionID })
+
+          const msgs = yield* ssn.messages({ sessionID })
+          const part = msgs.flatMap((msg) => msg.parts).find((part) => part.type === "tool")
+          expect(part?.type).toBe("tool")
+          if (part?.type === "tool" && part.state.status === "completed") {
+            expect(part.state.time.compacted).toBeUndefined()
+          }
+        }),
+      {
+        config: {
+          compaction: { prune: false },
+        },
+      },
+    ),
+  )
 })
 
 describe("session.compaction.process", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #184

### Type of change

- [x] Bug fix

### What does this PR do?

Sessions get noticeably slower after a few auto-compactions: each compaction is a full-context summarization request that runs synchronously in the prompt loop using the session's main model, and because tool-output pruning is off by default, heavy agent sessions climb back to the context ceiling within a few turns and re-trigger compaction over and over. Two changes attack the frequency and the cost of that hidden request:

1. `compaction.prune` now defaults to on (opt out with `compaction.prune: false`), so old tool outputs decay between compactions and full compactions become rare. Prune already runs forked off the critical path.

2. The compaction summarize step defaults to the provider's small/fast model, the same `Provider.getSmallModel` mechanism title generation already uses. It is guarded so it only applies when the small model's context window is at least as large as the session model's, and an explicit `agent.compaction.model` config always wins:

```ts
const model = agent.model
  ? yield* provider.getModel(agent.model.providerID, agent.model.modelID).pipe(Effect.orDie)
  : yield* Effect.gen(function* () {
      const base = yield* provider
        .getModel(userMessage.model.providerID, userMessage.model.modelID)
        .pipe(Effect.orDie)
      const small = yield* provider.getSmallModel(userMessage.model.providerID)
      return small && small.limit.context >= base.limit.context ? small : base
    })
```

Providers without a small-model family (and the `test` provider in CI) fall back to the session model, so behavior there is unchanged. A follow-up for pre-emptive background compaction is noted in #184.

### How did you verify your code works?

Added two tests in `packages/opencode/test/session/compaction.test.ts`: prune runs with no config present, and `compaction.prune: false` disables it. The existing prune, select, and process suites cover the fallback paths (the fake provider's `getSmallModel` returns the session model, and the live `test` provider has no small-model family, so both resolve to the previous behavior). Ran no local suite in this environment; relying on CI.

### Screenshots / recordings

Not a UI change.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compaction now prunes session history by default, reducing unnecessary context while preserving relevant information.
  * Compaction automatically prefers a suitable small model when available.

* **Configuration**
  * Pruning can be disabled by setting `compaction.prune` to `false`.

* **Bug Fixes**
  * Corrected default pruning behavior when the setting is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
