### PR TITLE
fix(bolt): stop pair host server on failed runs and note v1 limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The roadmap is about one thing now: making the agent itself smarter, more autono
 
 ### Done
 
-- [x] Pair programming: `bolt pair` shares one live session across two terminals, prompts and replies from either side appear in both (no shared cursor yet)
+- [x] Pair programming: `bolt pair` shares one live session across two terminals, prompts and replies from either side appear in both (no shared cursor yet; direct shell input may double-render, and permission prompts can be answered by either side)
 - [x] `bolt refactor`: test-aware refactor loops that change, run, verify, and repeat until green
 - [x] Session replays: `bolt export --html` writes a self-contained HTML replay of any session, with a step-through timeline you can share
 - [x] Design-to-code: `bolt figma <url>` fetches a Figma node and has the agent generate components matching your repo's conventions

--- a/packages/opencode/src/cli/cmd/pair.ts
+++ b/packages/opencode/src/cli/cmd/pair.ts
@@ -135,7 +135,6 @@ export const PairCommand = effectCmd({
         username: args.username,
         pair: true,
       }),
-    )
-    yield* Effect.promise(() => server.stop(true))
+    ).pipe(Effect.ensuring(Effect.promise(() => server.stop(true))))
   }),
 })


### PR DESCRIPTION
Follow-up to #225 addressing review feedback that landed after the merge. The host flow only stopped the local server when `runMini` resolved, so a rejected or interrupted interactive run left the listener open. The stop is now attached as a finalizer so it runs on every exit path:

```ts
yield* Effect.promise(() =>
  runMini({
    attach: url,
    session: created.id,
    // ...
    pair: true,
  }),
).pipe(Effect.ensuring(Effect.promise(() => server.stop(true))))
```

Also extends the README pair-programming Done entry to mention the remaining v1 limits (direct shell input may double-render, and permission prompts can be answered by either side) so the roadmap does not overstate v1 behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->