### PR TITLE
fix(memory): address deepsource findings on provenance code

### DIFF
--- a/packages/memory/src/capture/operations.ts
+++ b/packages/memory/src/capture/operations.ts
@@ -257,16 +257,16 @@ export namespace MemoryOperations {
       plan.touched.add(source)
       plan.removed += next.count
     }
-    for (const id of exact.ids) {
-      delete plan.inventory.items[id]
-      plan.dropped.push(id)
-    }
+    const drops = new Set(exact.ids)
     if (exact.fallback) {
       for (const [id, item] of Object.entries(plan.inventory.items)) {
-        if (exact.fallback !== item.key) continue
-        delete plan.inventory.items[id]
-        plan.dropped.push(id)
+        if (exact.fallback === item.key) drops.add(id)
       }
+    }
+    if (drops.size > 0) {
+      // Rebuild instead of `delete` on dynamically computed keys.
+      plan.inventory.items = Object.fromEntries(Object.entries(plan.inventory.items).filter(([id]) => !drops.has(id)))
+      plan.dropped.push(...drops)
     }
     plan.count++
   }

--- a/packages/memory/src/memory.ts
+++ b/packages/memory/src/memory.ts
@@ -226,6 +226,8 @@ export namespace Memory {
           added: 0,
           removed: 0,
           skipped: [],
+          // Staged writes land no facts yet, so there are no inventory ids to attribute.
+          ids: [],
           index: {
             text: index,
             bytes: Buffer.byteLength(index),
@@ -332,7 +334,7 @@ export namespace Memory {
     })
   }
 
