### PR TITLE
docs: quote upstream copyright line exactly in CREDITS

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,7 +1,7 @@
 This project contains code originally derived from OpenCode, 
 which is licensed under the MIT License. 
 
-Copyright (c) 2025 Anomlyco
+Copyright (c) 2025 opencode
 
 The original MIT permissions remain intact for the foundational 
 OpenCode files. All custom features, additions, and modifications 


### PR DESCRIPTION
Corrects the upstream attribution in CREDITS: the OpenCode MIT license names "opencode" as the copyright holder, not "Anomlyco". Attribution notices should quote the upstream copyright line exactly.

Closes #191

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs

## What changed

```diff
-Copyright (c) 2025 Anomlyco
+Copyright (c) 2025 opencode
```

## Verification

- Verified against the upstream LICENSE via the GitHub API (`repos/anomalyco/opencode/license`): MIT, "Copyright (c) 2025 opencode".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the copyright attribution from Anomlyco to opencode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->