### PR TITLE
fix(bolt): slashcommand review follow-ups

### DIFF
--- a/packages/opencode/src/tool/slashcommand.ts
+++ b/packages/opencode/src/tool/slashcommand.ts
@@ -11,7 +11,7 @@ export const Parameters = Schema.Struct({
 })
 
 const argsRegex = /(?:"[^"]*"|'[^']*'|[^\s"']+)/g
-const placeholderRegex = /\$(\d+)/g
+const placeholderRegex = /\$([1-9]\d*)/g
 const quoteTrimRegex = /^["']|["']$/g
 
 /**

--- a/packages/opencode/src/tool/slashcommand.ts
+++ b/packages/opencode/src/tool/slashcommand.ts
@@ -78,7 +78,9 @@ export const SlashcommandTool = Tool.define(
               `<command_instructions name="${command.name}">`,
               rendered,
               "</command_instructions>",
-              "Execute the instructions above as part of the current task.",
+              command.subtask
+                ? "Run the instructions above as a subtask via the task tool."
+                : "Execute the instructions above as part of the current task.",
             ].join("\n"),
             metadata: {
               command: command.name,

--- a/packages/opencode/test/tool/slashcommand.test.ts
+++ b/packages/opencode/test/tool/slashcommand.test.ts
@@ -40,6 +40,10 @@ describe("substitute", () => {
     expect(substitute("Run the standard review", "")).toBe("Run the standard review")
   })
 
+  test("$0 is not a positional placeholder", () => {
+    expect(substitute("Run $0 now", "a b")).toBe("Run $0 now\n\na b")
+  })
+
   test("repeated numbered placeholders each substitute", () => {
     expect(substitute("$1 and $1 again", "echo")).toBe("echo and echo again")
   })


### PR DESCRIPTION
Follow-up to #255 addressing review comments that landed after the merge. Two fixes to the slashcommand tool:

1. The documented positional syntax starts at $1, but the placeholder regex also matched $0, so a literal $0 in a template was replaced with the last argument instead of being left alone.

```ts
-const placeholderRegex = /\$(\d+)/g
+const placeholderRegex = /\$([1-9]\d*)/g
```

With $0 excluded, a template containing only $0 now counts as placeholder-free, so arguments are appended after it per the existing fallback. Adds a regression test covering "$0" with "a b".

2. For commands marked `subtask: true`, the note said to run the instructions via the task tool while the closing line unconditionally said to execute them inline. The closing line now matches:

```ts
command.subtask
  ? "Run the instructions above as a subtask via the task tool."
  : "Execute the instructions above as part of the current task.",
```