### PR TITLE
refactor(bolt): clean up flaky command lint findings

### DIFF
--- a/packages/opencode/src/cli/cmd/flaky.ts
+++ b/packages/opencode/src/cli/cmd/flaky.ts
@@ -52,7 +52,7 @@ export const FlakyCommand = effectCmd({
     const command = args.command
     const runs = Math.max(1, Math.floor(args.runs))
 
-    const execute = async () => {
+    const execute = () => {
       const shell = process.platform === "win32" ? ["cmd", "/c", command] : ["sh", "-c", command]
       const proc = Bun.spawn(shell, { cwd, stdout: "ignore", stderr: "ignore" })
       return proc.exited
@@ -84,7 +84,7 @@ export const FlakyCommand = effectCmd({
     UI.println("Verdict: FLAKY. The same command both passed and failed.")
     process.exitCode = 2
     if (!args.quarantine) {
-      UI.println("Record it with: bolt flaky \"" + command + "\" --quarantine")
+      UI.println(`Record it with: bolt flaky "${command}" --quarantine`)
       return
     }
 
@@ -93,7 +93,7 @@ export const FlakyCommand = effectCmd({
     const entry: Quarantined = { command, passes, runs, detected: Date.now() }
     const merged = [...existing.filter((item) => item.command !== command), entry]
     fs.mkdirSync(path.dirname(file), { recursive: true })
-    fs.writeFileSync(file, JSON.stringify(merged, null, 2) + "\n")
+    fs.writeFileSync(file, `${JSON.stringify(merged, null, 2)}\n`)
     UI.println(`Quarantined in ${FILE} (${merged.length} entr${merged.length === 1 ? "y" : "ies"}).`)
   }),
 })


### PR DESCRIPTION
Addresses the actionable DeepSource findings from #204, which merged before the fixes could land on its branch. Drops the unnecessary `async` on `execute` (it already returns the `proc.exited` promise) and replaces two string concatenations with template literals:

```ts
const execute = () => {
  const shell = process.platform === "win32" ? ["cmd", "/c", command] : ["sh", "-c", command]
  const proc = Bun.spawn(shell, { cwd, stdout: "ignore", stderr: "ignore" })
  return proc.exited
}
```

No behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->