-  export async function correct(input: {
+  export function correct(input: {
     root: string
     text: string
     key?: string

--- a/packages/memory/src/storage/origins.ts
+++ b/packages/memory/src/storage/origins.ts
@@ -16,9 +16,9 @@ function rec(input: unknown): input is Record<string, unknown> {
   return typeof input === "object" && input !== null && !Array.isArray(input)
 }
 
-function origin(input: unknown): Origin | undefined {
-  if (!rec(input)) return
-  if (typeof input.at !== "number" || !Number.isFinite(input.at) || input.at < 0) return
+function decodeOrigin(input: unknown): Origin | undefined {
+  if (!rec(input)) return undefined
+  if (typeof input.at !== "number" || !Number.isFinite(input.at) || input.at < 0) return undefined
   const sessionID = typeof input.sessionID === "string" && input.sessionID ? input.sessionID : undefined
   const messageID = typeof input.messageID === "string" && input.messageID ? input.messageID : undefined
   return {
@@ -33,7 +33,7 @@ export function parse(input: unknown): Ledger {
   if (!rec(input) || input.version !== 1 || !rec(input.items)) return empty
   const items: Ledger["items"] = {}
   for (const [id, raw] of Object.entries(input.items)) {
-    const item = origin(raw)
+    const item = decodeOrigin(raw)
     if (item) items[id] = item
   }
   return { version: 1, items }
@@ -73,10 +73,11 @@ export async function record(
 export async function drop(root: string, ids: string[]) {
   if (ids.length === 0) return
   const ledger = await read(root)
-  const found = ids.filter((id) => ledger.items[id] !== undefined)
-  if (found.length === 0) return
-  for (const id of found) delete ledger.items[id]
-  await write(root, ledger)
+  const drops = new Set(ids)
+  const remaining = Object.entries(ledger.items).filter(([id]) => !drops.has(id))
+  if (remaining.length === Object.keys(ledger.items).length) return
+  // Rebuild instead of `delete` on dynamically computed keys.
+  await write(root, { version: 1, items: Object.fromEntries(remaining) })
 }
 
 export * as MemoryOrigins from "./origins"

--- a/packages/memory/test/origins.test.ts
+++ b/packages/memory/test/origins.test.ts
@@ -33,65 +33,66 @@ describe("origin ledger", () => {
   })
 
   test("skips recording when no origin is known", async () => {
-    const t = await tmp()
+    const temp = await tmp()
     try {
-      await MemoryOrigins.record(t.root, { ids: ["a"], at: 1 })
-      expect((await MemoryOrigins.read(t.root)).items).toEqual({})
+      await MemoryOrigins.record(temp.root, { ids: ["a"], at: 1 })
+      expect((await MemoryOrigins.read(temp.root)).items).toEqual({})
     } finally {
-      await t.done()
+      await temp.done()
     }
   })
 })
 
 describe("write provenance", () => {
   test("links facts to the session and message that taught them", async () => {
-    const t = await tmp()
+    const temp = await tmp()
     try {
-      await Memory.enable({ root: t.root })
+      await Memory.enable({ root: temp.root })
       await Memory.remember({
-        root: t.root,
+        root: temp.root,
         text: "Deploys go through the release pipeline.",
         sessionID: "ses_teacher",
         messageID: "msg_lesson",
       })
 
-      const taught = await Memory.origins({ root: t.root })
+      const taught = await Memory.origins({ root: temp.root })
       const ids = Object.keys(taught.items)
       expect(ids.length).toBe(1)
-      expect(taught.items[ids[0]!]!.sessionID).toBe("ses_teacher")
-      expect(taught.items[ids[0]!]!.messageID).toBe("msg_lesson")
+      const entry = taught.items[ids[0] ?? ""]
+      expect(entry?.sessionID).toBe("ses_teacher")
+      expect(entry?.messageID).toBe("msg_lesson")
     } finally {
-      await t.done()
+      await temp.done()
     }
   })
 
   test("re-teaching re-attributes and forgetting drops the origin", async () => {
-    const t = await tmp()
+    const temp = await tmp()
     try {
-      await Memory.enable({ root: t.root })
-      await Memory.remember({ root: t.root, key: "deploy_region", text: "Deploys go to ord.", sessionID: "ses_a" })
-      await Memory.remember({ root: t.root, key: "deploy_region", text: "Deploys go to iad.", sessionID: "ses_b" })
+      await Memory.enable({ root: temp.root })
+      await Memory.remember({ root: temp.root, key: "deploy_region", text: "Deploys go to ord.", sessionID: "ses_a" })
+      await Memory.remember({ root: temp.root, key: "deploy_region", text: "Deploys go to iad.", sessionID: "ses_b" })
 
-      const taught = await Memory.origins({ root: t.root })
+      const taught = await Memory.origins({ root: temp.root })
       const ids = Object.keys(taught.items)
       expect(ids.length).toBe(1)
-      expect(taught.items[ids[0]!]!.sessionID).toBe("ses_b")
+      expect(taught.items[ids[0] ?? ""]?.sessionID).toBe("ses_b")
 
-      await Memory.forget({ root: t.root, query: "deploy_region" })
-      expect(Object.keys((await Memory.origins({ root: t.root })).items)).toEqual([])
+      await Memory.forget({ root: temp.root, query: "deploy_region" })
+      expect(Object.keys((await Memory.origins({ root: temp.root })).items)).toEqual([])
     } finally {
-      await t.done()
+      await temp.done()
     }
   })
 
   test("writes without a session leave no origin claim", async () => {
-    const t = await tmp()
+    const temp = await tmp()
     try {
-      await Memory.enable({ root: t.root })
-      await Memory.remember({ root: t.root, text: "An anonymous fact with no teacher." })
-      expect(Object.keys((await Memory.origins({ root: t.root })).items)).toEqual([])
+      await Memory.enable({ root: temp.root })
+      await Memory.remember({ root: temp.root, text: "An anonymous fact with no teacher." })
+      expect(Object.keys((await Memory.origins({ root: temp.root })).items)).toEqual([])
     } finally {
-      await t.done()
+      await temp.done()
     }
   })
 })

--- a/packages/opencode/src/cli/cmd/memory.ts
+++ b/packages/opencode/src/cli/cmd/memory.ts
@@ -26,7 +26,7 @@ type Digest = {
 /** Render stored memory entries and session digests as the evidence block for the why prompt. */
 export function dossier(input: { entries: Entry[]; sessions: Digest[] }) {
   const entries = input.entries.map(
-    (item) => `- [${item.file} > ${item.section} > ${item.key}]${stamp(item.updatedAt)}${origin(item)} ${item.text}`,
+    (item) => `- [${item.file} > ${item.section} > ${item.key}]${stamp(item.updatedAt)}${taughtBy(item)} ${item.text}`,
   )
   const sessions = input.sessions.map(
     (item) => `- [session ${item.id}${item.topic ? ` > ${item.topic}` : ""}] learned ${item.time}: ${item.summary}`,
@@ -44,7 +44,7 @@ function stamp(ms?: number) {
   return ` (updated ${new Date(ms).toISOString().slice(0, 10)})`
 }
 
-function origin(item: Entry) {
+function taughtBy(item: Entry) {
   if (!item.sessionID && !item.messageID) return ""
   const parts = [
     ...(item.sessionID ? [`session ${item.sessionID}`] : []),


### PR DESCRIPTION
Follow-up to #320 (merged before its DeepSource review fixes could land): addresses the actionable static-analysis findings on the memory provenance code and restores the `Result.ids` contract the merge dropped.

The staging path in `Memory.apply` returned a `Result` literal without the `ids` field that `MemoryOperations.Result` now requires, breaking typecheck on `dev`. Staged writes land no facts, so:

```ts
result: {
  operationCount: 0,
  added: 0,
  removed: 0,
  skipped: [],
  // Staged writes land no facts yet, so there are no inventory ids to attribute.
  ids: [],
  // ...
}
```

The lint fixes are behavior-preserving: `planRemove` and `MemoryOrigins.drop` rebuild their record via filter instead of `delete` on dynamically computed keys, the `origin` helpers were renamed (`decodeOrigin` in the ledger, `taughtBy` in the CLI) to stop shadowing the read-only `origin` global, `decodeOrigin` returns `undefined` explicitly on every path, `Memory.correct` dropped a needless `async`, and the origins test replaces non-null assertions with narrowed lookups and renames the too-short `t` temp-dir variable.

Verified with `bun test` and `bun typecheck` in `packages/memory` and `packages/opencode`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->