### PR TITLE
fix(app): improve gateway settings translations

### DIFF
--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -1088,7 +1088,7 @@ export const dict = {
   "settings.gateways.title": "Pasarelas",
   "settings.gateways.description":
     "Conecta una pasarela de IA para acceder a muchos modelos con una sola clave API, incluidos modelos gratuitos.",
-  "settings.gateways.tag.connected": "Conectado",
+  "settings.gateways.tag.connected": "Conectada",
   "settings.gateways.note.kilo": "Pasarela compatible con OpenRouter con modelos gratuitos enrutados automáticamente",
   "settings.gateways.note.zoo": "Pasarela comunitaria del proyecto Zoo Code",
   "settings.gateways.connect.title": "Conectar {{gateway}}",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -1014,7 +1014,7 @@ export const dict = {
   "settings.gateways.note.kilo": "Brama zgodna z OpenRouter z bezpłatnymi, automatycznie kierowanymi modelami",
   "settings.gateways.note.zoo": "Brama społecznościowa z projektu Zoo Code",
   "settings.gateways.connect.title": "Połącz {{gateway}}",
-  "settings.gateways.connect.description": "Wklej swój klucz API {{gateway}}, aby połączyć modele tej bramy.",
+  "settings.gateways.connect.description": "Wklej swój klucz API {{gateway}}, aby uzyskać dostęp do modeli tej bramy.",
   "settings.models.title": "Modele",
   "settings.models.description": "Ustawienia modeli będą tutaj konfigurowalne.",
   "settings.agents.title": "Agenci",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -1082,7 +1082,7 @@ export const dict = {
   "settings.providers.tag.other": "Другое",
   "settings.gateways.title": "Шлюзы",
   "settings.gateways.description":
-    "Подключите AI-шлюз, чтобы получить доступ ко многим моделям, включая бесплатные, по одному ключу API.",
+    "Подключите шлюз ИИ, чтобы получить доступ ко многим моделям, включая бесплатные, по одному ключу API.",
   "settings.gateways.tag.connected": "Подключено",
   "settings.gateways.note.kilo": "Совместимый с OpenRouter шлюз с бесплатными автоматически маршрутизируемыми моделями",
   "settings.gateways.note.zoo": "Шлюз сообщества из проекта Zoo Code",

--- a/packages/app/src/i18n/sv.ts
+++ b/packages/app/src/i18n/sv.ts
@@ -1092,7 +1092,7 @@ export const dict = {
   "settings.gateways.note.kilo": "OpenRouter-kompatibel gateway med gratis automatiskt dirigerade modeller",
   "settings.gateways.note.zoo": "Community-gateway från Zoo Code-projektet",
   "settings.gateways.connect.title": "Anslut {{gateway}}",
-  "settings.gateways.connect.description": "Klistra in din {{gateway}} API-nyckel för att ansluta dess modeller.",
+  "settings.gateways.connect.description": "Klistra in din {{gateway}}-API-nyckel för att ansluta dess modeller.",
   "settings.models.title": "Modeller",
   "settings.models.description": "Modellinställningar kommer att kunna konfigureras här.",
   "settings.agents.title": "Agenter",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -1063,7 +1063,7 @@ export const dict = {
   "settings.gateways.note.kilo": "เกตเวย์ที่เข้ากันได้กับ OpenRouter พร้อมโมเดลฟรีที่กำหนดเส้นทางอัตโนมัติ",
   "settings.gateways.note.zoo": "เกตเวย์ชุมชนจากโปรเจกต์ Zoo Code",
   "settings.gateways.connect.title": "เชื่อมต่อ {{gateway}}",
-  "settings.gateways.connect.description": "วางคีย์ API {{gateway}} ของคุณเพื่อเชื่อมต่อโมเดลของเกตเวย์นั้น",
+  "settings.gateways.connect.description": "วางคีย์ API {{gateway}} ของคุณเพื่อเข้าถึงโมเดลของเกตเวย์นั้น",
   "settings.models.title": "โมเดล",
   "settings.models.description": "การตั้งค่าโมเดลจะสามารถกำหนดค่าได้ที่นี่",
   "settings.agents.title": "เอเจนต์",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -1090,7 +1090,7 @@ export const dict = {
   "settings.gateways.note.kilo": "Ücretsiz otomatik yönlendirilen modellere sahip OpenRouter uyumlu ağ geçidi",
   "settings.gateways.note.zoo": "Zoo Code projesinden topluluk ağ geçidi",
   "settings.gateways.connect.title": "{{gateway}} ile bağlantı kur",
-  "settings.gateways.connect.description": "Modellerini bağlamak için {{gateway}} API anahtarınızı yapıştırın.",
+  "settings.gateways.connect.description": "{{gateway}} modellerine bağlanmak için API anahtarınızı yapıştırın.",
   "settings.models.title": "Modeller",
   "settings.models.description": "Model ayarları burada yapılandırılabilecek.",
   "settings.agents.title": "Ajanlar",

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -1187,7 +1187,7 @@ export const dict = {
   "settings.providers.tag.other": "Інше",
   "settings.gateways.title": "Шлюзи",
   "settings.gateways.description":
-    "Підключіть AI-шлюз, щоб отримати доступ до багатьох моделей, зокрема безкоштовних, за одним ключем API.",
+    "Підключіть шлюз ШІ, щоб отримати доступ до багатьох моделей, зокрема безкоштовних, за одним ключем API.",
   "settings.gateways.tag.connected": "Підключено",
   "settings.gateways.note.kilo": "Сумісний з OpenRouter шлюз із безкоштовними автоматично маршрутизованими моделями",
   "settings.gateways.note.zoo": "Шлюз спільноти від проєкту Zoo Code",


### PR DESCRIPTION
Applies the still-valid localization review feedback from #331 (closed after #330 landed the gateway translations on `dev`) to the current `settings.gateways.*` strings: Spanish gender agreement, Swedish compound hyphenation, established Russian/Ukrainian AI terminology, and access-oriented phrasing in Polish, Thai, and Turkish. For example:

```ts
// es.ts: "pasarela" is feminine
"settings.gateways.tag.connected": "Conectada",
// ru.ts: matches the file's existing ИИ terminology
"settings.gateways.description": "Подключите шлюз ИИ, чтобы получить доступ ко многим моделям...",
// sv.ts: matches the existing {{provider}}-API-nyckel compound form
"settings.gateways.connect.description": "Klistra in din {{gateway}}-API-nyckel för att ansluta dess modeller.",
```

Values only; no keys or placeholders changed, so the i18n parity test is unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->