### PR TITLE
fix(bolt): validate --model format and clean up throwaway ask session

### DIFF
--- a/packages/opencode/src/cli/cmd/ask.ts
+++ b/packages/opencode/src/cli/cmd/ask.ts
@@ -9,6 +9,11 @@ export function compose(question: string, piped?: string) {
   return `${question}\n\nContext:\n${context}`
 }
 
+/** True when a --model value has both a provider and a model component. */
+export function validModel(model: string) {
+  return /^[^/]+\/.+$/.test(model)
+}
+
 export const AskCommand = effectCmd({
   command: "ask <question..>",
   describe: "ask a one-shot question and print only the answer to stdout",
@@ -32,6 +37,7 @@ export const AskCommand = effectCmd({
   handler: Effect.fn("Cli.ask")(function* (args) {
     const question = args.question.join(" ").trim()
     if (!question) return yield* fail("Provide a question to ask.")
+    if (args.model && !validModel(args.model)) return yield* fail("Provide --model in the format provider/model.")
     const piped = process.stdin.isTTY ? undefined : yield* Effect.promise(() => Bun.stdin.text())
 
     const { Session } = yield* Effect.promise(() => import("@/session/session"))
@@ -46,30 +52,33 @@ export const AskCommand = effectCmd({
       permission: [{ permission: "question", action: "deny", pattern: "*" }],
     })
 
-    const result = yield* prompt
-      .prompt({
-        sessionID: session.id,
-        messageID: MessageID.ascending(),
-        agent: args.agent,
-        model: args.model ? parseModel(args.model) : undefined,
-        parts: [
-          {
-            id: PartID.ascending(),
-            type: "text",
-            text: compose(question, piped),
-          },
-        ],
-      })
-      .pipe(Effect.orDie)
+    return yield* Effect.gen(function* () {
+      const result = yield* prompt
+        .prompt({
+          sessionID: session.id,
+          messageID: MessageID.ascending(),
+          agent: args.agent,
+          model: args.model ? parseModel(args.model) : undefined,
+          parts: [
+            {
+              id: PartID.ascending(),
+              type: "text",
+              text: compose(question, piped),
+            },
+          ],
+        })
+        .pipe(Effect.orDie)
 
-    if (result.info.role === "assistant" && result.info.error) {
-      const err = result.info.error
-      const message = "message" in err.data ? err.data.message : ""
-      return yield* fail(`${err.name}: ${message}`)
-    }
+      if (result.info.role === "assistant" && result.info.error) {
+        const err = result.info.error
+        const message = "message" in err.data ? err.data.message : ""
+        return yield* fail(`${err.name}: ${message}`)
+      }
 
-    const text = extractResponseText(result.parts) ?? ""
-    if (!text) return yield* fail("The model returned an empty answer.")
-    process.stdout.write(text.trim() + EOL)
+      const text = extractResponseText(result.parts) ?? ""
+      if (!text) return yield* fail("The model returned an empty answer.")
+      process.stdout.write(text.trim() + EOL)
+      // the throwaway session must not retain piped input in durable history
+    }).pipe(Effect.ensuring(sessions.remove(session.id).pipe(Effect.ignore)))
   }),
 })

--- a/packages/opencode/test/cli/ask.test.ts
+++ b/packages/opencode/test/cli/ask.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { compose } from "../../src/cli/cmd/ask"
+import { compose, validModel } from "../../src/cli/cmd/ask"
 
 describe("compose", () => {
   test("returns the question when nothing is piped", () => {
@@ -14,5 +14,23 @@ describe("compose", () => {
     expect(compose("why is this failing", "TypeError: x is undefined\n")).toBe(
       "why is this failing\n\nContext:\nTypeError: x is undefined",
     )
+  })
+})
+
+describe("validModel", () => {
+  test("rejects a provider-only value", () => {
+    expect(validModel("provider")).toBe(false)
+  })
+
+  test("rejects an empty provider", () => {
+    expect(validModel("/model")).toBe(false)
+  })
+
+  test("accepts provider/model", () => {
+    expect(validModel("anthropic/claude-sonnet-4")).toBe(true)
+  })
+
+  test("accepts model IDs containing slashes", () => {
+    expect(validModel("openrouter/anthropic/claude-sonnet-4")).toBe(true)
   })
 })


### PR DESCRIPTION
Follow-up to #342 (merged before these review fixes landed), addressing two review findings on `bolt ask`.

First, `parseModel("provider")` silently produced an empty model ID, so provider-only `--model` values are now rejected at the CLI boundary:

```ts
export function validModel(model: string) {
  return /^[^/]+\/.+$/.test(model)
}
// in the handler
if (args.model && !validModel(args.model)) return yield* fail("Provide --model in the format provider/model.")
```

Second, the throwaway session created for each ask persisted the piped stdin in durable session history. The prompt-and-print flow is now finalized with `Effect.ensuring(sessions.remove(session.id).pipe(Effect.ignore))`, so the session is deleted on success, failure, and interruption.

Validated with `bun test ./test/cli/ask.test.ts` (including new `validModel` cases) and `bun typecheck` from `packages/opencode`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bolt-builder/codesmith/bolt-cli/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->