### PR TITLE
chore: right-size 5 CI runners (~$27/month)

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,7 +8,7 @@ on:
     types: [opened]
 jobs:
   run:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
   deploy:
     # Skip when AWS deploy credentials are not configured for this repo.
     if: github.repository == 'bolt-builder/bolt-cli' && (github.ref_name == 'dev' || github.ref_name == 'production') && vars.AWS_DEPLOY_ROLE_ARN != ''
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   generate:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-duplicates:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
 
   build-cli:
     needs: version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'bolt-builder/bolt-cli'
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0


### PR DESCRIPTION
Downsizes five lightly loaded jobs from 4 vCPU to 2 vCPU based on the last 30 days of observed CPU and memory metrics, saving roughly $27/month with under 1.1% projected wall-time growth on every job. Each change is the same one-line swap, e.g. in `generate.yml`:

```yaml
jobs:
  generate:
    runs-on: blacksmith-2vcpu-ubuntu-2404
```

### Apply for savings

- `generate.yml` / `generate` (~$12/month, 262 runs): average CPU around 28% with 95th percentile CPU under 47% and peak memory under 10%; projected wall-time growth 0.4%. Cautious confidence. [Sample run](https://app.blacksmith.sh/bolt-builder/runs/30922317017/jobs/92035763075?tab=metrics)
- `pr-management.yml` / `check-duplicates` (~$2/month, 134 runs): average CPU around 21% with peak memory under 8%; projected wall-time growth 0.4%. Cautious confidence. [Sample run](https://app.blacksmith.sh/bolt-builder/runs/30477559339/jobs/90662977918?tab=metrics)

### Test before applying

- `deploy.yml` / `deploy` (~$6/month, 60 runs): average CPU about 25% with peak memory under 5%, but 95th percentile CPU touches 54%; projected wall-time growth 0.9%. Cautious confidence. [Sample run](https://app.blacksmith.sh/bolt-builder/runs/30597498223/jobs/91052968732?tab=metrics)
- `publish.yml` / `build-cli` (~$5/month, 127 runs): average CPU about 29% with peak memory under 23%; projected wall-time growth 0.5%. Cautious confidence. This job's metrics were recorded under the former `release` workflow name. [Sample run](https://app.blacksmith.sh/bolt-builder/runs/30567679698/jobs/90957016241?tab=metrics)
- `auto-assign.yml` / `run` (~$2/month, 73 runs): average CPU under 19% with negligible memory use; projected wall-time growth 1.0%. Cautious confidence. [Sample run](https://app.blacksmith.sh/bolt-builder/runs/31070820625/jobs/92518217564?tab=metrics)

If any of these jobs slow down noticeably, reverting is the same one-line change back to `blacksmith-4vcpu-ubuntu-2404`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation and deployment jobs to use smaller, more efficient build runners.
  * Applied the runner update across assignment, deployment, generation, pull request management, and publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->