### PR TITLE
test(opencode): rename short seedPrunable variables

### DIFF
--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -810,7 +810,7 @@ describe("session.compaction.prune", () => {
     Effect.gen(function* () {
       const ssn = yield* SessionNs.Service
       const info = yield* ssn.create({})
-      const a = yield* ssn.updateMessage({
+      const userMsg = yield* ssn.updateMessage({
         id: MessageID.ascending(),
         role: "user",
         sessionID: info.id,
@@ -820,12 +820,12 @@ describe("session.compaction.prune", () => {
       })
       yield* ssn.updatePart({
         id: PartID.ascending(),
-        messageID: a.id,
+        messageID: userMsg.id,
         sessionID: info.id,
         type: "text",
         text: "first",
       })
-      const b: SessionV1.Assistant = {
+      const assistantMsg: SessionV1.Assistant = {
         id: MessageID.ascending(),
         role: "assistant",
         sessionID: info.id,
@@ -841,14 +841,14 @@ describe("session.compaction.prune", () => {
         },
         modelID: ref.modelID,
         providerID: ref.providerID,
-        parentID: a.id,
+        parentID: userMsg.id,
         time: { created: Date.now() },
         finish: "end_turn",
       }
-      yield* ssn.updateMessage(b)
+      yield* ssn.updateMessage(assistantMsg)
       yield* ssn.updatePart({
         id: PartID.ascending(),
-        messageID: b.id,
+        messageID: assistantMsg.id,
         sessionID: info.id,
         type: "tool",
         callID: crypto.randomUUID(),


### PR DESCRIPTION
Follow-up to #185 addressing DeepSource's "variable name is too small" findings in the `seedPrunable` test helper: the single-letter `a` and `b` message bindings are now `userMsg` and `assistantMsg`. No behavior change; the compaction test suite still passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture readability by using descriptive message names.
  * No changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->