### PR TITLE
docs: use bolt commit scope instead of opencode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,9 @@ Examples: `session-recovery`, `fix-scroll-state`, `regenerate-sdk`.
 
 Use conventional commit-style messages and PR titles: `type(scope): summary`.
 
-Valid types are `feat`, `fix`, `docs`, `chore`, `refactor`, and `test`. Scopes are optional; use the affected package or area when helpful, e.g. `core`, `opencode`, `tui`, `app`, `desktop`, `sdk`, or `plugin`.
+Valid types are `feat`, `fix`, `docs`, `chore`, `refactor`, and `test`. Scopes are optional; use the affected package or area when helpful, e.g. `core`, `bolt`, `tui`, `app`, `desktop`, `sdk`, or `plugin`. Use `bolt` (not `opencode`) as the scope for changes to `packages/opencode`.
 
-Examples: `fix(tui): simplify thinking toggle styling`, `docs: update contributing guide`, `chore(sdk): regenerate types`.
+Examples: `fix(tui): simplify thinking toggle styling`, `fix(bolt): keep sessions fast after repeated compactions`, `docs: update contributing guide`, `chore(sdk): regenerate types`.
 
 ## Style Guide
 


### PR DESCRIPTION
### Issue for this PR

Closes #186

### Type of change

- [x] Documentation

### What does this PR do?

Updates the commit/PR title convention in AGENTS.md so changes to `packages/opencode` are scoped `bolt` instead of `opencode`, matching the product name. Contributors and coding agents read this file for conventions, so this makes the new scope stick going forward.

### How did you verify your code works?

Documentation-only change; no code paths affected.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated commit and pull request title guidance to use the `bolt` scope.
  * Added examples for `bolt`-scoped fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->