### PR TITLE
refactor(bolt): address resume lint findings

### DIFF
--- a/packages/opencode/src/cli/cmd/resume.ts
+++ b/packages/opencode/src/cli/cmd/resume.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect"
-import * as prompts from "@clack/prompts"
+import { autocomplete, isCancel } from "@clack/prompts"
 import { effectCmd, fail } from "../effect-cmd"
 import { Session } from "@/session/session"
 import { SessionID } from "../../session/schema"
@@ -68,7 +68,7 @@ export const ResumeCommand = effectCmd({
       }))
 
       const picked = yield* Effect.promise(() =>
-        prompts.autocomplete<SessionID>({
+        autocomplete<SessionID>({
           message: "Resume session",
           maxItems: 10,
           options() {
@@ -76,7 +76,7 @@ export const ResumeCommand = effectCmd({
           },
         }),
       )
-      if (prompts.isCancel(picked)) return yield* Effect.die(new UI.CancelledError())
+      if (isCancel(picked)) return yield* Effect.die(new UI.CancelledError())
       return picked
     })
 

--- a/packages/opencode/test/cli/resume.test.ts
+++ b/packages/opencode/test/cli/resume.test.ts
@@ -13,11 +13,10 @@ describe("resume.fuzzy", () => {
   })
 
   test("scores denser matches lower", () => {
-    const dense = fuzzy("bug", "bug hunt")
-    const sparse = fuzzy("bug", "billing untangled gremlin")
-    expect(dense).toBeDefined()
-    expect(sparse).toBeDefined()
-    expect(dense!).toBeLessThan(sparse!)
+    // Fall back to values that fail the comparison so a non-match still fails the test.
+    const dense = fuzzy("bug", "bug hunt") ?? Number.POSITIVE_INFINITY
+    const sparse = fuzzy("bug", "billing untangled gremlin") ?? Number.NEGATIVE_INFINITY
+    expect(dense).toBeLessThan(sparse)
   })
 
   test("empty query matches everything with a zero score", () => {


### PR DESCRIPTION
Follow-up to #345 (already merged) addressing the actionable DeepSource findings on the resume command: replaces the `@clack/prompts` star import with named imports per the repo's import rules, and removes the non-null assertions in the fuzzy-scoring test.

The test now fails on a non-match through the comparison itself instead of asserting non-null:

```ts
test("scores denser matches lower", () => {
  // Fall back to values that fail the comparison so a non-match still fails the test.
  const dense = fuzzy("bug", "bug hunt") ?? Number.POSITIVE_INFINITY
  const sparse = fuzzy("bug", "billing untangled gremlin") ?? Number.NEGATIVE_INFINITY
  expect(dense).toBeLessThan(sparse)
})
```

No behavior changes.