### PR TITLE
fix(bolt): harden task storage and update validation

### DIFF
--- a/packages/opencode/src/tool/tasks.ts
+++ b/packages/opencode/src/tool/tasks.ts
@@ -62,6 +62,8 @@ export function transition(
     return { ok: false, reason: `unknown task id "${input.id}" (known ids: ${known || "none"})` }
   }
 
+  if (input.subject !== undefined && !input.subject.trim()) return { ok: false, reason: "subject must not be empty" }
+
   if (input.blockers) {
     if (input.blockers.includes(input.id)) return { ok: false, reason: `task ${input.id} cannot block itself` }
     const known = tasks.map((task) => task.id)
@@ -123,8 +125,14 @@ export function render(tasks: readonly Info[]) {
 
 const KEY = "session_task"
 
-const load = (storage: Storage.Interface, sessionID: string) =>
-  storage.read<Info[]>([KEY, sessionID]).pipe(Effect.catch(() => Effect.succeed([] as Info[])))
+// A missing key means no tasks yet; any other storage failure must not be
+// mistaken for an empty list, or a later write would erase persisted tasks.
+const load = Effect.fnUntraced(function* (storage: Storage.Interface, sessionID: string) {
+  return yield* storage.read<Info[]>([KEY, sessionID]).pipe(
+    Effect.catchTag("NotFoundError", () => Effect.succeed([] as Info[])),
+    Effect.orDie,
+  )
+})
 
 export const CreateParameters = Schema.Struct({
   subject: Schema.String.annotate({ description: "Brief imperative summary of the task" }),
@@ -248,7 +256,10 @@ export const TaskListTool = Tool.define(
           return {
             title: `${tasks.filter((task) => task.status !== "completed" && task.status !== "cancelled").length} open tasks`,
             output: render(tasks),
-            metadata: { count: tasks.length },
+            metadata: {
+              count: tasks.length,
+              tasks: tasks.map((task) => ({ ...task, blocked: blocked(tasks, task) })),
+            },
           }
         }),
     }

--- a/packages/opencode/test/tool/tasks.test.ts
+++ b/packages/opencode/test/tool/tasks.test.ts
@@ -1,5 +1,39 @@
-import { describe, expect, test } from "bun:test"
-import { blocked, create, render, transition, type Info } from "../../src/tool/tasks"
+import { afterEach, describe, expect, test } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Effect, Layer } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { Config } from "@/config/config"
+import { Plugin } from "../../src/plugin"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Storage } from "@/storage/storage"
+import { Truncate } from "@/tool/truncate"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { blocked, create, render, transition, TaskListTool, type Info } from "../../src/tool/tasks"
+import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const layer = Layer.mergeAll(
+  LayerNode.compile(
+    LayerNode.group([
+      CrossSpawnSpawner.node,
+      FSUtil.node,
+      Plugin.node,
+      Truncate.node,
+      Config.node,
+      Agent.node,
+      RuntimeFlags.node,
+      Storage.node,
+    ]),
+  ),
+  testInstanceStoreLayer,
+)
+const it = testEffect(layer)
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
 
 function task(id: string, status: Info["status"], blockers: string[] = []): Info {
   return { id, subject: `task ${id}`, status, blockers }
@@ -104,6 +138,11 @@ describe("transition", () => {
     expect(out.tasks[0]).toMatchObject({ subject: "renamed", status: "in_progress" })
   })
 
+  test("rejects a whitespace-only subject", () => {
+    const out = transition([task("1", "pending")], { id: "1", subject: "   " })
+    expect(out).toEqual({ ok: false, reason: "subject must not be empty" })
+  })
+
   test("rejects self-blocking", () => {
     const out = transition([task("1", "pending")], { id: "1", blockers: ["1"] })
     expect(out.ok).toBe(false)
@@ -144,6 +183,44 @@ describe("blocked", () => {
     const item = task("1", "pending", ["9"])
     expect(blocked([item], item)).toEqual([])
   })
+})
+
+describe("task_list execute", () => {
+  it.live("returns structured task records with live blocked info", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.gen(function* () {
+        const storage = yield* Storage.Service
+        const sessionID = SessionID.make(`ses_tasks-test-${crypto.randomUUID()}`)
+        yield* Effect.addFinalizer(() => storage.remove(["session_task", sessionID]).pipe(Effect.ignore))
+        const tasks = [task("1", "pending"), task("2", "pending", ["1"])]
+        yield* storage.write(["session_task", sessionID], tasks)
+
+        const info = yield* TaskListTool
+        const def = yield* info.init()
+        const result = yield* def.execute(
+          {},
+          {
+            sessionID,
+            messageID: MessageID.make("msg_tasks-test"),
+            callID: "",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(result.metadata.count).toBe(2)
+        expect(result.metadata.tasks).toEqual([
+          { ...tasks[0], blocked: [] },
+          { ...tasks[1], blocked: ["1"] },
+        ])
+        expect(result.output).toContain("blocked by: 1")
+      }).pipe(provideInstance(dir))
+    }),
+  )
 })
 
 describe("render", () => {


### PR DESCRIPTION
Follow-up to #260 (merged before review fixes landed) addressing the remaining CodeRabbit findings on the task tools.

The main fix is data integrity in the task store: `load` previously mapped every `Storage.read` failure to an empty list, so a decode or I/O error during `task_create` would cause the subsequent write to replace the persisted task list with a single new task. It now treats only the verified missing-key case as "no tasks yet":

```ts
const load = Effect.fnUntraced(function* (storage: Storage.Interface, sessionID: string) {
  return yield* storage.read<Info[]>([KEY, sessionID]).pipe(
    Effect.catchTag("NotFoundError", () => Effect.succeed([] as Info[])),
    Effect.orDie,
  )
})
```

Also: `transition` now rejects whitespace-only subjects on `task_update` (matching `task_create` validation), and `task_list` returns machine-readable task records with live blocked-by ids through `metadata` alongside the rendered output. Covered by a new pure regression test and an execute-level test for the structured records.