### PR TITLE
fix(bolt): security and correctness fixes from audit

### DIFF
--- a/packages/opencode/src/cli/cmd/cron.ts
+++ b/packages/opencode/src/cli/cmd/cron.ts
@@ -66,12 +66,14 @@ export function matches(expr: string, date: Date) {
   if (sets.some((set) => !set)) return false
   const [minute, hour, dom, month, dow] = sets as Set<number>[]
   const day = date.getDay()
+  const domMatch = dom.has(date.getDate())
+  const dowMatch = dow.has(day) || (day === 0 && dow.has(7))
+  // POSIX/Vixie cron: when both day-of-month and day-of-week are restricted, the
+  // day matches if EITHER matches; when one is `*` it matches every day, so the
+  // AND below degrades to the restricted field on its own.
+  const dayMatch = parts[2] !== "*" && parts[4] !== "*" ? domMatch || dowMatch : domMatch && dowMatch
   return (
-    minute.has(date.getMinutes()) &&
-    hour.has(date.getHours()) &&
-    dom.has(date.getDate()) &&
-    month.has(date.getMonth() + 1) &&
-    (dow.has(day) || (day === 0 && dow.has(7)))
+    minute.has(date.getMinutes()) && hour.has(date.getHours()) && month.has(date.getMonth() + 1) && dayMatch
   )
 }
 

--- a/packages/opencode/src/cli/cmd/jobs.ts
+++ b/packages/opencode/src/cli/cmd/jobs.ts
@@ -28,6 +28,24 @@ export function alive(pid: number) {
 }
 
 /**
+ * Kill a detached job and its descendants. Jobs are spawned as their own
+ * process-group leader (see spawnJob), and `bolt run` spawns tool subprocesses
+ * (sh -c ...) into that group, so signal the whole group. Falls back to the
+ * lone pid when the group signal is unsupported (Windows) or already gone.
+ */
+export function killJob(pid: number, signal: NodeJS.Signals | number = "SIGTERM") {
+  if (process.platform === "win32") {
+    process.kill(pid, signal)
+    return
+  }
+  try {
+    process.kill(-pid, signal)
+  } catch {
+    process.kill(pid, signal)
+  }
+}
+
+/**
  * Spawn a detached background job that re-runs this CLI with the given argv,
  * appending output to a log file under the global state directory.
  */
@@ -126,7 +144,7 @@ export const JobsCommand = effectCmd({
         UI.println(`Job ${job.id} is not running.`)
         return
       }
-      process.kill(job.pid)
+      killJob(job.pid)
       UI.println(`Killed job ${job.id} (pid ${job.pid}).`)
       return
     }

--- a/packages/opencode/src/cli/cmd/refactor.ts
+++ b/packages/opencode/src/cli/cmd/refactor.ts
@@ -96,9 +96,6 @@ export const RefactorCommand = effectCmd({
       return { exit, output: `${stdout}\n${stderr}` }
     })
 
