### PR TITLE
docs: remove duplicate pair programming roadmap entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,6 @@ The roadmap is about one thing: making the agent smarter, more autonomous, and m
 - [x] VS Code extension (`sdks/vscode`) and ACP for editors like Zed
 - [x] Web UI: `bolt web` starts the server and opens the browser dashboard
 - [x] Custom agents defined as markdown in your repo, or generated with `bolt agent create`
-- [x] Pair programming: `bolt pair` shares one live session across two terminals, prompts and replies from either side appear in both (no shared cursor yet)
 - [x] `bolt refactor`: test-aware refactor loops that change, run, verify, and repeat until green
 - [x] Session replays: `bolt export --html` writes a self-contained HTML replay of any session, with a step-through timeline you can share
 - [x] Design-to-code: `bolt figma <url>` fetches a Figma node and has the agent generate components matching your repo's conventions


### PR DESCRIPTION
The merge of #226 resolved the README conflict against #223 by keeping both versions of the pair-programming Done bullet, so the roadmap listed it twice: once with the v1 limits parenthetical and once with the stale text. This removes the stale duplicate, keeping the single entry that mentions the v1 limits (direct shell input may double-render, and permission prompts can be answered by either side).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->