-    UI.println("Refactoring...")
-    yield* send(args.instruction)
-
     // Review the resulting worktree diff in a fresh code-review session. Warns
     // on a FAIL verdict but never reverts: tests are green at this point.
     const review = Effect.gen(function* () {
@@ -171,11 +168,6 @@ export const RefactorCommand = effectCmd({
       const run = yield* test
       if (run.exit === 0) {
         UI.println("Tests are green. Refactor complete.")
-        if (!args.confidence) return
-        const level = confidence(latest)
-        UI.println(
-          level ? `Confidence: ${level.toUpperCase()}` : "Could not determine a confidence level from the response.",
-        )
         if (args.confidence) {
           const level = confidence(latest)
           UI.println(

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { effectCmd, fail } from "../effect-cmd"
-import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { withNetworkOptions, resolveNetworkOptions, enforceLoopbackWithoutAuth } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 
 export const ServeCommand = effectCmd({
@@ -16,22 +16,9 @@ export const ServeCommand = effectCmd({
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const resolved = yield* resolveNetworkOptions(args)
-    // "localhost" resolves through DNS/hosts and may map to a non-loopback
-    // address, so pin unauthenticated binds to a literal loopback IP.
-    const opts =
-      !Flag.OPENCODE_SERVER_PASSWORD && resolved.hostname === "localhost"
-        ? { ...resolved, hostname: "127.0.0.1" }
-        : resolved
-    // Refuse to expose an unauthenticated server beyond loopback: the API
-    // grants file read/write and shell execution, so binding 0.0.0.0 (or
-    // advertising over mDNS) without a password hands that to the whole LAN.
-    const loopback = ["127.0.0.1", "::1"].includes(opts.hostname)
-    if (!Flag.OPENCODE_SERVER_PASSWORD && (!loopback || opts.mdns)) {
-      return yield* fail(
-        "Refusing to listen on a non-loopback interface without authentication. Set OPENCODE_SERVER_PASSWORD or bind to 127.0.0.1.",
-      )
-    }
-    const server = yield* Effect.promise(() => Server.listen(opts))
+    const guard = enforceLoopbackWithoutAuth(resolved)
+    if (!guard.ok) return yield* fail(guard.error)
+    const server = yield* Effect.promise(() => Server.listen(guard.opts))
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
 
     yield* Effect.never

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "url"
 import { UI } from "@/cli/ui"
 import { errorMessage } from "@opencode-ai/tui/util/error"
 import { withTimeout } from "@/util/timeout"
-import { withNetworkOptions, resolveNetworkOptionsNoConfig, hasArg } from "@/cli/network"
+import { withNetworkOptions, resolveNetworkOptionsNoConfig, hasArg, enforceLoopbackWithoutAuth } from "@/cli/network"
 import { Filesystem } from "@/util/filesystem"
 import type { GlobalEvent } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "@opencode-ai/tui/context/sdk"
@@ -230,8 +230,17 @@ export const TuiThreadCommand = cmd({
       const prompt = await input(args.prompt)
       const config = await TuiConfig.get()
 
-      const network = resolveNetworkOptionsNoConfig(args)
-      const external = hasArg("--port") || hasArg("--hostname") || network.mdns === true
+      const resolved = resolveNetworkOptionsNoConfig(args)
+      const external = hasArg("--port") || hasArg("--hostname") || resolved.mdns === true
+      // An external bind exposes the file/shell API; refuse it beyond loopback
+      // when no server password is set.
+      const guard = external ? enforceLoopbackWithoutAuth(resolved) : ({ ok: true as const, opts: resolved })
+      if (!guard.ok) {
+        UI.error(guard.error)
+        process.exitCode = 1
+        return
+      }
+      const network = guard.opts
 
       const headers = external ? ServerAuth.headers() : undefined
 

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { UI } from "../ui"
-import { effectCmd } from "../effect-cmd"
-import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { effectCmd, fail } from "../effect-cmd"
+import { withNetworkOptions, resolveNetworkOptions, enforceLoopbackWithoutAuth } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
@@ -40,7 +40,11 @@ export const WebCommand = effectCmd({
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
-    const opts = yield* resolveNetworkOptions(args)
+    const resolved = yield* resolveNetworkOptions(args)
+    // Refuse to expose the unauthenticated file/shell API beyond loopback.
+    const guard = enforceLoopbackWithoutAuth(resolved)
+    if (!guard.ok) return yield* fail(guard.error)
+    const opts = guard.opts
     const server = yield* Effect.promise(() => Server.listen(opts))
     UI.empty()
     UI.println(UI.logo("  "))

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -1,6 +1,7 @@
 import type { Argv, InferredOptionTypes } from "yargs"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import type { Config } from "@/config/config"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { Effect } from "effect"
 
 const options = {
@@ -77,4 +78,30 @@ export function resolveNetworkOptionsNoConfig(args: NetworkOptions, config?: Con
   const cors = [...configCors, ...argsCors]
 
   return { hostname, port, mdns, mdnsDomain, cors }
+}
+
+/**
+ * Refuse to expose an unauthenticated server beyond loopback. The API grants
+ * file read/write and shell execution, so binding a non-loopback interface (or
+ * advertising it over mDNS) without a password would hand that to the whole LAN.
+ *
+ * Centralized here so every CLI entrypoint (serve, web, tui) inherits the same
+ * check. Tests and internal RPC callers that use `Server.listen` directly
+ * bypass this on purpose. When authenticated, or already loopback, the options
+ * are returned unchanged; `"localhost"` is pinned to a literal loopback IP
+ * because it can resolve to a non-loopback address via DNS/hosts.
+ */
+export function enforceLoopbackWithoutAuth<T extends { hostname: string; mdns?: boolean }>(
+  opts: T,
+): { ok: true; opts: T } | { ok: false; error: string } {
+  if (Flag.OPENCODE_SERVER_PASSWORD) return { ok: true, opts }
+  const pinned = opts.hostname === "localhost" ? { ...opts, hostname: "127.0.0.1" } : opts
+  const loopback = pinned.hostname === "127.0.0.1" || pinned.hostname === "::1"
+  if (!loopback || pinned.mdns)
+    return {
+      ok: false,
+      error:
+        "Refusing to listen on a non-loopback interface without authentication. Set OPENCODE_SERVER_PASSWORD or bind to 127.0.0.1.",
+    }
+  return { ok: true, opts: pinned }
 }

--- a/packages/opencode/src/server/auth.ts
+++ b/packages/opencode/src/server/auth.ts
@@ -2,6 +2,7 @@ export * as ServerAuth from "./auth"
 
 import { ConfigService } from "@/effect/config-service"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { createHash, timingSafeEqual } from "node:crypto"
 import { Config as EffectConfig, Context, Option, Redacted } from "effect"
 
 export type Credentials = {
@@ -26,11 +27,20 @@ export function required(config: Info) {
 }
 
 export function authorized(credentials: DecodedCredentials, config: Info) {
-  return (
-    Option.isSome(config.password) &&
-    credentials.username === config.username &&
-    Redacted.value(credentials.password) === config.password.value
-  )
+  if (Option.isNone(config.password)) return false
+  // Evaluate both comparisons so a username mismatch does not skip the password
+  // hash, which would leak username validity through response timing.
+  const username = equals(credentials.username, config.username)
+  const password = equals(Redacted.value(credentials.password), config.password.value)
+  return username && password
+}
+
+// Constant-time comparison so the password cannot be recovered byte-by-byte
+// through response timing. Hashing first equalizes lengths, which
+// timingSafeEqual requires (and avoids leaking the length itself).
+function equals(a: string, b: string) {
+  const hash = (value: string) => createHash("sha256").update(value).digest()
+  return timingSafeEqual(hash(a), hash(b))
 }
 
 export function header(credentials?: Credentials) {

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -76,7 +76,12 @@ function credentialFromRequest(request: HttpServerRequest.HttpServerRequest) {
 
 function credentialFromURL(url: URL, request: HttpServerRequest.HttpServerRequest) {
   const token = url.searchParams.get(AUTH_TOKEN_QUERY)
-  if (token) return decodeCredential(token)
+  // Only honor credentials from the query string on safe, non-mutating requests
+  // (UI page loads, EventSource, WebSocket upgrades) that cannot set an
+  // Authorization header. Requiring the header for mutating methods keeps a
+  // password leaked via URL, Referer, or access logs from being replayed to
+  // change state.
+  if (token && (request.method === "GET" || request.method === "HEAD")) return decodeCredential(token)
   const match = /^Basic\s+(.+)$/i.exec(request.headers.authorization ?? "")
   if (match) return decodeCredential(match[1])
   return Effect.succeed(emptyCredential())

--- a/packages/opencode/test/cli/cron.test.ts
+++ b/packages/opencode/test/cli/cron.test.ts
@@ -58,4 +58,21 @@ describe("matches", () => {
     expect(matches("0 12 16 1 *", date)).toBe(false)
     expect(matches("0 12 15 2 *", date)).toBe(false)
   })
+
+  test("ORs day-of-month and day-of-week when both are restricted", () => {
+    // 2026-01-01 is a Thursday (getDay() === 4).
+    const firstOfMonth = new Date(2026, 0, 1, 0, 0)
+    expect(firstOfMonth.getDate()).toBe(1)
+    expect(firstOfMonth.getDay()).toBe(4)
+    // "1st OR Monday": matches on the 1st even though it is not a Monday.
+    expect(matches("0 0 1 * 1", firstOfMonth)).toBe(true)
+    // ...and matches on a Monday that is not the 1st.
+    const monday = new Date(2026, 0, 5, 0, 0)
+    expect(monday.getDay()).toBe(1)
+    expect(matches("0 0 1 * 1", monday)).toBe(true)
+    // A Thursday that is not the 1st matches neither, so no run.
+    const otherThursday = new Date(2026, 0, 8, 0, 0)
+    expect(otherThursday.getDay()).toBe(4)
+    expect(matches("0 0 1 * 1", otherThursday)).toBe(false)
+  })
 })

--- a/packages/server/src/middleware/authorization.ts
+++ b/packages/server/src/middleware/authorization.ts
@@ -29,7 +29,12 @@ function decodeCredential(input: string) {
 function credentialFromRequest(request: HttpServerRequest.HttpServerRequest) {
   const url = new URL(request.url, "http://localhost")
   const token = url.searchParams.get(AUTH_TOKEN_QUERY)
-  if (token) return decodeCredential(token)
+  // Only honor credentials from the query string on safe, non-mutating requests
+  // (UI page loads, EventSource, WebSocket upgrades) that cannot set an
+  // Authorization header. Requiring the header for mutating methods keeps a
+  // password leaked via URL, Referer, or access logs from being replayed to
+  // change state.
+  if (token && (request.method === "GET" || request.method === "HEAD")) return decodeCredential(token)
   const match = /^Basic\s+(.+)$/i.exec(request.headers.authorization ?? "")
   if (match) return decodeCredential(match[1])
   return Effect.succeed(emptyCredential())


### PR DESCRIPTION
Fixes a batch of confirmed audit findings, one file per commit. All findings verified by reading the code; `packages/opencode` and `packages/server` typecheck cleanly and the touched `cron` / `httpapi-authorization` suites pass.

## Security

**Unauthenticated non-loopback binds.** `serve` already refused to bind a non-loopback interface without a password (the API grants file read/write and shell execution), but `web` only warned and `tui --mdns/--hostname` bound unconditionally. Centralized the guard in a shared `enforceLoopbackWithoutAuth` helper at the network-option layer that all three CLI entrypoints route through (tests and internal RPC that call `Server.listen` directly bypass it on purpose, so the mDNS suite stays valid):

```ts
export function enforceLoopbackWithoutAuth<T extends { hostname: string; mdns?: boolean }>(opts: T) {
  if (Flag.OPENCODE_SERVER_PASSWORD) return { ok: true, opts } as const
  const pinned = opts.hostname === "localhost" ? { ...opts, hostname: "127.0.0.1" } : opts
  const loopback = pinned.hostname === "127.0.0.1" || pinned.hostname === "::1"
  if (!loopback || pinned.mdns) return { ok: false, error: "Refusing to listen on a non-loopback interface without authentication. Set OPENCODE_SERVER_PASSWORD or bind to 127.0.0.1." } as const
  return { ok: true, opts: pinned } as const
}
```

**Timing-unsafe credential check.** `packages/opencode/src/server/auth.ts` compared the Basic-auth password with `===` and short-circuited on username, leaking validity through timing. Now mirrors the hardened `packages/server` implementation (sha256 + `timingSafeEqual`, both comparisons always evaluated).

**`auth_token` query credential on every route.** The base64 password in `?auth_token=` was honored for all methods, so it could be replayed from URLs/Referer/access logs to mutate state. Restricted to safe `GET`/`HEAD` requests (UI page loads, EventSource, WebSocket upgrades cannot set headers); mutating methods now require the `Authorization` header. Applied in both middleware copies. Note: this is a scoped mitigation; a fuller fix (ticket-based UI bootstrap, like the existing PTY connect ticket) is a larger client-coordinated change and left as follow-up.

## Correctness

- **`refactor` sent the instruction twice** (bad-merge remnant), doubling every run's cost; also `--self-review` was unreachable unless `--confidence` was passed, and the confidence line printed twice. Now sends once and runs self-review independent of `--confidence`.
- **`jobs kill` orphaned tool subprocesses**: jobs are spawned `detached` (own process group) but only the leader pid was signaled. Now signals the process group with a lone-pid fallback (Windows / group already gone).
- **`cron` day matching** used AND for day-of-month and day-of-week; POSIX/Vixie cron runs when *either* matches if both are restricted (e.g. `0 0 1 * 1` = the 1st **or** any Monday). Added a regression test.

Each fix is its own single-file commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->